### PR TITLE
Fix geo accuracy

### DIFF
--- a/prebuilt/core/booking-option.json
+++ b/prebuilt/core/booking-option.json
@@ -488,15 +488,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -547,15 +545,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -770,15 +766,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -487,15 +487,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -546,15 +544,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -769,15 +765,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -1513,15 +1507,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1572,15 +1564,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1795,15 +1785,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -2502,15 +2490,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -2561,15 +2547,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -2784,15 +2768,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/core/geolocation.json
+++ b/prebuilt/core/geolocation.json
@@ -35,15 +35,13 @@
                         "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -90,
-                        "maximum": 90,
-                        "multipleOf": 0.000001
+                        "maximum": 90
                       },
                       {
                         "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -180,
-                        "maximum": 180,
-                        "multipleOf": 0.000001
+                        "maximum": 180
                       }
                     ]
                   }
@@ -138,15 +136,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               ]
             }
@@ -227,15 +223,13 @@
               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
               "type": "number",
               "minimum": -90,
-              "maximum": 90,
-              "multipleOf": 0.000001
+              "maximum": 90
             },
             {
               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
               "type": "number",
               "minimum": -180,
-              "maximum": 180,
-              "multipleOf": 0.000001
+              "maximum": 180
             }
           ]
         }

--- a/prebuilt/core/iot-thing-shadow.json
+++ b/prebuilt/core/iot-thing-shadow.json
@@ -18,15 +18,13 @@
               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
               "type": "number",
               "minimum": -90,
-              "maximum": 90,
-              "multipleOf": 0.000001
+              "maximum": 90
             },
             "lon": {
               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
               "type": "number",
               "minimum": -180,
-              "maximum": 180,
-              "multipleOf": 0.000001
+              "maximum": 180
             },
             "timestamp": {
               "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",

--- a/prebuilt/core/itinerary.json
+++ b/prebuilt/core/itinerary.json
@@ -662,15 +662,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -721,15 +719,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -944,15 +940,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [

--- a/prebuilt/core/plan.json
+++ b/prebuilt/core/plan.json
@@ -738,15 +738,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -797,15 +795,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -1020,15 +1016,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1831,15 +1825,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -1890,15 +1882,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -2113,15 +2103,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -2919,15 +2907,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -2978,15 +2964,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -3201,15 +3185,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [

--- a/prebuilt/core/productOption.json
+++ b/prebuilt/core/productOption.json
@@ -159,15 +159,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -218,15 +216,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -441,15 +437,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/core/transport-service-provider.json
+++ b/prebuilt/core/transport-service-provider.json
@@ -160,15 +160,13 @@
                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                 "type": "number",
                 "minimum": -90,
-                "maximum": 90,
-                "multipleOf": 0.000001
+                "maximum": 90
               },
               {
                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                 "type": "number",
                 "minimum": -180,
-                "maximum": 180,
-                "multipleOf": 0.000001
+                "maximum": 180
               }
             ]
           }

--- a/prebuilt/core/units.json
+++ b/prebuilt/core/units.json
@@ -29,15 +29,13 @@
       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
       "type": "number",
       "minimum": -90,
-      "maximum": 90,
-      "multipleOf": 0.000001
+      "maximum": 90
     },
     "longitude": {
       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
       "type": "number",
       "minimum": -180,
-      "maximum": 180,
-      "multipleOf": 0.000001
+      "maximum": 180
     },
     "location": {
       "description": "Geographic latitude-longitude object in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
@@ -47,15 +45,13 @@
           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -90,
-          "maximum": 90,
-          "multipleOf": 0.000001
+          "maximum": 90
         },
         "lon": {
           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -180,
-          "maximum": 180,
-          "multipleOf": 0.000001
+          "maximum": 180
         }
       },
       "required": [
@@ -105,15 +101,13 @@
           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -90,
-          "maximum": 90,
-          "multipleOf": 0.000001
+          "maximum": 90
         },
         {
           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -180,
-          "maximum": 180,
-          "multipleOf": 0.000001
+          "maximum": 180
         }
       ]
     },
@@ -297,15 +291,13 @@
               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
               "type": "number",
               "minimum": -90,
-              "maximum": 90,
-              "multipleOf": 0.000001
+              "maximum": 90
             },
             "lon": {
               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
               "type": "number",
               "minimum": -180,
-              "maximum": 180,
-              "multipleOf": 0.000001
+              "maximum": 180
             }
           },
           "required": [

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
@@ -496,15 +496,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -555,15 +553,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -778,15 +774,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -494,15 +494,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -553,15 +551,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -776,15 +772,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1520,15 +1514,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -1579,15 +1571,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [
@@ -1802,15 +1792,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -2509,15 +2497,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -2568,15 +2554,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -2791,15 +2775,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [

--- a/prebuilt/maas-backend/bookings/bookings-create/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/request.json
@@ -498,15 +498,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -557,15 +555,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -780,15 +776,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -493,15 +493,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -552,15 +550,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -775,15 +771,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1519,15 +1513,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1578,15 +1570,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1801,15 +1791,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2508,15 +2496,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2567,15 +2553,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2790,15 +2774,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -496,15 +496,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -555,15 +553,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -778,15 +774,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [
@@ -1522,15 +1516,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -1581,15 +1573,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [
@@ -1804,15 +1794,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [
@@ -2511,15 +2499,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [
@@ -2570,15 +2556,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [
@@ -2793,15 +2777,13 @@
                         "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -90,
-                        "maximum": 90,
-                        "multipleOf": 0.000001
+                        "maximum": 90
                       },
                       "lon": {
                         "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -180,
-                        "maximum": 180,
-                        "multipleOf": 0.000001
+                        "maximum": 180
                       }
                     },
                     "required": [

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -493,15 +493,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -552,15 +550,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -775,15 +771,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1519,15 +1513,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1578,15 +1570,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1801,15 +1791,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2508,15 +2496,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2567,15 +2553,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2790,15 +2774,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/maas-backend/bookings/bookings-update/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/request.json
@@ -502,15 +502,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -561,15 +559,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -784,15 +780,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1528,15 +1522,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1587,15 +1579,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1810,15 +1800,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2517,15 +2505,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2576,15 +2562,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2799,15 +2783,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -493,15 +493,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -552,15 +550,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -775,15 +771,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1519,15 +1513,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1578,15 +1570,13 @@
                               "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -90,
-                              "maximum": 90,
-                              "multipleOf": 0.000001
+                              "maximum": 90
                             },
                             "lon": {
                               "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                               "type": "number",
                               "minimum": -180,
-                              "maximum": 180,
-                              "multipleOf": 0.000001
+                              "maximum": 180
                             }
                           },
                           "required": [
@@ -1801,15 +1791,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2508,15 +2496,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2567,15 +2553,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -2790,15 +2774,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/maas-backend/geocoding/geocoding-query/response.json
+++ b/prebuilt/maas-backend/geocoding/geocoding-query/response.json
@@ -34,15 +34,13 @@
                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                     "type": "number",
                     "minimum": -90,
-                    "maximum": 90,
-                    "multipleOf": 0.000001
+                    "maximum": 90
                   },
                   {
                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                     "type": "number",
                     "minimum": -180,
-                    "maximum": 180,
-                    "multipleOf": 0.000001
+                    "maximum": 180
                   }
                 ]
               }

--- a/prebuilt/maas-backend/geocoding/geocoding-reverse/response.json
+++ b/prebuilt/maas-backend/geocoding/geocoding-reverse/response.json
@@ -36,15 +36,13 @@
                         "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -90,
-                        "maximum": 90,
-                        "multipleOf": 0.000001
+                        "maximum": 90
                       },
                       {
                         "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -180,
-                        "maximum": 180,
-                        "multipleOf": 0.000001
+                        "maximum": 180
                       }
                     ]
                   }

--- a/prebuilt/maas-backend/itineraries/itinerary-create/request.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/request.json
@@ -668,15 +668,13 @@
                                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -90,
-                                    "maximum": 90,
-                                    "multipleOf": 0.000001
+                                    "maximum": 90
                                   },
                                   "lon": {
                                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -180,
-                                    "maximum": 180,
-                                    "multipleOf": 0.000001
+                                    "maximum": 180
                                   }
                                 },
                                 "required": [
@@ -727,15 +725,13 @@
                                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -90,
-                                    "maximum": 90,
-                                    "multipleOf": 0.000001
+                                    "maximum": 90
                                   },
                                   "lon": {
                                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -180,
-                                    "maximum": 180,
-                                    "multipleOf": 0.000001
+                                    "maximum": 180
                                   }
                                 },
                                 "required": [
@@ -950,15 +946,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [

--- a/prebuilt/maas-backend/itineraries/itinerary-create/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/response.json
@@ -668,15 +668,13 @@
                                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -90,
-                                    "maximum": 90,
-                                    "multipleOf": 0.000001
+                                    "maximum": 90
                                   },
                                   "lon": {
                                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -180,
-                                    "maximum": 180,
-                                    "multipleOf": 0.000001
+                                    "maximum": 180
                                   }
                                 },
                                 "required": [
@@ -727,15 +725,13 @@
                                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -90,
-                                    "maximum": 90,
-                                    "multipleOf": 0.000001
+                                    "maximum": 90
                                   },
                                   "lon": {
                                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -180,
-                                    "maximum": 180,
-                                    "multipleOf": 0.000001
+                                    "maximum": 180
                                   }
                                 },
                                 "required": [
@@ -950,15 +946,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [

--- a/prebuilt/maas-backend/itineraries/itinerary-list/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-list/response.json
@@ -671,15 +671,13 @@
                                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -90,
-                                      "maximum": 90,
-                                      "multipleOf": 0.000001
+                                      "maximum": 90
                                     },
                                     "lon": {
                                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -180,
-                                      "maximum": 180,
-                                      "multipleOf": 0.000001
+                                      "maximum": 180
                                     }
                                   },
                                   "required": [
@@ -730,15 +728,13 @@
                                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -90,
-                                      "maximum": 90,
-                                      "multipleOf": 0.000001
+                                      "maximum": 90
                                     },
                                     "lon": {
                                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -180,
-                                      "maximum": 180,
-                                      "multipleOf": 0.000001
+                                      "maximum": 180
                                     }
                                   },
                                   "required": [
@@ -953,15 +949,13 @@
                                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -90,
-                                  "maximum": 90,
-                                  "multipleOf": 0.000001
+                                  "maximum": 90
                                 },
                                 "lon": {
                                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                   "type": "number",
                                   "minimum": -180,
-                                  "maximum": 180,
-                                  "multipleOf": 0.000001
+                                  "maximum": 180
                                 }
                               },
                               "required": [

--- a/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
@@ -668,15 +668,13 @@
                                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -90,
-                                    "maximum": 90,
-                                    "multipleOf": 0.000001
+                                    "maximum": 90
                                   },
                                   "lon": {
                                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -180,
-                                    "maximum": 180,
-                                    "multipleOf": 0.000001
+                                    "maximum": 180
                                   }
                                 },
                                 "required": [
@@ -727,15 +725,13 @@
                                     "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -90,
-                                    "maximum": 90,
-                                    "multipleOf": 0.000001
+                                    "maximum": 90
                                   },
                                   "lon": {
                                     "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                     "type": "number",
                                     "minimum": -180,
-                                    "maximum": 180,
-                                    "multipleOf": 0.000001
+                                    "maximum": 180
                                   }
                                 },
                                 "required": [
@@ -950,15 +946,13 @@
                                 "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -90,
-                                "maximum": 90,
-                                "multipleOf": 0.000001
+                                "maximum": 90
                               },
                               "lon": {
                                 "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                 "type": "number",
                                 "minimum": -180,
-                                "maximum": 180,
-                                "multipleOf": 0.000001
+                                "maximum": 180
                               }
                             },
                             "required": [

--- a/prebuilt/maas-backend/provider/routes/request.json
+++ b/prebuilt/maas-backend/provider/routes/request.json
@@ -16,15 +16,13 @@
           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -90,
-          "maximum": 90,
-          "multipleOf": 0.000001
+          "maximum": 90
         },
         {
           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -180,
-          "maximum": 180,
-          "multipleOf": 0.000001
+          "maximum": 180
         }
       ]
     },
@@ -47,15 +45,13 @@
           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -90,
-          "maximum": 90,
-          "multipleOf": 0.000001
+          "maximum": 90
         },
         {
           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
           "type": "number",
           "minimum": -180,
-          "maximum": 180,
-          "multipleOf": 0.000001
+          "maximum": 180
         }
       ]
     },

--- a/prebuilt/maas-backend/provider/routes/response.json
+++ b/prebuilt/maas-backend/provider/routes/response.json
@@ -718,15 +718,13 @@
                                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -90,
-                                          "maximum": 90,
-                                          "multipleOf": 0.000001
+                                          "maximum": 90
                                         },
                                         "lon": {
                                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -180,
-                                          "maximum": 180,
-                                          "multipleOf": 0.000001
+                                          "maximum": 180
                                         }
                                       },
                                       "required": [
@@ -777,15 +775,13 @@
                                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -90,
-                                          "maximum": 90,
-                                          "multipleOf": 0.000001
+                                          "maximum": 90
                                         },
                                         "lon": {
                                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -180,
-                                          "maximum": 180,
-                                          "multipleOf": 0.000001
+                                          "maximum": 180
                                         }
                                       },
                                       "required": [
@@ -1000,15 +996,13 @@
                                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -90,
-                                      "maximum": 90,
-                                      "multipleOf": 0.000001
+                                      "maximum": 90
                                     },
                                     "lon": {
                                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -180,
-                                      "maximum": 180,
-                                      "multipleOf": 0.000001
+                                      "maximum": 180
                                     }
                                   },
                                   "required": [

--- a/prebuilt/maas-backend/routes/routes-query/response.json
+++ b/prebuilt/maas-backend/routes/routes-query/response.json
@@ -718,15 +718,13 @@
                                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -90,
-                                          "maximum": 90,
-                                          "multipleOf": 0.000001
+                                          "maximum": 90
                                         },
                                         "lon": {
                                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -180,
-                                          "maximum": 180,
-                                          "multipleOf": 0.000001
+                                          "maximum": 180
                                         }
                                       },
                                       "required": [
@@ -777,15 +775,13 @@
                                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -90,
-                                          "maximum": 90,
-                                          "multipleOf": 0.000001
+                                          "maximum": 90
                                         },
                                         "lon": {
                                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                           "type": "number",
                                           "minimum": -180,
-                                          "maximum": 180,
-                                          "multipleOf": 0.000001
+                                          "maximum": 180
                                         }
                                       },
                                       "required": [
@@ -1000,15 +996,13 @@
                                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -90,
-                                      "maximum": 90,
-                                      "multipleOf": 0.000001
+                                      "maximum": 90
                                     },
                                     "lon": {
                                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                                       "type": "number",
                                       "minimum": -180,
-                                      "maximum": 180,
-                                      "multipleOf": 0.000001
+                                      "maximum": 180
                                     }
                                   },
                                   "required": [

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
@@ -338,15 +338,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -397,15 +395,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -620,15 +616,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
@@ -342,15 +342,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -401,15 +399,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -624,15 +620,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -1123,15 +1117,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1182,15 +1174,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1405,15 +1395,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/prebuilt/tsp/booking-cancel/response.json
+++ b/prebuilt/tsp/booking-cancel/response.json
@@ -335,15 +335,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -394,15 +392,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -617,15 +613,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/booking-create/request.json
+++ b/prebuilt/tsp/booking-create/request.json
@@ -277,15 +277,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -336,15 +334,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -559,15 +555,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/booking-create/response.json
+++ b/prebuilt/tsp/booking-create/response.json
@@ -337,15 +337,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -396,15 +394,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -619,15 +615,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/booking-option.json
+++ b/prebuilt/tsp/booking-option.json
@@ -359,15 +359,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -418,15 +416,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -641,15 +637,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/booking-options-list/response.json
+++ b/prebuilt/tsp/booking-options-list/response.json
@@ -367,15 +367,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [
@@ -426,15 +424,13 @@
                             "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -90,
-                            "maximum": 90,
-                            "multipleOf": 0.000001
+                            "maximum": 90
                           },
                           "lon": {
                             "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                             "type": "number",
                             "minimum": -180,
-                            "maximum": 180,
-                            "multipleOf": 0.000001
+                            "maximum": 180
                           }
                         },
                         "required": [
@@ -649,15 +645,13 @@
                         "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -90,
-                        "maximum": 90,
-                        "multipleOf": 0.000001
+                        "maximum": 90
                       },
                       "lon": {
                         "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                         "type": "number",
                         "minimum": -180,
-                        "maximum": 180,
-                        "multipleOf": 0.000001
+                        "maximum": 180
                       }
                     },
                     "required": [

--- a/prebuilt/tsp/booking-read-by-id/response.json
+++ b/prebuilt/tsp/booking-read-by-id/response.json
@@ -328,15 +328,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -387,15 +385,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -610,15 +606,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/booking-update/response.json
+++ b/prebuilt/tsp/booking-update/response.json
@@ -327,15 +327,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -386,15 +384,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -609,15 +605,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/webhooks-bookings-update/remote-request.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-request.json
@@ -327,15 +327,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -386,15 +384,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -609,15 +605,13 @@
                   "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -90,
-                  "maximum": 90,
-                  "multipleOf": 0.000001
+                  "maximum": 90
                 },
                 "lon": {
                   "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                   "type": "number",
                   "minimum": -180,
-                  "maximum": 180,
-                  "multipleOf": 0.000001
+                  "maximum": 180
                 }
               },
               "required": [

--- a/prebuilt/tsp/webhooks-bookings-update/remote-response.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-response.json
@@ -342,15 +342,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -401,15 +399,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -624,15 +620,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [
@@ -1123,15 +1117,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1182,15 +1174,13 @@
                           "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -90,
-                          "maximum": 90,
-                          "multipleOf": 0.000001
+                          "maximum": 90
                         },
                         "lon": {
                           "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                           "type": "number",
                           "minimum": -180,
-                          "maximum": 180,
-                          "multipleOf": 0.000001
+                          "maximum": 180
                         }
                       },
                       "required": [
@@ -1405,15 +1395,13 @@
                       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -90,
-                      "maximum": 90,
-                      "multipleOf": 0.000001
+                      "maximum": 90
                     },
                     "lon": {
                       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
                       "type": "number",
                       "minimum": -180,
-                      "maximum": 180,
-                      "multipleOf": 0.000001
+                      "maximum": 180
                     }
                   },
                   "required": [

--- a/schemas/core/units.json
+++ b/schemas/core/units.json
@@ -29,15 +29,13 @@
       "description": "Geographic latitude (north-south axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
       "type": "number",
       "minimum": -90,
-      "maximum": 90,
-      "multipleOf": 0.000001
+      "maximum": 90
     },
     "longitude": {
       "description": "Geographic longitude (east-west axis) in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",
       "type": "number",
       "minimum": -180,
-      "maximum": 180,
-      "multipleOf": 0.000001
+      "maximum": 180
     },
     "location": {
       "description": "Geographic latitude-longitude object in WGS-84 system, see https://en.wikipedia.org/wiki/World_Geodetic_System",


### PR DESCRIPTION
Applying artificial limit, introduced a lot of issues, as we were marking a valid geo data (as coming directly from TSP providers) as invalid.

Forgetting to apply rounding before sending the result to backend, resulted in occasional app crashes, which put off numerous of our services on production

It was originally introduced to workaround possible iOS client issue (which was accused of rounding values on its own, see this slack thread > https://maasfi.slack.com/archives/C0QPZRKS4/p1477416263000126), but it was confirmed (over year later) by @volatilegg that nothing like that should happen -> https://maasfi.slack.com/archives/C0QPZRKS4/p1512996672000084?thread_ts=1510823060.000413&cid=C0QPZRKS4

Anyway it'll be good put it to round of tests that involve iOS app directly