### PR TITLE
Maintain states in its own file; add CONFIRMED state

### DIFF
--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -21,8 +21,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -471,8 +472,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -1118,23 +1120,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "state": {
-      "description": "The life-cycle state of the booking",
-      "type": "string",
-      "enum": [
-        "START",
-        "PENDING",
-        "RESERVED",
-        "PAID",
-        "ACTIVATED",
-        "CANCELLED",
-        "CANCELLED_WITH_ERRORS",
-        "EXPIRED",
-        "RECONCILING",
-        "RESOLVED",
-        "REJECTED"
-      ]
     },
     "fare": {
       "type": "object",

--- a/prebuilt/core/iot-thing-shadow.json
+++ b/prebuilt/core/iot-thing-shadow.json
@@ -48,7 +48,16 @@
               "minimum": 1451606400
             },
             "state": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "START",
+                "PLANNED",
+                "PAID",
+                "ACTIVATED",
+                "CANCELLED",
+                "CANCELLED_WITH_ERRORS",
+                "FINISHED"
+              ]
             }
           }
         }

--- a/prebuilt/core/itinerary.json
+++ b/prebuilt/core/itinerary.json
@@ -9,6 +9,18 @@
         "signature": {
           "type": "string"
         },
+        "state": {
+          "type": "string",
+          "enum": [
+            "START",
+            "PLANNED",
+            "PAID",
+            "ACTIVATED",
+            "CANCELLED",
+            "CANCELLED_WITH_ERRORS",
+            "FINISHED"
+          ]
+        },
         "startTime": {
           "type": "integer",
           "maximum": 9007199254740991,
@@ -80,6 +92,18 @@
                   "properties": {
                     "signature": {
                       "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "START",
+                        "PLANNED",
+                        "PAID",
+                        "ACTIVATED",
+                        "CANCELLED",
+                        "CANCELLED_WITH_ERRORS",
+                        "FINISHED"
+                      ]
                     },
                     "from": {
                       "type": "object",
@@ -229,18 +253,6 @@
                       "type": "number",
                       "minimum": 0
                     },
-                    "state": {
-                      "type": "string",
-                      "enum": [
-                        "START",
-                        "PLANNED",
-                        "PAID",
-                        "ACTIVATED",
-                        "CANCELLED",
-                        "CANCELLED_WITH_ERRORS",
-                        "FINISHED"
-                      ]
-                    },
                     "route": {
                       "type": "string",
                       "minLength": 1
@@ -372,6 +384,18 @@
             "properties": {
               "signature": {
                 "type": "string"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "START",
+                  "PLANNED",
+                  "PAID",
+                  "ACTIVATED",
+                  "CANCELLED",
+                  "CANCELLED_WITH_ERRORS",
+                  "FINISHED"
+                ]
               },
               "from": {
                 "type": "object",
@@ -521,18 +545,6 @@
                 "type": "number",
                 "minimum": 0
               },
-              "state": {
-                "type": "string",
-                "enum": [
-                  "START",
-                  "PLANNED",
-                  "PAID",
-                  "ACTIVATED",
-                  "CANCELLED",
-                  "CANCELLED_WITH_ERRORS",
-                  "FINISHED"
-                ]
-              },
               "route": {
                 "type": "string",
                 "minLength": 1
@@ -645,6 +657,18 @@
           "properties": {
             "signature": {
               "type": "string"
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "START",
+                "PLANNED",
+                "PAID",
+                "ACTIVATED",
+                "CANCELLED",
+                "CANCELLED_WITH_ERRORS",
+                "FINISHED"
+              ]
             },
             "from": {
               "type": "object",
@@ -793,18 +817,6 @@
             "distance": {
               "type": "number",
               "minimum": 0
-            },
-            "state": {
-              "type": "string",
-              "enum": [
-                "START",
-                "PLANNED",
-                "PAID",
-                "ACTIVATED",
-                "CANCELLED",
-                "CANCELLED_WITH_ERRORS",
-                "FINISHED"
-              ]
             },
             "route": {
               "type": "string",

--- a/prebuilt/core/plan.json
+++ b/prebuilt/core/plan.json
@@ -63,6 +63,18 @@
           "signature": {
             "type": "string"
           },
+          "state": {
+            "type": "string",
+            "enum": [
+              "START",
+              "PLANNED",
+              "PAID",
+              "ACTIVATED",
+              "CANCELLED",
+              "CANCELLED_WITH_ERRORS",
+              "FINISHED"
+            ]
+          },
           "startTime": {
             "type": "integer",
             "maximum": 9007199254740991,
@@ -134,6 +146,18 @@
                     "properties": {
                       "signature": {
                         "type": "string"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "START",
+                          "PLANNED",
+                          "PAID",
+                          "ACTIVATED",
+                          "CANCELLED",
+                          "CANCELLED_WITH_ERRORS",
+                          "FINISHED"
+                        ]
                       },
                       "from": {
                         "type": "object",
@@ -282,18 +306,6 @@
                       "distance": {
                         "type": "number",
                         "minimum": 0
-                      },
-                      "state": {
-                        "type": "string",
-                        "enum": [
-                          "START",
-                          "PLANNED",
-                          "PAID",
-                          "ACTIVATED",
-                          "CANCELLED",
-                          "CANCELLED_WITH_ERRORS",
-                          "FINISHED"
-                        ]
                       },
                       "route": {
                         "type": "string",
@@ -412,6 +424,18 @@
           "signature": {
             "type": "string"
           },
+          "state": {
+            "type": "string",
+            "enum": [
+              "START",
+              "PLANNED",
+              "PAID",
+              "ACTIVATED",
+              "CANCELLED",
+              "CANCELLED_WITH_ERRORS",
+              "FINISHED"
+            ]
+          },
           "startTime": {
             "type": "integer",
             "maximum": 9007199254740991,
@@ -483,6 +507,18 @@
                     "properties": {
                       "signature": {
                         "type": "string"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "START",
+                          "PLANNED",
+                          "PAID",
+                          "ACTIVATED",
+                          "CANCELLED",
+                          "CANCELLED_WITH_ERRORS",
+                          "FINISHED"
+                        ]
                       },
                       "from": {
                         "type": "object",
@@ -632,18 +668,6 @@
                         "type": "number",
                         "minimum": 0
                       },
-                      "state": {
-                        "type": "string",
-                        "enum": [
-                          "START",
-                          "PLANNED",
-                          "PAID",
-                          "ACTIVATED",
-                          "CANCELLED",
-                          "CANCELLED_WITH_ERRORS",
-                          "FINISHED"
-                        ]
-                      },
                       "route": {
                         "type": "string",
                         "minLength": 1
@@ -756,6 +780,18 @@
         "signature": {
           "type": "string"
         },
+        "state": {
+          "type": "string",
+          "enum": [
+            "START",
+            "PLANNED",
+            "PAID",
+            "ACTIVATED",
+            "CANCELLED",
+            "CANCELLED_WITH_ERRORS",
+            "FINISHED"
+          ]
+        },
         "startTime": {
           "type": "integer",
           "maximum": 9007199254740991,
@@ -827,6 +863,18 @@
                   "properties": {
                     "signature": {
                       "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "START",
+                        "PLANNED",
+                        "PAID",
+                        "ACTIVATED",
+                        "CANCELLED",
+                        "CANCELLED_WITH_ERRORS",
+                        "FINISHED"
+                      ]
                     },
                     "from": {
                       "type": "object",
@@ -976,18 +1024,6 @@
                       "type": "number",
                       "minimum": 0
                     },
-                    "state": {
-                      "type": "string",
-                      "enum": [
-                        "START",
-                        "PLANNED",
-                        "PAID",
-                        "ACTIVATED",
-                        "CANCELLED",
-                        "CANCELLED_WITH_ERRORS",
-                        "FINISHED"
-                      ]
-                    },
                     "route": {
                       "type": "string",
                       "minLength": 1
@@ -1100,6 +1136,18 @@
           "properties": {
             "signature": {
               "type": "string"
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "START",
+                "PLANNED",
+                "PAID",
+                "ACTIVATED",
+                "CANCELLED",
+                "CANCELLED_WITH_ERRORS",
+                "FINISHED"
+              ]
             },
             "from": {
               "type": "object",
@@ -1249,18 +1297,6 @@
               "type": "number",
               "minimum": 0
             },
-            "state": {
-              "type": "string",
-              "enum": [
-                "START",
-                "PLANNED",
-                "PAID",
-                "ACTIVATED",
-                "CANCELLED",
-                "CANCELLED_WITH_ERRORS",
-                "FINISHED"
-              ]
-            },
             "route": {
               "type": "string",
               "minLength": 1
@@ -1362,6 +1398,18 @@
       "properties": {
         "signature": {
           "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "START",
+            "PLANNED",
+            "PAID",
+            "ACTIVATED",
+            "CANCELLED",
+            "CANCELLED_WITH_ERRORS",
+            "FINISHED"
+          ]
         },
         "from": {
           "type": "object",
@@ -1510,18 +1558,6 @@
         "distance": {
           "type": "number",
           "minimum": 0
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "START",
-            "PLANNED",
-            "PAID",
-            "ACTIVATED",
-            "CANCELLED",
-            "CANCELLED_WITH_ERRORS",
-            "FINISHED"
-          ]
         },
         "route": {
           "type": "string",

--- a/prebuilt/core/state.json
+++ b/prebuilt/core/state.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://api.maas.global/v1/state",
+  "description": "MaaS schema for defining states",
+  "definitions": {
+    "bookingState": {
+      "description": "The life-cycle state of the booking",
+      "type": "string",
+      "enum": [
+        "START",
+        "PENDING",
+        "PAID",
+        "RESERVED",
+        "CONFIRMED",
+        "ACTIVATED",
+        "CANCELLED",
+        "CANCELLED_WITH_ERRORS",
+        "EXPIRED",
+        "RECONCILING",
+        "RESOLVED",
+        "REJECTED"
+      ]
+    },
+    "legState": {
+      "type": "string",
+      "enum": [
+        "START",
+        "PLANNED",
+        "PAID",
+        "ACTIVATED",
+        "CANCELLED",
+        "CANCELLED_WITH_ERRORS",
+        "FINISHED"
+      ]
+    },
+    "itineraryState": {
+      "type": "string",
+      "enum": [
+        "START",
+        "PLANNED",
+        "PAID",
+        "ACTIVATED",
+        "CANCELLED",
+        "CANCELLED_WITH_ERRORS",
+        "FINISHED"
+      ]
+    }
+  }
+}

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -21,8 +21,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -471,8 +472,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -1118,23 +1120,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "state": {
-      "description": "The life-cycle state of the booking",
-      "type": "string",
-      "enum": [
-        "START",
-        "PENDING",
-        "RESERVED",
-        "PAID",
-        "ACTIVATED",
-        "CANCELLED",
-        "CANCELLED_WITH_ERRORS",
-        "EXPIRED",
-        "RECONCILING",
-        "RESOLVED",
-        "REJECTED"
-      ]
     },
     "fare": {
       "type": "object",

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -21,8 +21,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -471,8 +472,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -1118,23 +1120,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "state": {
-      "description": "The life-cycle state of the booking",
-      "type": "string",
-      "enum": [
-        "START",
-        "PENDING",
-        "RESERVED",
-        "PAID",
-        "ACTIVATED",
-        "CANCELLED",
-        "CANCELLED_WITH_ERRORS",
-        "EXPIRED",
-        "RECONCILING",
-        "RESOLVED",
-        "REJECTED"
-      ]
     },
     "fare": {
       "type": "object",

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -30,8 +30,9 @@
                 "enum": [
                   "START",
                   "PENDING",
-                  "RESERVED",
                   "PAID",
+                  "RESERVED",
+                  "CONFIRMED",
                   "ACTIVATED",
                   "CANCELLED",
                   "CANCELLED_WITH_ERRORS",
@@ -480,8 +481,9 @@
                 "enum": [
                   "START",
                   "PENDING",
-                  "RESERVED",
                   "PAID",
+                  "RESERVED",
+                  "CONFIRMED",
                   "ACTIVATED",
                   "CANCELLED",
                   "CANCELLED_WITH_ERRORS",
@@ -1127,23 +1129,6 @@
               }
             },
             "additionalProperties": false
-          },
-          "state": {
-            "description": "The life-cycle state of the booking",
-            "type": "string",
-            "enum": [
-              "START",
-              "PENDING",
-              "RESERVED",
-              "PAID",
-              "ACTIVATED",
-              "CANCELLED",
-              "CANCELLED_WITH_ERRORS",
-              "EXPIRED",
-              "RECONCILING",
-              "RESOLVED",
-              "REJECTED"
-            ]
           },
           "fare": {
             "type": "object",

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -21,8 +21,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -471,8 +472,9 @@
           "enum": [
             "START",
             "PENDING",
-            "RESERVED",
             "PAID",
+            "RESERVED",
+            "CONFIRMED",
             "ACTIVATED",
             "CANCELLED",
             "CANCELLED_WITH_ERRORS",
@@ -1118,23 +1120,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "state": {
-      "description": "The life-cycle state of the booking",
-      "type": "string",
-      "enum": [
-        "START",
-        "PENDING",
-        "RESERVED",
-        "PAID",
-        "ACTIVATED",
-        "CANCELLED",
-        "CANCELLED_WITH_ERRORS",
-        "EXPIRED",
-        "RECONCILING",
-        "RESOLVED",
-        "REJECTED"
-      ]
     },
     "fare": {
       "type": "object",

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -27,8 +27,9 @@
               "enum": [
                 "START",
                 "PENDING",
-                "RESERVED",
                 "PAID",
+                "RESERVED",
+                "CONFIRMED",
                 "ACTIVATED",
                 "CANCELLED",
                 "CANCELLED_WITH_ERRORS",
@@ -477,8 +478,9 @@
               "enum": [
                 "START",
                 "PENDING",
-                "RESERVED",
                 "PAID",
+                "RESERVED",
+                "CONFIRMED",
                 "ACTIVATED",
                 "CANCELLED",
                 "CANCELLED_WITH_ERRORS",
@@ -1124,23 +1126,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "state": {
-          "description": "The life-cycle state of the booking",
-          "type": "string",
-          "enum": [
-            "START",
-            "PENDING",
-            "RESERVED",
-            "PAID",
-            "ACTIVATED",
-            "CANCELLED",
-            "CANCELLED_WITH_ERRORS",
-            "EXPIRED",
-            "RECONCILING",
-            "RESOLVED",
-            "REJECTED"
-          ]
         },
         "fare": {
           "type": "object",

--- a/prebuilt/maas-backend/itineraries/itinerary-create/request.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/request.json
@@ -15,6 +15,18 @@
             "signature": {
               "type": "string"
             },
+            "state": {
+              "type": "string",
+              "enum": [
+                "START",
+                "PLANNED",
+                "PAID",
+                "ACTIVATED",
+                "CANCELLED",
+                "CANCELLED_WITH_ERRORS",
+                "FINISHED"
+              ]
+            },
             "startTime": {
               "type": "integer",
               "maximum": 9007199254740991,
@@ -86,6 +98,18 @@
                       "properties": {
                         "signature": {
                           "type": "string"
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "START",
+                            "PLANNED",
+                            "PAID",
+                            "ACTIVATED",
+                            "CANCELLED",
+                            "CANCELLED_WITH_ERRORS",
+                            "FINISHED"
+                          ]
                         },
                         "from": {
                           "type": "object",
@@ -235,18 +259,6 @@
                           "type": "number",
                           "minimum": 0
                         },
-                        "state": {
-                          "type": "string",
-                          "enum": [
-                            "START",
-                            "PLANNED",
-                            "PAID",
-                            "ACTIVATED",
-                            "CANCELLED",
-                            "CANCELLED_WITH_ERRORS",
-                            "FINISHED"
-                          ]
-                        },
                         "route": {
                           "type": "string",
                           "minLength": 1
@@ -378,6 +390,18 @@
                 "properties": {
                   "signature": {
                     "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "START",
+                      "PLANNED",
+                      "PAID",
+                      "ACTIVATED",
+                      "CANCELLED",
+                      "CANCELLED_WITH_ERRORS",
+                      "FINISHED"
+                    ]
                   },
                   "from": {
                     "type": "object",
@@ -527,18 +551,6 @@
                     "type": "number",
                     "minimum": 0
                   },
-                  "state": {
-                    "type": "string",
-                    "enum": [
-                      "START",
-                      "PLANNED",
-                      "PAID",
-                      "ACTIVATED",
-                      "CANCELLED",
-                      "CANCELLED_WITH_ERRORS",
-                      "FINISHED"
-                    ]
-                  },
                   "route": {
                     "type": "string",
                     "minLength": 1
@@ -651,6 +663,18 @@
               "properties": {
                 "signature": {
                   "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "START",
+                    "PLANNED",
+                    "PAID",
+                    "ACTIVATED",
+                    "CANCELLED",
+                    "CANCELLED_WITH_ERRORS",
+                    "FINISHED"
+                  ]
                 },
                 "from": {
                   "type": "object",
@@ -799,18 +823,6 @@
                 "distance": {
                   "type": "number",
                   "minimum": 0
-                },
-                "state": {
-                  "type": "string",
-                  "enum": [
-                    "START",
-                    "PLANNED",
-                    "PAID",
-                    "ACTIVATED",
-                    "CANCELLED",
-                    "CANCELLED_WITH_ERRORS",
-                    "FINISHED"
-                  ]
                 },
                 "route": {
                   "type": "string",

--- a/prebuilt/maas-backend/itineraries/itinerary-create/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/response.json
@@ -15,6 +15,18 @@
             "signature": {
               "type": "string"
             },
+            "state": {
+              "type": "string",
+              "enum": [
+                "START",
+                "PLANNED",
+                "PAID",
+                "ACTIVATED",
+                "CANCELLED",
+                "CANCELLED_WITH_ERRORS",
+                "FINISHED"
+              ]
+            },
             "startTime": {
               "type": "integer",
               "maximum": 9007199254740991,
@@ -86,6 +98,18 @@
                       "properties": {
                         "signature": {
                           "type": "string"
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "START",
+                            "PLANNED",
+                            "PAID",
+                            "ACTIVATED",
+                            "CANCELLED",
+                            "CANCELLED_WITH_ERRORS",
+                            "FINISHED"
+                          ]
                         },
                         "from": {
                           "type": "object",
@@ -235,18 +259,6 @@
                           "type": "number",
                           "minimum": 0
                         },
-                        "state": {
-                          "type": "string",
-                          "enum": [
-                            "START",
-                            "PLANNED",
-                            "PAID",
-                            "ACTIVATED",
-                            "CANCELLED",
-                            "CANCELLED_WITH_ERRORS",
-                            "FINISHED"
-                          ]
-                        },
                         "route": {
                           "type": "string",
                           "minLength": 1
@@ -378,6 +390,18 @@
                 "properties": {
                   "signature": {
                     "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "START",
+                      "PLANNED",
+                      "PAID",
+                      "ACTIVATED",
+                      "CANCELLED",
+                      "CANCELLED_WITH_ERRORS",
+                      "FINISHED"
+                    ]
                   },
                   "from": {
                     "type": "object",
@@ -527,18 +551,6 @@
                     "type": "number",
                     "minimum": 0
                   },
-                  "state": {
-                    "type": "string",
-                    "enum": [
-                      "START",
-                      "PLANNED",
-                      "PAID",
-                      "ACTIVATED",
-                      "CANCELLED",
-                      "CANCELLED_WITH_ERRORS",
-                      "FINISHED"
-                    ]
-                  },
                   "route": {
                     "type": "string",
                     "minLength": 1
@@ -651,6 +663,18 @@
               "properties": {
                 "signature": {
                   "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "START",
+                    "PLANNED",
+                    "PAID",
+                    "ACTIVATED",
+                    "CANCELLED",
+                    "CANCELLED_WITH_ERRORS",
+                    "FINISHED"
+                  ]
                 },
                 "from": {
                   "type": "object",
@@ -799,18 +823,6 @@
                 "distance": {
                   "type": "number",
                   "minimum": 0
-                },
-                "state": {
-                  "type": "string",
-                  "enum": [
-                    "START",
-                    "PLANNED",
-                    "PAID",
-                    "ACTIVATED",
-                    "CANCELLED",
-                    "CANCELLED_WITH_ERRORS",
-                    "FINISHED"
-                  ]
                 },
                 "route": {
                   "type": "string",

--- a/prebuilt/maas-backend/itineraries/itinerary-list/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-list/response.json
@@ -18,6 +18,18 @@
               "signature": {
                 "type": "string"
               },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "START",
+                  "PLANNED",
+                  "PAID",
+                  "ACTIVATED",
+                  "CANCELLED",
+                  "CANCELLED_WITH_ERRORS",
+                  "FINISHED"
+                ]
+              },
               "startTime": {
                 "type": "integer",
                 "maximum": 9007199254740991,
@@ -89,6 +101,18 @@
                         "properties": {
                           "signature": {
                             "type": "string"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "START",
+                              "PLANNED",
+                              "PAID",
+                              "ACTIVATED",
+                              "CANCELLED",
+                              "CANCELLED_WITH_ERRORS",
+                              "FINISHED"
+                            ]
                           },
                           "from": {
                             "type": "object",
@@ -238,18 +262,6 @@
                             "type": "number",
                             "minimum": 0
                           },
-                          "state": {
-                            "type": "string",
-                            "enum": [
-                              "START",
-                              "PLANNED",
-                              "PAID",
-                              "ACTIVATED",
-                              "CANCELLED",
-                              "CANCELLED_WITH_ERRORS",
-                              "FINISHED"
-                            ]
-                          },
                           "route": {
                             "type": "string",
                             "minLength": 1
@@ -381,6 +393,18 @@
                   "properties": {
                     "signature": {
                       "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "START",
+                        "PLANNED",
+                        "PAID",
+                        "ACTIVATED",
+                        "CANCELLED",
+                        "CANCELLED_WITH_ERRORS",
+                        "FINISHED"
+                      ]
                     },
                     "from": {
                       "type": "object",
@@ -530,18 +554,6 @@
                       "type": "number",
                       "minimum": 0
                     },
-                    "state": {
-                      "type": "string",
-                      "enum": [
-                        "START",
-                        "PLANNED",
-                        "PAID",
-                        "ACTIVATED",
-                        "CANCELLED",
-                        "CANCELLED_WITH_ERRORS",
-                        "FINISHED"
-                      ]
-                    },
                     "route": {
                       "type": "string",
                       "minLength": 1
@@ -654,6 +666,18 @@
                 "properties": {
                   "signature": {
                     "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "START",
+                      "PLANNED",
+                      "PAID",
+                      "ACTIVATED",
+                      "CANCELLED",
+                      "CANCELLED_WITH_ERRORS",
+                      "FINISHED"
+                    ]
                   },
                   "from": {
                     "type": "object",
@@ -802,18 +826,6 @@
                   "distance": {
                     "type": "number",
                     "minimum": 0
-                  },
-                  "state": {
-                    "type": "string",
-                    "enum": [
-                      "START",
-                      "PLANNED",
-                      "PAID",
-                      "ACTIVATED",
-                      "CANCELLED",
-                      "CANCELLED_WITH_ERRORS",
-                      "FINISHED"
-                    ]
                   },
                   "route": {
                     "type": "string",

--- a/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
@@ -15,6 +15,18 @@
             "signature": {
               "type": "string"
             },
+            "state": {
+              "type": "string",
+              "enum": [
+                "START",
+                "PLANNED",
+                "PAID",
+                "ACTIVATED",
+                "CANCELLED",
+                "CANCELLED_WITH_ERRORS",
+                "FINISHED"
+              ]
+            },
             "startTime": {
               "type": "integer",
               "maximum": 9007199254740991,
@@ -86,6 +98,18 @@
                       "properties": {
                         "signature": {
                           "type": "string"
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "START",
+                            "PLANNED",
+                            "PAID",
+                            "ACTIVATED",
+                            "CANCELLED",
+                            "CANCELLED_WITH_ERRORS",
+                            "FINISHED"
+                          ]
                         },
                         "from": {
                           "type": "object",
@@ -235,18 +259,6 @@
                           "type": "number",
                           "minimum": 0
                         },
-                        "state": {
-                          "type": "string",
-                          "enum": [
-                            "START",
-                            "PLANNED",
-                            "PAID",
-                            "ACTIVATED",
-                            "CANCELLED",
-                            "CANCELLED_WITH_ERRORS",
-                            "FINISHED"
-                          ]
-                        },
                         "route": {
                           "type": "string",
                           "minLength": 1
@@ -378,6 +390,18 @@
                 "properties": {
                   "signature": {
                     "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "START",
+                      "PLANNED",
+                      "PAID",
+                      "ACTIVATED",
+                      "CANCELLED",
+                      "CANCELLED_WITH_ERRORS",
+                      "FINISHED"
+                    ]
                   },
                   "from": {
                     "type": "object",
@@ -527,18 +551,6 @@
                     "type": "number",
                     "minimum": 0
                   },
-                  "state": {
-                    "type": "string",
-                    "enum": [
-                      "START",
-                      "PLANNED",
-                      "PAID",
-                      "ACTIVATED",
-                      "CANCELLED",
-                      "CANCELLED_WITH_ERRORS",
-                      "FINISHED"
-                    ]
-                  },
                   "route": {
                     "type": "string",
                     "minLength": 1
@@ -651,6 +663,18 @@
               "properties": {
                 "signature": {
                   "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "START",
+                    "PLANNED",
+                    "PAID",
+                    "ACTIVATED",
+                    "CANCELLED",
+                    "CANCELLED_WITH_ERRORS",
+                    "FINISHED"
+                  ]
                 },
                 "from": {
                   "type": "object",
@@ -799,18 +823,6 @@
                 "distance": {
                   "type": "number",
                   "minimum": 0
-                },
-                "state": {
-                  "type": "string",
-                  "enum": [
-                    "START",
-                    "PLANNED",
-                    "PAID",
-                    "ACTIVATED",
-                    "CANCELLED",
-                    "CANCELLED_WITH_ERRORS",
-                    "FINISHED"
-                  ]
                 },
                 "route": {
                   "type": "string",

--- a/prebuilt/maas-backend/provider/routes/response.json
+++ b/prebuilt/maas-backend/provider/routes/response.json
@@ -45,6 +45,18 @@
                   "signature": {
                     "type": "string"
                   },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "START",
+                      "PLANNED",
+                      "PAID",
+                      "ACTIVATED",
+                      "CANCELLED",
+                      "CANCELLED_WITH_ERRORS",
+                      "FINISHED"
+                    ]
+                  },
                   "startTime": {
                     "type": "integer",
                     "maximum": 9007199254740991,
@@ -116,6 +128,18 @@
                             "properties": {
                               "signature": {
                                 "type": "string"
+                              },
+                              "state": {
+                                "type": "string",
+                                "enum": [
+                                  "START",
+                                  "PLANNED",
+                                  "PAID",
+                                  "ACTIVATED",
+                                  "CANCELLED",
+                                  "CANCELLED_WITH_ERRORS",
+                                  "FINISHED"
+                                ]
                               },
                               "from": {
                                 "type": "object",
@@ -264,18 +288,6 @@
                               "distance": {
                                 "type": "number",
                                 "minimum": 0
-                              },
-                              "state": {
-                                "type": "string",
-                                "enum": [
-                                  "START",
-                                  "PLANNED",
-                                  "PAID",
-                                  "ACTIVATED",
-                                  "CANCELLED",
-                                  "CANCELLED_WITH_ERRORS",
-                                  "FINISHED"
-                                ]
                               },
                               "route": {
                                 "type": "string",

--- a/prebuilt/maas-backend/routes/routes-query/response.json
+++ b/prebuilt/maas-backend/routes/routes-query/response.json
@@ -45,6 +45,18 @@
                   "signature": {
                     "type": "string"
                   },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "START",
+                      "PLANNED",
+                      "PAID",
+                      "ACTIVATED",
+                      "CANCELLED",
+                      "CANCELLED_WITH_ERRORS",
+                      "FINISHED"
+                    ]
+                  },
                   "startTime": {
                     "type": "integer",
                     "maximum": 9007199254740991,
@@ -116,6 +128,18 @@
                             "properties": {
                               "signature": {
                                 "type": "string"
+                              },
+                              "state": {
+                                "type": "string",
+                                "enum": [
+                                  "START",
+                                  "PLANNED",
+                                  "PAID",
+                                  "ACTIVATED",
+                                  "CANCELLED",
+                                  "CANCELLED_WITH_ERRORS",
+                                  "FINISHED"
+                                ]
                               },
                               "from": {
                                 "type": "object",
@@ -264,18 +288,6 @@
                               "distance": {
                                 "type": "number",
                                 "minimum": 0
-                              },
-                              "state": {
-                                "type": "string",
-                                "enum": [
-                                  "START",
-                                  "PLANNED",
-                                  "PAID",
-                                  "ACTIVATED",
-                                  "CANCELLED",
-                                  "CANCELLED_WITH_ERRORS",
-                                  "FINISHED"
-                                ]
                               },
                               "route": {
                                 "type": "string",

--- a/prebuilt/tsp/booking-create/response.json
+++ b/prebuilt/tsp/booking-create/response.json
@@ -10,7 +10,9 @@
     },
     "state": {
       "enum": [
-        "RESERVED"
+        "RESERVED",
+        "CONFIRMED",
+        "ACTIVATED"
       ]
     },
     "cost": {

--- a/prebuilt/tsp/booking-read-by-id/response.json
+++ b/prebuilt/tsp/booking-read-by-id/response.json
@@ -29,6 +29,7 @@
     "state": {
       "enum": [
         "RESERVED",
+        "CONFIRMED",
         "ACTIVATED",
         "EXPIRED",
         "CANCELLED"

--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -22,7 +22,7 @@
           "$ref": "#/definitions/tspId"
         },
         "state": {
-          "$ref": "#/definitions/state"
+          "$ref": "./state.json#/definitions/bookingState"
         },
         "fare": {
           "$ref": "#/definitions/fare"
@@ -125,23 +125,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "state": {
-      "description": "The life-cycle state of the booking",
-      "type": "string",
-      "enum": [
-        "START",
-        "PENDING",
-        "RESERVED",
-        "PAID",
-        "ACTIVATED",
-        "CANCELLED",
-        "CANCELLED_WITH_ERRORS",
-        "EXPIRED",
-        "RECONCILING",
-        "RESOLVED",
-        "REJECTED"
-      ]
     },
     "fare": {
       "$ref": "../core/units.json#/definitions/fare"

--- a/schemas/core/iot-thing-shadow.json
+++ b/schemas/core/iot-thing-shadow.json
@@ -38,7 +38,7 @@
               "$ref": "./units.json#/definitions/time"
             },
             "state": {
-              "type": "string"
+              "$ref": "./state.json#/definitions/legState"
             }
           }
         }

--- a/schemas/core/plan.json
+++ b/schemas/core/plan.json
@@ -24,6 +24,9 @@
         "signature": {
           "type": "string"
         },
+        "state": {
+          "$ref": "./state.json#/definitions/itineraryState"
+        },
         "startTime": {
           "$ref": "./units.json#/definitions/time"
         },
@@ -75,6 +78,9 @@
         "signature": {
           "type": "string"
         },
+        "state": {
+          "$ref": "./state.json#/definitions/legState"
+        },
         "from": {
           "$ref": "#/definitions/place"
         },
@@ -101,18 +107,6 @@
         "distance": {
           "type": "number",
           "minimum": 0
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "START",
-            "PLANNED",
-            "PAID",
-            "ACTIVATED",
-            "CANCELLED",
-            "CANCELLED_WITH_ERRORS",
-            "FINISHED"
-          ]
         },
         "route": {
           "type": "string",

--- a/schemas/core/state.json
+++ b/schemas/core/state.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://api.maas.global/v1/state",
+  "description": "MaaS schema for defining states",
+  "definitions": {
+    "bookingState": {
+      "description": "The life-cycle state of the booking",
+      "type": "string",
+      "enum": [
+        "START",
+        "PENDING",
+        "PAID",
+        "RESERVED",
+        "CONFIRMED",
+        "ACTIVATED",
+        "CANCELLED",
+        "CANCELLED_WITH_ERRORS",
+        "EXPIRED",
+        "RECONCILING",
+        "RESOLVED",
+        "REJECTED"
+      ]
+    },
+    "legState": {
+      "type": "string",
+      "enum": [
+        "START",
+        "PLANNED",
+        "PAID",
+        "ACTIVATED",
+        "CANCELLED",
+        "CANCELLED_WITH_ERRORS",
+        "FINISHED"
+      ]
+    },
+    "itineraryState": {
+      "type": "string",
+      "enum": [
+        "START",
+        "PLANNED",
+        "PAID",
+        "ACTIVATED",
+        "CANCELLED",
+        "CANCELLED_WITH_ERRORS",
+        "FINISHED"
+      ]
+    }
+  }
+}

--- a/schemas/tsp/booking-create/response.json
+++ b/schemas/tsp/booking-create/response.json
@@ -8,7 +8,7 @@
       "$ref": "../../core/booking.json#/definitions/tspId"
     },
     "state": {
-      "enum": [ "RESERVED" ]
+      "enum": [ "RESERVED", "CONFIRMED", "ACTIVATED" ]
     },
     "cost": {
       "$ref": "../../core/booking.json#/definitions/cost"

--- a/schemas/tsp/booking-read-by-id/response.json
+++ b/schemas/tsp/booking-read-by-id/response.json
@@ -10,7 +10,7 @@
       "$ref": "../../core/booking.json#/definitions/cost"
     },
     "state": {
-      "enum": [ "RESERVED", "ACTIVATED", "EXPIRED", "CANCELLED" ]
+      "enum": [ "RESERVED", "CONFIRMED", "ACTIVATED", "EXPIRED", "CANCELLED" ]
     },
     "leg": {
       "$ref": "../../core/booking.json#/definitions/leg"


### PR DESCRIPTION
Also refine scheme so that a booking reservation can be directly returned in RESERVED, CONFIRMED or ACTIVATED state.

The possible cases justifying this:
- CONFIRMED: The taxi center directly assigns a Taxi (& hence we cannot cancel anymore), HSL ticket purchase (that can't be cancelled)
- ACTIVATED: Buy a HSL ticket that starts right away
