### PR TITLE
Support Profile and InfoMessage types

### DIFF
--- a/prebuilt/maas-backend/push-notification/request.json
+++ b/prebuilt/maas-backend/push-notification/request.json
@@ -33,7 +33,8 @@
     "type": {
       "enum": [
         "ObjectChange",
-        "TripActivate"
+        "TripActivate",
+        "InfoMessage"
       ]
     },
     "data": {
@@ -63,6 +64,34 @@
             "ids"
           ],
           "additionalProperties": false
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "objectType": {
+              "enum": [
+                "Profile"
+              ]
+            },
+            "ids": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 1,
+              "items": {
+                "description": "Customer identity id - currently an AWS identityId",
+                "type": "string",
+                "pattern": "^[aepus]{2}-[\\w]{4}-\\d:[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$"
+              }
+            }
+          },
+          "required": [
+            "objectType",
+            "ids"
+          ],
+          "additionalProperties": false
         }
       ]
     }
@@ -70,8 +99,7 @@
   "required": [
     "identityId",
     "badge",
-    "type",
-    "data"
+    "type"
   ],
   "additionalProperties": false
 }

--- a/schemas/maas-backend/push-notification/request.json
+++ b/schemas/maas-backend/push-notification/request.json
@@ -14,7 +14,7 @@
       "enum": ["Alert", "Warning", "Information"]
     },
     "type": {
-      "enum": ["ObjectChange", "TripActivate"]
+      "enum": ["ObjectChange", "TripActivate",  "InfoMessage"]
     },
     "data": {
       "oneOf": [
@@ -33,10 +33,29 @@
           },
           "required": ["objectType", "ids"],
           "additionalProperties": false
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "objectType": { "enum": ["Profile"] },
+            "ids": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 1,
+              "items": {
+                "$ref": "../../core/units.json#/definitions/identityId"
+              }
+            }
+          },
+          "required": ["objectType", "ids"],
+          "additionalProperties": false
         }
       ]
     }
   },
-  "required": ["identityId", "badge", "type", "data"],
+  "required": ["identityId", "badge", "type"],
   "additionalProperties": false
 }


### PR DESCRIPTION
This enables two new push notification types:
- ObjectChange where the object is Profile (for notifying about profile changes, e.g. Balance changed or such)
- InfoMessage (for generic information that we want to display for end users)