### PR TITLE
Add state parameter to required parameters for creating a booking

### DIFF
--- a/tsp/booking-create/request.json
+++ b/tsp/booking-create/request.json
@@ -4,6 +4,9 @@
   "description": "Request schema for creating a booking through a TSP adapter",
   "type": "object",
   "properties": {
+    "state": {
+      "$ref": "core/booking.json#/definitions/bookingState"
+    },
     "leg": {
       "$ref": "core/plan.json#/definitions/leg"
     },
@@ -15,6 +18,6 @@
       "$ref": "core/customer.json"
     }
   },
-  "required": ["leg", "meta", "customer"],
+  "required": ["state", "leg", "meta", "customer"],
   "additionalProperties": false
 }

--- a/tsp/booking-create/response.json
+++ b/tsp/booking-create/response.json
@@ -4,6 +4,9 @@
   "description": "Response schema for creating a booking through a TSP adapter",
   "type": "object",
   "properties": {
+    "state": {
+      "$ref": "core/booking.json#/definitions/bookingState"
+    },
     "leg": {
       "$ref": "core/plan.json#/definitions/leg"
     },
@@ -23,6 +26,6 @@
       "type": "string"
     }
   },
-  "required": ["leg", "meta", "terms", "token", "customer", "tspId"],
+  "required": ["state", "leg", "meta", "terms", "token", "customer", "tspId"],
   "additionalProperties": false
 }


### PR DESCRIPTION
I didn't see this one mentioned anywhere, but I think we should require a state for all bookings, as what I've understood we will be using the state parameter for communication between the core and TSP. 

The discussed scenario was:
1. Core -> TSP: "make me a reservation"
2. TSP -> Core: "No, I can't make a direct reservation, you need to give me an option on which to perform my reservation, please continue with retrieving options"
3. Core -> TSP: "Give me options for booking"
4. TSP -> Core : "Here are your options"
5. Core -> TSP: "Reserve me option with id 29372"
...
...
DONE

On the TSP side this update did not break any existing tests, but still not sure if this might break something? @blackevil245 any thoughts?
