### PR TITLE
Add validity start & end times to estimates

### DIFF
--- a/prebuilt/maas-backend/subscriptions/pricing.json
+++ b/prebuilt/maas-backend/subscriptions/pricing.json
@@ -141,6 +141,37 @@
         }
       },
       "additionalProperties": false
+    },
+    "terms": {
+      "description": "Terms related to this subscription",
+      "type": "object",
+      "properties": {
+        "validity": {
+          "description": "Subscription validity conditions",
+          "type": "object",
+          "properties": {
+            "startTime": {
+              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "type": "integer",
+              "maximum": 9007199254740991,
+              "minimum": 1451606400
+            },
+            "endTime": {
+              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "type": "integer",
+              "maximum": 9007199254740991,
+              "minimum": 1451606400
+            }
+          },
+          "required": [
+            "startTime",
+            "endTime"
+          ]
+        }
+      },
+      "required": [
+        "validity"
+      ]
     }
   },
   "required": [
@@ -252,6 +283,37 @@
         "discount"
       ],
       "additionalProperties": false
+    },
+    "terms": {
+      "description": "Terms related to this subscription",
+      "type": "object",
+      "properties": {
+        "validity": {
+          "description": "Subscription validity conditions",
+          "type": "object",
+          "properties": {
+            "startTime": {
+              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "type": "integer",
+              "maximum": 9007199254740991,
+              "minimum": 1451606400
+            },
+            "endTime": {
+              "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+              "type": "integer",
+              "maximum": 9007199254740991,
+              "minimum": 1451606400
+            }
+          },
+          "required": [
+            "startTime",
+            "endTime"
+          ]
+        }
+      },
+      "required": [
+        "validity"
+      ]
     }
   }
 }

--- a/prebuilt/maas-backend/subscriptions/subscriptions-estimate/response.json
+++ b/prebuilt/maas-backend/subscriptions/subscriptions-estimate/response.json
@@ -147,6 +147,37 @@
             }
           },
           "additionalProperties": false
+        },
+        "terms": {
+          "description": "Terms related to this subscription",
+          "type": "object",
+          "properties": {
+            "validity": {
+              "description": "Subscription validity conditions",
+              "type": "object",
+              "properties": {
+                "startTime": {
+                  "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+                  "type": "integer",
+                  "maximum": 9007199254740991,
+                  "minimum": 1451606400
+                },
+                "endTime": {
+                  "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+                  "type": "integer",
+                  "maximum": 9007199254740991,
+                  "minimum": 1451606400
+                }
+              },
+              "required": [
+                "startTime",
+                "endTime"
+              ]
+            }
+          },
+          "required": [
+            "validity"
+          ]
         }
       },
       "required": [
@@ -258,6 +289,37 @@
             "discount"
           ],
           "additionalProperties": false
+        },
+        "terms": {
+          "description": "Terms related to this subscription",
+          "type": "object",
+          "properties": {
+            "validity": {
+              "description": "Subscription validity conditions",
+              "type": "object",
+              "properties": {
+                "startTime": {
+                  "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+                  "type": "integer",
+                  "maximum": 9007199254740991,
+                  "minimum": 1451606400
+                },
+                "endTime": {
+                  "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
+                  "type": "integer",
+                  "maximum": 9007199254740991,
+                  "minimum": 1451606400
+                }
+              },
+              "required": [
+                "startTime",
+                "endTime"
+              ]
+            }
+          },
+          "required": [
+            "validity"
+          ]
         }
       }
     },

--- a/schemas/maas-backend/subscriptions/pricing.json
+++ b/schemas/maas-backend/subscriptions/pricing.json
@@ -19,6 +19,9 @@
     "total": {
       "description": "Sum of the quantity * unitPrice - sum of discounts",
       "$ref": "../../core/units.json#/definitions/cost"
+    },
+    "terms": {
+      "$ref": "#/definitions/terms"
     }
   },
   "required": ["lineItems", "total"],
@@ -68,6 +71,22 @@
       },
       "required": ["description", "discount"],
       "additionalProperties": false
+    },
+    "terms": {
+      "description": "Terms related to this subscription",
+      "type": "object",
+      "properties": {
+        "validity": {
+          "description": "Subscription validity conditions",
+          "type": "object",
+          "properties": {
+            "startTime": { "$ref": "../../core/units.json#/definitions/time" },
+            "endTime": { "$ref": "../../core/units.json#/definitions/time" }
+          },
+          "required": ["startTime", "endTime"]
+        }
+      },
+      "required": ["validity"]
     }
   }
 }


### PR DESCRIPTION
UI needs to display when the estimated upgrade starts & ends. This schema reuses the subscription terms style subschema for displaying it.