### PR TITLE
Make estimates and update endpoints more tolerant on different inputs

### DIFF
--- a/prebuilt/maas-backend/subscriptions/subscription.json
+++ b/prebuilt/maas-backend/subscriptions/subscription.json
@@ -10,14 +10,6 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -160,14 +152,6 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -313,14 +297,6 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -462,14 +438,6 @@
     "subscriptionBase": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -606,7 +574,8 @@
             ]
           }
         }
-      }
+      },
+      "additionalProperties": true
     },
     "plan": {
       "description": "Customer subscription plan",

--- a/prebuilt/maas-backend/subscriptions/subscriptionOption.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptionOption.json
@@ -6,14 +6,6 @@
     {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -150,7 +142,8 @@
             ]
           }
         }
-      }
+      },
+      "additionalProperties": true
     },
     {
       "type": "object",

--- a/prebuilt/maas-backend/subscriptions/subscriptions-estimate/request.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptions-estimate/request.json
@@ -17,17 +17,8 @@
       "default": false
     },
     "payload": {
-      "additionalProperties": false,
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -164,7 +155,8 @@
             ]
           }
         }
-      }
+      },
+      "additionalProperties": true
     }
   },
   "required": [

--- a/prebuilt/maas-backend/subscriptions/subscriptions-options/response.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptions-options/response.json
@@ -14,14 +14,6 @@
           {
             "type": "object",
             "properties": {
-              "name": {
-                "type": "string",
-                "minLength": 1
-              },
-              "description": {
-                "type": "string",
-                "minLength": 1
-              },
               "plan": {
                 "description": "Customer subscription plan",
                 "type": "object",
@@ -158,7 +150,8 @@
                   ]
                 }
               }
-            }
+            },
+            "additionalProperties": true
           },
           {
             "type": "object",

--- a/prebuilt/maas-backend/subscriptions/subscriptions-retrieve/response.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptions-retrieve/response.json
@@ -12,14 +12,6 @@
         {
           "type": "object",
           "properties": {
-            "name": {
-              "type": "string",
-              "minLength": 1
-            },
-            "description": {
-              "type": "string",
-              "minLength": 1
-            },
             "plan": {
               "description": "Customer subscription plan",
               "type": "object",
@@ -156,7 +148,8 @@
                 ]
               }
             }
-          }
+          },
+          "additionalProperties": true
         },
         {
           "type": "object",

--- a/prebuilt/maas-backend/subscriptions/subscriptions-update/request.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptions-update/request.json
@@ -19,14 +19,6 @@
     "payload": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "description": "Customer subscription plan",
           "type": "object",
@@ -163,7 +155,8 @@
             ]
           }
         }
-      }
+      },
+      "additionalProperties": true
     }
   },
   "required": [

--- a/prebuilt/maas-backend/subscriptions/subscriptions-update/response.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptions-update/response.json
@@ -12,14 +12,6 @@
         {
           "type": "object",
           "properties": {
-            "name": {
-              "type": "string",
-              "minLength": 1
-            },
-            "description": {
-              "type": "string",
-              "minLength": 1
-            },
             "plan": {
               "description": "Customer subscription plan",
               "type": "object",
@@ -156,7 +148,8 @@
                 ]
               }
             }
-          }
+          },
+          "additionalProperties": true
         },
         {
           "type": "object",

--- a/schemas/maas-backend/subscriptions/subscription.json
+++ b/schemas/maas-backend/subscriptions/subscription.json
@@ -20,14 +20,6 @@
     "subscriptionBase": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        },
         "plan": {
           "$ref": "#/definitions/plan"
         },
@@ -43,7 +35,8 @@
             "$ref": "#/definitions/coupon"
           }
         }
-      }
+      },
+      "additionalProperties": true
     },
     "plan": {
       "description": "Customer subscription plan",

--- a/schemas/maas-backend/subscriptions/subscriptions-estimate/request.json
+++ b/schemas/maas-backend/subscriptions/subscriptions-estimate/request.json
@@ -15,7 +15,7 @@
       "default": false
     },
     "payload": {
-      "$ref": "../subscription.json#/definitions/subscriptionUpdate"
+      "$ref": "../subscription.json#/definitions/subscriptionBase"
     }
   },
   "required": ["customerId", "userId", "payload" ],


### PR DESCRIPTION
In practice, we only have constraints on what 'plan', 'addons' and 'coupons' objects are & contain