### PR TITLE
added subscription into Booking:customer

### DIFF
--- a/prebuilt/core/booking-option.json
+++ b/prebuilt/core/booking-option.json
@@ -854,12 +854,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {

--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -853,12 +853,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {
@@ -1823,12 +1820,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {
@@ -1957,12 +1951,9 @@
           "maxLength": 64
         },
         "subscription": {
+          "description": "Subset of customer subscription information to be stored e.g. in every booking",
           "type": "object",
           "properties": {
-            "id": {
-              "type": "integer",
-              "minValue": 0
-            },
             "plan": {
               "type": "object",
               "properties": {

--- a/prebuilt/core/customer.json
+++ b/prebuilt/core/customer.json
@@ -30,6 +30,47 @@
       "type": "string",
       "pattern": "^(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])+@(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])+\\.(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])+$",
       "maxLength": 64
+    },
+    "subscription": {
+      "description": "Subset of customer subscription information to be stored e.g. in every booking",
+      "type": "object",
+      "properties": {
+        "plan": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "addons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        },
+        "coupons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        }
+      },
+      "required": [
+        "plan",
+        "addons",
+        "coupons"
+      ]
     }
   }
 }

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
@@ -862,12 +862,9 @@
                     "maxLength": 64
                   },
                   "subscription": {
+                    "description": "Subset of customer subscription information to be stored e.g. in every booking",
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "type": "integer",
-                        "minValue": 0
-                      },
                       "plan": {
                         "type": "object",
                         "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -860,12 +860,9 @@
                       "maxLength": 64
                     },
                     "subscription": {
+                      "description": "Subset of customer subscription information to be stored e.g. in every booking",
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "integer",
-                          "minValue": 0
-                        },
                         "plan": {
                           "type": "object",
                           "properties": {
@@ -1830,12 +1827,9 @@
                       "maxLength": 64
                     },
                     "subscription": {
+                      "description": "Subset of customer subscription information to be stored e.g. in every booking",
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "integer",
-                          "minValue": 0
-                        },
                         "plan": {
                           "type": "object",
                           "properties": {
@@ -1964,12 +1958,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-create/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/request.json
@@ -864,12 +864,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -859,12 +859,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1829,12 +1826,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1963,12 +1957,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -862,12 +862,9 @@
                     "maxLength": 64
                   },
                   "subscription": {
+                    "description": "Subset of customer subscription information to be stored e.g. in every booking",
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "type": "integer",
-                        "minValue": 0
-                      },
                       "plan": {
                         "type": "object",
                         "properties": {
@@ -1832,12 +1829,9 @@
                     "maxLength": 64
                   },
                   "subscription": {
+                    "description": "Subset of customer subscription information to be stored e.g. in every booking",
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "type": "integer",
-                        "minValue": 0
-                      },
                       "plan": {
                         "type": "object",
                         "properties": {
@@ -1966,12 +1960,9 @@
                 "maxLength": 64
               },
               "subscription": {
+                "description": "Subset of customer subscription information to be stored e.g. in every booking",
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "type": "integer",
-                    "minValue": 0
-                  },
                   "plan": {
                     "type": "object",
                     "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -859,12 +859,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1829,12 +1826,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1963,12 +1957,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-update/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/request.json
@@ -868,12 +868,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1838,12 +1835,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1972,12 +1966,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -859,12 +859,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1829,12 +1826,9 @@
                   "maxLength": 64
                 },
                 "subscription": {
+                  "description": "Subset of customer subscription information to be stored e.g. in every booking",
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minValue": 0
-                    },
                     "plan": {
                       "type": "object",
                       "properties": {
@@ -1963,12 +1957,9 @@
               "maxLength": 64
             },
             "subscription": {
+              "description": "Subset of customer subscription information to be stored e.g. in every booking",
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer",
-                  "minValue": 0
-                },
                 "plan": {
                   "type": "object",
                   "properties": {

--- a/prebuilt/tsp/booking-create/request.json
+++ b/prebuilt/tsp/booking-create/request.json
@@ -643,12 +643,9 @@
           "maxLength": 64
         },
         "subscription": {
+          "description": "Subset of customer subscription information to be stored e.g. in every booking",
           "type": "object",
           "properties": {
-            "id": {
-              "type": "integer",
-              "minValue": 0
-            },
             "plan": {
               "type": "object",
               "properties": {

--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -76,42 +76,7 @@
           "$ref": "./customer.json#/definitions/email"
         },
         "subscription": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "integer",
-              "minValue": 0
-            },
-            "plan": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 255
-                }
-              },
-              "required": [ "id" ],
-              "additionalProperties": false
-            },
-            "addons": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 255
-              }
-            },
-            "coupons": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 255
-              }
-            }
-          },
-          "required": ["plan", "addons", "coupons"]
+          "$ref": "./customer.json#/definitions/subscription"
         }
       },
       "required": [

--- a/schemas/core/customer.json
+++ b/schemas/core/customer.json
@@ -30,6 +30,41 @@
       "type": "string",
       "pattern": "^.+@.+\\..+$",
       "maxLength": 64
+    },
+    "subscription": {
+      "description": "Subset of customer subscription information to be stored e.g. in every booking",
+      "type": "object",
+      "properties": {
+        "plan": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            }
+          },
+          "required": [ "id" ],
+          "additionalProperties": false
+        },
+        "addons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        },
+        "coupons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        }
+      },
+      "required": ["plan", "addons", "coupons"]
     }
   }
 }


### PR DESCRIPTION
Added (optional) subscription info into Booking, with plan, addons and coupons.

Required for corresponding maas-backend PR. *Should* be backwards compatible as introducing only optional new fields.