### PR TITLE
Revert "Permit either leaveAt or arriveBy, not both"

### DIFF
--- a/prebuilt/maas-backend/routes/routes-query/request.json
+++ b/prebuilt/maas-backend/routes/routes-query/request.json
@@ -3,15 +3,9 @@
   "id": "https://api.maas.global/maas-backend/routes/routes-query/request",
   "description": "Request schema for reverse geocoding providers",
   "type": "object",
-  "oneOf": [
+  "allOf": [
     {
       "type": "object",
-      "description": "Permit leaveAt",
-      "required": [
-        "from",
-        "to",
-        "leaveAt"
-      ],
       "properties": {
         "identityId": {
           "type": "string",
@@ -57,119 +51,29 @@
       "additionalProperties": false
     },
     {
-      "type": "object",
-      "description": "Permit arriveBy",
-      "required": [
-        "from",
-        "to",
-        "arriveBy"
-      ],
-      "properties": {
-        "identityId": {
-          "type": "string",
-          "pattern": "^[aepus]{2}-[\\w]{4}-\\d:[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$"
+      "oneOf": [
+        {
+          "description": "Permit leaveAt",
+          "required": [
+            "from",
+            "to",
+            "leaveAt"
+          ]
         },
-        "from": {
-          "description": "Geographic latitude-longitude number-pair as a string in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
-          "type": "string",
-          "pattern": "^[+-]?\\d{1,3}(\\.\\d+)?,[+-]?\\d{1,3}(\\.\\d+)?$"
-        },
-        "fromName": {
-          "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",
-          "type": "string",
-          "pattern": "^([A-ö\\d]+[`'´\\(\\)\\-/,\\.]?)+(\\s?[A-ö\\d`'´\\(\\)\\-/,\\.]?)*$"
-        },
-        "to": {
-          "description": "Geographic latitude-longitude number-pair as a string in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
-          "type": "string",
-          "pattern": "^[+-]?\\d{1,3}(\\.\\d+)?,[+-]?\\d{1,3}(\\.\\d+)?$"
-        },
-        "toName": {
-          "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",
-          "type": "string",
-          "pattern": "^([A-ö\\d]+[`'´\\(\\)\\-/,\\.]?)+(\\s?[A-ö\\d`'´\\(\\)\\-/,\\.]?)*$"
-        },
-        "leaveAt": {
-          "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
-          "type": "integer",
-          "maximum": 9007199254740991,
-          "minimum": 1451606400
-        },
-        "arriveBy": {
-          "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
-          "type": "integer",
-          "maximum": 9007199254740991,
-          "minimum": 1451606400
-        },
-        "modes": {
-          "type": "string",
-          "pattern": "^(:?(:?WALK|BICYCLE|CAR|TRAM|SUBWAY|RAIL|BUS|FERRY|CABLE_CAR|GONDOLA|FUNICULAR|TRANSIT|TRAIN|TRAINISH|BUSISH|LEG_SWITCH|MAAS_TRIP|MAAS_PERSONAL|TAXI),)*(:?WALK|BICYCLE|CAR|TRAM|SUBWAY|RAIL|BUS|FERRY|CABLE_CAR|GONDOLA|FUNICULAR|TRANSIT|TRAIN|TRAINISH|BUSISH|LEG_SWITCH|MAAS_TRIP|MAAS_PERSONAL|TAXI)$"
+        {
+          "description": "Permit arriveBy",
+          "required": [
+            "from",
+            "to",
+            "arriveBy"
+          ]
         }
-      },
-      "additionalProperties": false
+      ]
     }
   ],
   "definitions": {
-    "payload1": {
+    "payload": {
       "type": "object",
-      "description": "Permit leaveAt",
-      "required": [
-        "from",
-        "to",
-        "leaveAt"
-      ],
-      "properties": {
-        "identityId": {
-          "type": "string",
-          "pattern": "^[aepus]{2}-[\\w]{4}-\\d:[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$"
-        },
-        "from": {
-          "description": "Geographic latitude-longitude number-pair as a string in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
-          "type": "string",
-          "pattern": "^[+-]?\\d{1,3}(\\.\\d+)?,[+-]?\\d{1,3}(\\.\\d+)?$"
-        },
-        "fromName": {
-          "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",
-          "type": "string",
-          "pattern": "^([A-ö\\d]+[`'´\\(\\)\\-/,\\.]?)+(\\s?[A-ö\\d`'´\\(\\)\\-/,\\.]?)*$"
-        },
-        "to": {
-          "description": "Geographic latitude-longitude number-pair as a string in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
-          "type": "string",
-          "pattern": "^[+-]?\\d{1,3}(\\.\\d+)?,[+-]?\\d{1,3}(\\.\\d+)?$"
-        },
-        "toName": {
-          "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",
-          "type": "string",
-          "pattern": "^([A-ö\\d]+[`'´\\(\\)\\-/,\\.]?)+(\\s?[A-ö\\d`'´\\(\\)\\-/,\\.]?)*$"
-        },
-        "leaveAt": {
-          "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
-          "type": "integer",
-          "maximum": 9007199254740991,
-          "minimum": 1451606400
-        },
-        "arriveBy": {
-          "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
-          "type": "integer",
-          "maximum": 9007199254740991,
-          "minimum": 1451606400
-        },
-        "modes": {
-          "type": "string",
-          "pattern": "^(:?(:?WALK|BICYCLE|CAR|TRAM|SUBWAY|RAIL|BUS|FERRY|CABLE_CAR|GONDOLA|FUNICULAR|TRANSIT|TRAIN|TRAINISH|BUSISH|LEG_SWITCH|MAAS_TRIP|MAAS_PERSONAL|TAXI),)*(:?WALK|BICYCLE|CAR|TRAM|SUBWAY|RAIL|BUS|FERRY|CABLE_CAR|GONDOLA|FUNICULAR|TRANSIT|TRAIN|TRAINISH|BUSISH|LEG_SWITCH|MAAS_TRIP|MAAS_PERSONAL|TAXI)$"
-        }
-      },
-      "additionalProperties": false
-    },
-    "payload2": {
-      "type": "object",
-      "description": "Permit arriveBy",
-      "required": [
-        "from",
-        "to",
-        "arriveBy"
-      ],
       "properties": {
         "identityId": {
           "type": "string",

--- a/schemas/maas-backend/routes/routes-query/request.json
+++ b/schemas/maas-backend/routes/routes-query/request.json
@@ -3,54 +3,26 @@
   "id": "https://api.maas.global/maas-backend/routes/routes-query/request",
   "description": "Request schema for reverse geocoding providers",
   "type": "object",
-  "oneOf": [
+  "allOf": [
     {
-      "type": "object",
-      "$ref": "#/definitions/payload1"
+      "$ref": "#/definitions/payload"
     },
     {
-      "type": "object",
-      "$ref": "#/definitions/payload2"
+      "oneOf": [
+        {
+          "description": "Permit leaveAt",
+          "required": ["from", "to", "leaveAt"]
+        },
+        {
+          "description": "Permit arriveBy",
+          "required": ["from", "to", "arriveBy"]
+        }
+      ]
     }
   ],
   "definitions": {
-    "payload1": {
+    "payload": {
       "type": "object",
-      "description": "Permit leaveAt",
-      "required": ["from", "to", "leaveAt"],
-      "properties": {
-        "identityId": {
-          "$ref": "../../../core/aws-units.json#/definitions/identityId"
-        },
-        "from": {
-          "$ref": "../../../core/units.json#/definitions/shortLocationString"
-        },
-        "fromName": {
-          "$ref": "../../../core/address.json#/definitions/address"
-        },
-        "to": {
-          "$ref": "../../../core/units.json#/definitions/shortLocationString"
-        },
-        "toName": {
-          "$ref": "../../../core/address.json#/definitions/address"
-        },
-        "leaveAt": {
-          "$ref": "../../../core/units.json#/definitions/time"
-        },
-        "arriveBy": {
-          "$ref": "../../../core/units.json#/definitions/time"
-        },
-        "modes": {
-          "type": "string",
-          "pattern": "^(:?(:?WALK|BICYCLE|CAR|TRAM|SUBWAY|RAIL|BUS|FERRY|CABLE_CAR|GONDOLA|FUNICULAR|TRANSIT|TRAIN|TRAINISH|BUSISH|LEG_SWITCH|MAAS_TRIP|MAAS_PERSONAL|TAXI),)*(:?WALK|BICYCLE|CAR|TRAM|SUBWAY|RAIL|BUS|FERRY|CABLE_CAR|GONDOLA|FUNICULAR|TRANSIT|TRAIN|TRAINISH|BUSISH|LEG_SWITCH|MAAS_TRIP|MAAS_PERSONAL|TAXI)$"
-        }
-      },
-      "additionalProperties": false
-    },
-    "payload2": {
-      "type": "object",
-      "description": "Permit arriveBy",
-      "required": ["from", "to", "arriveBy"],
       "properties": {
         "identityId": {
           "$ref": "../../../core/aws-units.json#/definitions/identityId"


### PR DESCRIPTION
Reverts maasglobal/maas-schemas#122

I reverted this because this did not fix the root cause of the problem, e.g. not assigning defaults to leaveAt if both were missing. This is now done in routes-query.