### PR TITLE
Fix error.data handling in ValidationError

### DIFF
--- a/ValidationError.js
+++ b/ValidationError.js
@@ -37,7 +37,7 @@ class ValidationError extends Error {
    */
   static fromValidatorErrors(errors, object) {
     const messages = errors.map(error => {
-      return `'${error.dataPath}' ${trim(error.message)}, got '${trim(JSON.stringify(error.data))}'`;
+      return `'${error.dataPath}' ${trim(error.message)}, got '${error.data == null ? String(error.data) : trim(JSON.stringify(error.data))}'`;
     });
 
     if (messages.length > 1) {


### PR DESCRIPTION
in maas-transport-booking, I have situation where `error.data` is `undefined, and in such case following crash happens:

```
TypeError: Cannot read property 'length' of undefined
      at trim (node_modules/maas-schemas/ValidationError.js:6:14)
      at errors.map.error (node_modules/maas-schemas/ValidationError.js:41:66)
      at Array.map (native)
      at Function.fromValidatorErrors (node_modules/maas-schemas/ValidationError.js:39:29)
      at validateSync (node_modules/maas-schemas/validator.js:175:27)
      at Object.validate (node_modules/maas-schemas/validator.js:195:28)
```

This patch prevents such crash