### PR TITLE
Amend to the Profile.paymentMethod schema

### DIFF
--- a/prebuilt/core/profile.json
+++ b/prebuilt/core/profile.json
@@ -162,25 +162,37 @@
     "paymentMethod": {
       "type": "object",
       "properties": {
-        "status": {
+        "type": {
           "type": "string",
           "enum": [
-            "valid",
-            "valid_expiring",
-            "invalid",
-            "unknown"
+            "unknown",
+            "card",
+            "stripe"
           ]
         },
+        "valid": {
+          "description": "Whether the payment method is valid and working",
+          "type": "boolean"
+        },
+        "maskedNumber": {
+          "description": "Typically the credit card number with all but the last four digits obfuscated",
+          "type": "string"
+        },
+        "issuer": {
+          "description": "The card issuer, e.g. 'Visa'",
+          "type": "string"
+        },
         "expiry": {
-          "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+          "description": "When this payment method expires",
           "type": "integer",
           "maximum": 9007199254740991,
           "minimum": 1451606400
-        },
-        "maskedNumber": {
-          "type": "string"
         }
-      }
+      },
+      "required": [
+        "type",
+        "valid"
+      ]
     }
   },
   "additionalProperties": false,

--- a/prebuilt/maas-backend/profile/profile-active-plan-put/response.json
+++ b/prebuilt/maas-backend/profile/profile-active-plan-put/response.json
@@ -168,25 +168,37 @@
         "paymentMethod": {
           "type": "object",
           "properties": {
-            "status": {
+            "type": {
               "type": "string",
               "enum": [
-                "valid",
-                "valid_expiring",
-                "invalid",
-                "unknown"
+                "unknown",
+                "card",
+                "stripe"
               ]
             },
+            "valid": {
+              "description": "Whether the payment method is valid and working",
+              "type": "boolean"
+            },
+            "maskedNumber": {
+              "description": "Typically the credit card number with all but the last four digits obfuscated",
+              "type": "string"
+            },
+            "issuer": {
+              "description": "The card issuer, e.g. 'Visa'",
+              "type": "string"
+            },
             "expiry": {
-              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "description": "When this payment method expires",
               "type": "integer",
               "maximum": 9007199254740991,
               "minimum": 1451606400
-            },
-            "maskedNumber": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "type",
+            "valid"
+          ]
         }
       },
       "additionalProperties": false,

--- a/prebuilt/maas-backend/profile/profile-edit/response.json
+++ b/prebuilt/maas-backend/profile/profile-edit/response.json
@@ -168,25 +168,37 @@
         "paymentMethod": {
           "type": "object",
           "properties": {
-            "status": {
+            "type": {
               "type": "string",
               "enum": [
-                "valid",
-                "valid_expiring",
-                "invalid",
-                "unknown"
+                "unknown",
+                "card",
+                "stripe"
               ]
             },
+            "valid": {
+              "description": "Whether the payment method is valid and working",
+              "type": "boolean"
+            },
+            "maskedNumber": {
+              "description": "Typically the credit card number with all but the last four digits obfuscated",
+              "type": "string"
+            },
+            "issuer": {
+              "description": "The card issuer, e.g. 'Visa'",
+              "type": "string"
+            },
             "expiry": {
-              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "description": "When this payment method expires",
               "type": "integer",
               "maximum": 9007199254740991,
               "minimum": 1451606400
-            },
-            "maskedNumber": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "type",
+            "valid"
+          ]
         }
       },
       "additionalProperties": false,

--- a/prebuilt/maas-backend/profile/profile-payment-get/response.json
+++ b/prebuilt/maas-backend/profile/profile-payment-get/response.json
@@ -168,25 +168,37 @@
         "paymentMethod": {
           "type": "object",
           "properties": {
-            "status": {
+            "type": {
               "type": "string",
               "enum": [
-                "valid",
-                "valid_expiring",
-                "invalid",
-                "unknown"
+                "unknown",
+                "card",
+                "stripe"
               ]
             },
+            "valid": {
+              "description": "Whether the payment method is valid and working",
+              "type": "boolean"
+            },
+            "maskedNumber": {
+              "description": "Typically the credit card number with all but the last four digits obfuscated",
+              "type": "string"
+            },
+            "issuer": {
+              "description": "The card issuer, e.g. 'Visa'",
+              "type": "string"
+            },
             "expiry": {
-              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "description": "When this payment method expires",
               "type": "integer",
               "maximum": 9007199254740991,
               "minimum": 1451606400
-            },
-            "maskedNumber": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "type",
+            "valid"
+          ]
         }
       },
       "additionalProperties": false,

--- a/prebuilt/maas-backend/profile/profile-payment-put/response.json
+++ b/prebuilt/maas-backend/profile/profile-payment-put/response.json
@@ -168,25 +168,37 @@
         "paymentMethod": {
           "type": "object",
           "properties": {
-            "status": {
+            "type": {
               "type": "string",
               "enum": [
-                "valid",
-                "valid_expiring",
-                "invalid",
-                "unknown"
+                "unknown",
+                "card",
+                "stripe"
               ]
             },
+            "valid": {
+              "description": "Whether the payment method is valid and working",
+              "type": "boolean"
+            },
+            "maskedNumber": {
+              "description": "Typically the credit card number with all but the last four digits obfuscated",
+              "type": "string"
+            },
+            "issuer": {
+              "description": "The card issuer, e.g. 'Visa'",
+              "type": "string"
+            },
             "expiry": {
-              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "description": "When this payment method expires",
               "type": "integer",
               "maximum": 9007199254740991,
               "minimum": 1451606400
-            },
-            "maskedNumber": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "type",
+            "valid"
+          ]
         }
       },
       "additionalProperties": false,

--- a/prebuilt/maas-backend/profile/profile-webhook/response.json
+++ b/prebuilt/maas-backend/profile/profile-webhook/response.json
@@ -168,25 +168,37 @@
         "paymentMethod": {
           "type": "object",
           "properties": {
-            "status": {
+            "type": {
               "type": "string",
               "enum": [
-                "valid",
-                "valid_expiring",
-                "invalid",
-                "unknown"
+                "unknown",
+                "card",
+                "stripe"
               ]
             },
+            "valid": {
+              "description": "Whether the payment method is valid and working",
+              "type": "boolean"
+            },
+            "maskedNumber": {
+              "description": "Typically the credit card number with all but the last four digits obfuscated",
+              "type": "string"
+            },
+            "issuer": {
+              "description": "The card issuer, e.g. 'Visa'",
+              "type": "string"
+            },
             "expiry": {
-              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "description": "When this payment method expires",
               "type": "integer",
               "maximum": 9007199254740991,
               "minimum": 1451606400
-            },
-            "maskedNumber": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "type",
+            "valid"
+          ]
         }
       },
       "additionalProperties": false,

--- a/schemas/core/profile.json
+++ b/schemas/core/profile.json
@@ -55,17 +55,28 @@
     "paymentMethod": {
       "type": "object",
       "properties": {
-        "status": {
+        "type": {
           "type": "string",
-          "enum": ["valid", "valid_expiring", "invalid", "unknown"]
+          "enum": ["unknown", "card", "stripe"]
         },
-        "expiry": {
-          "$ref": "./units.json#/definitions/time"
+        "valid": {
+          "description": "Whether the payment method is valid and working",
+          "type": "boolean"
         },
         "maskedNumber": {
+          "description": "Typically the credit card number with all but the last four digits obfuscated",
           "type": "string"
+        },
+        "issuer": {
+          "description": "The card issuer, e.g. 'Visa'",
+          "type": "string"
+        },
+        "expiry": {
+          "description": "When this payment method expires",
+          "$ref": "./units.json#/definitions/time"
         }
-      }
+      },
+      "required": ["type", "valid"]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
 For consistency with other existing schemas.
The main changes are:
    - convert `status` to a boolean `valid` flag
    - add an `issuer` field to hold, e.g. 'visa' if the type is a credit card
    - make `type` and `valid` to be required

