### PR TITLE
Configurator schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "bluebird": "^3.4.5",
     "chai": "^3.5.0",
+    "chalk": "^2.3.0",
     "eslint": "^3.1.1",
     "eslint-config-airbnb-base": "^5.0.0",
     "eslint-plugin-import": "^1.11.1",

--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -37,8 +37,14 @@
       "$ref": "#/definitions/terms"
     },
     "customer": {
-      "$ref": "./components/customer.json",
-      "required": ["firstName", "lastName", "phone", "email"]
+      "allOf": [
+        {
+          "$ref": "./components/customer.json"
+        },
+        {
+          "required": ["firstName", "lastName", "phone", "email"]
+        }
+      ]
     },
     "product": {
       "$ref": "./product.json"
@@ -53,7 +59,7 @@
       "$ref": "./components/configurator.json#/definitions/customerSelection"
     }
   },
-  "required": ["tspId", "state", "leg", "meta", "terms", "token", "customer"],
+  "required": ["id", "state", "leg", "meta", "terms", "token", "customer"],
   "definitions": {
     "tspId": {
       "type": "string",

--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -45,6 +45,12 @@
     },
     "signature": {
       "$ref": "./components/units.json#/definitions/signature"
+    },
+    "configurator": {
+      "$ref": "./components/configurator.json"
+    },
+    "customerSelection": {
+      "$ref": "./components/configurator.json#/definitions/customerSelection"
     }
   },
   "required": ["tspId", "state", "leg", "meta", "terms", "token", "customer"],

--- a/schemas/core/components/configurator.json
+++ b/schemas/core/components/configurator.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Configurator schema to customize a booking option",
+  "type": "object",
+  "description": "Wrapper schema, with each of its properties a config that the user can customize",
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Single ticket choices",
+          "properties": {
+            "single": { "$ref": "#/definitions/config" }
+          },
+          "required": ["single"]
+        },
+        {
+          "type": "object",
+          "description": "Two way ticket choices",
+          "properties": {
+            "openReturn": { "$ref": "#/definitions/config" }
+          },
+          "required": ["openReturn"]
+        }
+      ]
+    },
+    { "$ref": "#/definitions/commonConfigurations" }
+  ],
+  "definitions": {
+    "commonConfigurations": {
+      "type": "object",
+      "description": "Common ticket preferences",
+      "properties": {
+        "seatDirection": { "$ref": "#/definitions/config" },
+        "seatPosition": { "$ref": "#/definitions/config" },
+        "seatType": { "$ref": "#/definitions/config" },
+        "seatFeatures": { "$ref": "#/definitions/config" }
+      }
+    },
+    "config": {
+      "type": "object",
+      "description": "A customization to the booking option",
+      "properties": {
+        "type": {
+          "description": "Describe the possible combination of choices user can make",
+          "enum": ["oneOf", "someOf", "allOf", "oneOrNoneOf", "someOrNoneOf"]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 255
+        },
+        "description": {
+          "type": "string"
+        },
+        "choices": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Set of choices for one customization",
+          "items": {
+            "$ref": "#/definitions/choice"
+          },
+          "contains": {
+            "allOf": [
+              { "$ref": "#/definitions/choice" },
+              { "required": ["default"] }
+            ]
+          }
+        }
+      },
+      "required": ["type", "name", "choices"]
+    },
+    "choice": {
+      "type": "object",
+      "description": "A choice for one customization",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "asd",
+          "maxLength": 255
+        },
+        "name": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 255
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": {
+          "type": "boolean"
+        },
+        "cost": {
+          "$ref": "./cost.json"
+        },
+        "fares": {
+          "type": "array",
+          "items": [
+            {
+              "ref": "./fare.json"
+            }
+          ]
+        },
+        "terms": {
+          "$ref": "./terms.json"
+        },
+        "meta": {
+          "type": "object"
+        }
+      },
+      "required": ["id", "name", "default", "terms", "meta"]
+    },
+    "customerSelection": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9\\-]+$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/core/components/configurator.md
+++ b/schemas/core/components/configurator.md
@@ -1,0 +1,65 @@
+
+# Configurator
+The aim of this schema is to support the possibility of providing user with customizable booking options.
+
+Each choice the user make will be accumulated into the total sum of the booking.
+
+At the moment, only flat cost are given. In the future, schema may be extended to support cost per unit.
+
+**Use cases**
+- Rental cars that provides options for child seat, elder seat, additional care packages ...
+- Taxi that provides child seats, elder care, bench
+- Rail tickets that supports seat selection, additional luggages etc
+- Public transit for students / child / elders
+
+**Generating configurator**
+
+`Configurator` is an object, with each of its key a customization. `type` property is given as instruction on how the choice should be made. `choices` will be the set of choices in which the users choose from. All choices requires an (kebab-cased) id, human readable name and cost. If the choices are more or equal to one, at least one choice is required to be `default: true`.
+
+**Sample configurator**
+```json
+{
+  "ticket": {
+    "type": "oneOf",
+    "name": "Ticket type",
+    "choices": [
+      {
+        "id": "type-adult",
+        "name": "Adult ticket",
+        "default": true,
+        "cost": {
+          "amount": 5.5,
+          "currency": "EUR"
+        }
+      },
+      {
+        "id": "type-child",
+        "name": "Child ticket",
+        "cost": {
+          "amount": 2,
+          "currency": "EUR"
+        }
+      },
+      {
+        "id": "type-student",
+        "name": "Student ticket",
+        "cost": {
+          "amount": 2,
+          "currency": "EUR"
+        }
+      }
+    ]
+  }
+}
+```
+
+**Creating a selection**
+
+`Selection` is an object, with each of its key is a key of the `Configurator` object. The value of each key is an array of ids of choices the user made.
+
+**Sample configurator selection**
+```json
+{
+  "ticket": ["type-adult"]
+}
+```

--- a/schemas/core/components/customer.json
+++ b/schemas/core/components/customer.json
@@ -3,6 +3,9 @@
   "description": "MaaS customer schema",
   "type": "object",
   "properties": {
+    "identityId": {
+      "$ref": "./units.json#/definitions/identityId"
+    },
     "firstName": {
       "description": "First name of the customer (e.g. John)",
       "type": "string",

--- a/schemas/core/components/terms.json
+++ b/schemas/core/components/terms.json
@@ -13,7 +13,9 @@
       "type": "object",
       "properties": {
         "startTime": { "$ref": "./units.json#/definitions/time" },
-        "endTime": { "$ref": "./units.json#/definitions/time" }
+        "endTime": { "$ref": "./units.json#/definitions/time" },
+        "startTimeReturn": { "$ref": "./units.json#/definitions/time" },
+        "endTimeReturn": { "$ref": "./units.json#/definitions/time" }
       },
       "required": ["startTime", "endTime"]
     },

--- a/schemas/core/components/units-geo.json
+++ b/schemas/core/components/units-geo.json
@@ -116,6 +116,14 @@
               "type": "string",
               "minLength": 1,
               "maxLength": 64
+            },
+            "facilities": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 20
+              }
             }
           }
         }

--- a/schemas/core/components/units-geo.json
+++ b/schemas/core/components/units-geo.json
@@ -88,7 +88,7 @@
     "place": {
       "type": "object",
       "additionalProperties": true,
-      "description": "A place, as a location-name pair with name and address",
+      "description": "A place, could be a stop or a station",
       "allOf": [
         {
           "$ref": "#/definitions/relaxedLocation"
@@ -124,6 +124,9 @@
                 "minLength": 1,
                 "maxLength": 80
               }
+            },
+            "openingHours": {
+              "type": "object"
             }
           }
         }

--- a/schemas/core/components/units-geo.json
+++ b/schemas/core/components/units-geo.json
@@ -122,7 +122,7 @@
               "items": {
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 20
+                "maxLength": 80
               }
             }
           }

--- a/schemas/core/plan.json
+++ b/schemas/core/plan.json
@@ -1,16 +1,38 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "OpenTripPlanner compatible format for plans, extended with id for legs and itineraries",
-  "properties": {
-    "from": {
-      "$ref": "./components/units-geo.json#/definitions/place"
-    },
-    "planId": {
-        "$ref": "./components/units.json#/definitions/uuid"
+  "allOf": [
+    { "$ref": "#/definitions/plan" },
+    {
+      "oneOf": [
+        { "required": ["from", "planId", "itineraries"] },
+        { "required": ["from", "planId", "outwards", "returns"] }
+      ]
+    }
+  ],
+  "definitions": {
+    "plan": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "./components/units-geo.json#/definitions/place"
+        },
+        "planId": {
+          "$ref": "./components/units.json#/definitions/uuid"
+        },
+        "itineraries": {
+          "$ref": "#/definitions/itineraries"
+        },
+        "outwards": {
+          "$ref": "#/definitions/itineraries"
+        },
+        "returns": {
+          "$ref": "#/definitions/itineraries"
+        }
+      }
     },
     "itineraries": {
       "type": "array",
-      "minItems": 0,
       "items": {
         "$ref": "./itinerary.json"
       }

--- a/schemas/core/product-option.json
+++ b/schemas/core/product-option.json
@@ -2,43 +2,71 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://api.maas.global/core/itinerary",
   "description": "Product option for an itinerary, is either an existing booking pointer or a new booking instruction",
-  "type": "object",
-  "properties": {
-    "identityId": {
-      "$ref": "./components/units.json#/definitions/identityId"
+  "oneOf": [
+    {
+      "allOf": [
+        { "$ref": "#/definitions/content" },
+        {
+          "required": [
+            "identityId",
+            "ref",
+            "product",
+            "terms",
+            "meta",
+            "configurator"
+          ]
+        }
+      ]
     },
-    "bookingId": {
-      "$ref": "./components/units.json#/definitions/uuid"
-    },
-    "ref": {
-      "type": "integer",
-      "minValue": 0
-    },
-    "product": {
-      "$ref": "./product.json"
-    },
-    "fare": {
-      "$ref": "./components/fare.json"
-    },
-    "fares": {
-      "type": "array",
-      "items": {
-        "$ref": "./components/fare.json"
-      }
-    },
-    "terms": {
-      "$ref": "./components/terms.json"
-    },
-    "meta": {
-      "$ref": "./booking.json#/definitions/meta"
+    {
+      "allOf": [
+        { "$ref": "#/definitions/content" },
+        {
+          "required": [
+            "identityId",
+            "ref",
+            "product",
+            "terms",
+            "meta",
+            "fares"
+          ]
+        }
+      ]
     }
-  },
-  "required": [
-    "identityId",
-    "ref",
-    "product",
-    "terms",
-    "meta"
   ],
-  "additionalProperties": false
+  "definitions": {
+    "content": {
+      "identityId": {
+        "$ref": "./components/units.json#/definitions/identityId"
+      },
+      "bookingId": {
+        "$ref": "./components/units.json#/definitions/uuid"
+      },
+      "ref": {
+        "type": "integer",
+        "minValue": 0
+      },
+      "product": {
+        "$ref": "./product.json"
+      },
+      "fare": {
+        "$ref": "./components/fare.json"
+      },
+      "fares": {
+        "type": "array",
+        "items": {
+          "$ref": "./components/fare.json"
+        }
+      },
+      "terms": {
+        "$ref": "./components/terms.json"
+      },
+      "meta": {
+        "$ref": "./booking.json#/definitions/meta"
+      },
+      "configurator": {
+        "$ref": "./components/configurator.json"
+      }
+    }
+  }
 }

--- a/schemas/maas-backend/bookings/bookings-agency-options/response.json
+++ b/schemas/maas-backend/bookings/bookings-agency-options/response.json
@@ -9,7 +9,35 @@
       "items": {
         "allOf": [
           {
-            "$ref": "../../../core/booking.json"
+            "type": "object",
+            "properties": {
+              "fares": {
+                "$ref": "../../../core/booking.json#/properties/fares"
+              },
+              "cost": {
+                "$ref": "../../../core/booking.json#/properties/cost"
+              },
+              "leg": {
+                "$ref": "../../../core/booking.json#/properties/leg"
+              },
+              "meta": {
+                "$ref": "../../../core/booking.json#/properties/meta"
+              },
+              "terms": {
+                "$ref": "../../../core/booking.json#/properties/terms"
+              },
+              "tspProduct": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "configurator": {
+                "$ref": "../../../core/booking.json#/properties/configurator"
+              }
+            }
           },
           {
             "oneOf": [

--- a/schemas/maas-backend/bookings/bookings-agency-options/response.json
+++ b/schemas/maas-backend/bookings/bookings-agency-options/response.json
@@ -7,49 +7,7 @@
     "options": {
       "type": "array",
       "items": {
-        "allOf": [
-          {
-            "type": "object",
-            "properties": {
-              "fares": {
-                "$ref": "../../../core/booking.json#/properties/fares"
-              },
-              "cost": {
-                "$ref": "../../../core/booking.json#/properties/cost"
-              },
-              "leg": {
-                "$ref": "../../../core/booking.json#/properties/leg"
-              },
-              "meta": {
-                "$ref": "../../../core/booking.json#/properties/meta"
-              },
-              "terms": {
-                "$ref": "../../../core/booking.json#/properties/terms"
-              },
-              "tspProduct": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  }
-                }
-              },
-              "configurator": {
-                "$ref": "../../../core/booking.json#/properties/configurator"
-              }
-            }
-          },
-          {
-            "oneOf": [
-              {
-                "required": ["leg", "terms", "product", "fares"]
-              },
-              {
-                "required": ["leg", "terms", "product", "configurator"]
-              }
-            ]
-          }
-        ]
+        "$ref": "#/definitions/option"
       }
     },
     "additional": {
@@ -69,5 +27,52 @@
     }
   },
   "required": ["options"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "option": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "fares": {
+              "$ref": "../../../core/booking.json#/properties/fares"
+            },
+            "cost": {
+              "$ref": "../../../core/booking.json#/properties/cost"
+            },
+            "leg": {
+              "$ref": "../../../core/booking.json#/properties/leg"
+            },
+            "meta": {
+              "$ref": "../../../core/booking.json#/properties/meta"
+            },
+            "terms": {
+              "$ref": "../../../core/booking.json#/properties/terms"
+            },
+            "tspProduct": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            },
+            "configurator": {
+              "$ref": "../../../core/booking.json#/properties/configurator"
+            }
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "required": ["leg", "terms", "product", "fares"]
+            },
+            {
+              "required": ["leg", "terms", "product", "configurator"]
+            }
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/schemas/maas-backend/bookings/bookings-agency-options/response.json
+++ b/schemas/maas-backend/bookings/bookings-agency-options/response.json
@@ -7,8 +7,21 @@
     "options": {
       "type": "array",
       "items": {
-        "$ref": "../../../core/booking.json",
-        "required": ["leg", "terms", "product"]
+        "allOf": [
+          {
+            "$ref": "../../../core/booking.json"
+          },
+          {
+            "oneOf": [
+              {
+                "required": ["leg", "terms", "product", "fares"]
+              },
+              {
+                "required": ["leg", "terms", "product", "configurator"]
+              }
+            ]
+          }
+        ]
       }
     },
     "additional": {

--- a/schemas/maas-backend/bookings/bookings-create/request.json
+++ b/schemas/maas-backend/bookings/bookings-create/request.json
@@ -8,10 +8,15 @@
       "$ref": "../../../core/components/units.json#/definitions/identityId"
     },
     "payload": {
-      "allOf": [
-        { "$ref": "../../../core/booking.json" },
-        { "required": [ "leg", "terms", "product" ] }
-      ]
+      "type": "object",
+      "properties": {
+        "booking": {
+          "$ref": "../bookings-agency-options/response.json#/definitions/option"
+        },
+        "customerSelection": {
+          "$ref": "../../../core/components/configurator.json#/definitions/customerSelection"
+        }
+      }
     },
     "headers": {
       "$ref": "../../../core/components/api-common.json#/definitions/headers"

--- a/schemas/maas-backend/itineraries/itinerary-create/request.json
+++ b/schemas/maas-backend/itineraries/itinerary-create/request.json
@@ -4,6 +4,9 @@
   "description": "Request schema for itineraries-create",
   "type": "object",
   "properties": {
+    "identityId": {
+      "$ref": "../../../core/components/units.json#/definitions/identityId"
+    },
     "itinerary": {
       "$ref": "../../../core/itinerary.json"
     },

--- a/schemas/maas-backend/provider/routes/response.json
+++ b/schemas/maas-backend/provider/routes/response.json
@@ -1,27 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://api.maas.global/maas-backend/provider/routes/response",
-  "description": "Response schema for routes providers",
+  "description": "Response schema for routes providers, subset of routes-query response schema",
+  "type": "object",
   "properties": {
     "plan": {
-      "type": "object",
-      "properties": {
-        "from": {
-          "$ref": "../../../core/components/units-geo.json#/definitions/place"
+      "allOf": [
+        {
+          "$ref": "../../../core/plan.json#/definitions/plan"
         },
-        "itineraries": {
-          "allOf": [
-            {
-              "$ref": "../../../core/plan.json#/properties/itineraries"
-            }
-          ]
+        {
+          "required": ["from", "outwards", "returns"]
         }
-      },
-      "required": ["from", "itineraries" ],
-      "additionalProperties": false
-    },
-    "debug": { "type": "object" }
-  },
-  "required": [ "plan" ],
-  "additionalProperties": false
+      ]
+    }
+  }
 }

--- a/schemas/maas-backend/routes/routes-query/request.json
+++ b/schemas/maas-backend/routes/routes-query/request.json
@@ -31,7 +31,7 @@
       }
     }
   },
-  "required": [ "identityId", "payload" ],
+  "required": ["identityId", "payload"],
   "definitions": {
     "payload": {
       "type": "object",
@@ -65,20 +65,24 @@
         "arriveBy": {
           "$ref": "../../../core/components/units.json#/definitions/time"
         },
+        "leaveAtReturn": {
+          "$ref": "../../../core/components/units.json#/definitions/time"
+        },
+        "arriveByReturn": {
+          "$ref": "../../../core/components/units.json#/definitions/time"
+        },
         "modes": {
           "type": "string",
           "enum": ["PUBLIC_TRANSIT", "TAXI", "CAR", "WALK", "BICYCLE", "BICYCLE_RENT"]
         },
         "transitMode": {
           "type": "string",
-          "enum": ["TRAIN", "BUS", "SUBWAY", "TRAM"]
+          "enum": ["TRAIN", "BUS", "SUBWAY", "TRAM", "RAIL"]
         },
         "options": {
           "type": "object"
         }
-      },
-      "required": ["from", "to", "fromAddress", "toAddress", "fromName", "toName"],
-      "additionalProperties": false
+      }
     }
   }
 }

--- a/schemas/maas-backend/routes/routes-query/response.json
+++ b/schemas/maas-backend/routes/routes-query/response.json
@@ -4,28 +4,7 @@
   "description": "MaaS.fi routes-query response schema",
   "properties": {
     "plan": {
-      "type": "object",
-      "properties": {
-        "from": {
-          "$ref": "../../../core/components/units-geo.json#/definitions/place"
-        },
-        "planId": {
-          "allOf": [
-            {
-              "$ref": "../../../core/plan.json#/properties/planId"
-            }
-          ]
-        },
-        "itineraries": {
-          "allOf": [
-            {
-              "$ref": "../../../core/plan.json#/properties/itineraries"
-            }
-          ]
-        }
-      },
-      "required": ["from", "itineraries" ],
-      "additionalProperties": false
+      "$ref": "../../../core/plan.json"
     },
     "debug": { "type": "object" }
   },

--- a/schemas/tsp/booking-create/request.json
+++ b/schemas/tsp/booking-create/request.json
@@ -18,8 +18,20 @@
     },
     "tspProduct": {
       "$ref": "../booking-option.json#/definitions/tspProduct"
+    },
+    "configurator": {
+      "$ref": "../../core/components/configurator.json"
+    },
+    "customerSelection": {
+      "$ref": "../../core/components/configurator.json#/definitions/customerSelection"
     }
   },
-  "required": ["leg", "customer", "tspProduct"],
+  "required": [
+    "leg",
+    "meta",
+    "terms",
+    "customer",
+    "tspProduct"
+  ],
   "additionalProperties": true
 }

--- a/schemas/tsp/booking-create/response.json
+++ b/schemas/tsp/booking-create/response.json
@@ -27,6 +27,12 @@
     },
     "tspProduct": {
       "$ref": "../booking-option.json#/definitions/tspProduct"
+    },
+    "configurator": {
+      "$ref": "../../core/components/configurator.json"
+    },
+    "customerSelection": {
+      "$ref": "../../core/components/configurator.json#/definitions/customerSelection"
     }
   },
   "required": ["tspId", "state", "meta", "terms", "token", "tspProduct" ],

--- a/schemas/tsp/booking-option.json
+++ b/schemas/tsp/booking-option.json
@@ -4,23 +4,26 @@
   "description": "MaaS single TSP adapter option",
   "type": "object",
   "properties": {
-    "cost": {
-      "$ref": "../core/components/cost.json"
-    },
     "leg": {
       "$ref": "#/definitions/leg"
-     },
-     "terms": {
-       "$ref": "../core/booking.json#/definitions/terms"
+    },
+    "terms": {
+      "$ref": "../core/booking.json#/definitions/terms"
     },
     "meta": {
       "$ref": "../core/booking.json#/definitions/meta"
     },
     "tspProduct": {
       "$ref": "#/definitions/tspProduct"
+    },
+    "configurator": {
+      "$ref": "../core/components/configurator.json"
+    },
+    "customerSelection": {
+      "$ref": "../core/components/configurator.json#/definitions/customerSelection"
     }
   },
-  "required": ["cost", "leg", "meta", "terms", "tspProduct" ],
+  "required": ["leg", "meta", "terms", "tspProduct"],
   "definitions": {
     "leg": {
       "type": "object",

--- a/schemas/tsp/booking-option.json
+++ b/schemas/tsp/booking-option.json
@@ -3,28 +3,42 @@
   "id": "https://api.maas.global/tsp/booking-option",
   "description": "MaaS single TSP adapter option",
   "type": "object",
-  "properties": {
-    "leg": {
-      "$ref": "#/definitions/leg"
+  "allOf": [
+    {
+      "$ref": "#/definitions/content"
     },
-    "terms": {
-      "$ref": "../core/booking.json#/definitions/terms"
-    },
-    "meta": {
-      "$ref": "../core/booking.json#/definitions/meta"
-    },
-    "tspProduct": {
-      "$ref": "#/definitions/tspProduct"
-    },
-    "configurator": {
-      "$ref": "../core/components/configurator.json"
-    },
-    "customerSelection": {
-      "$ref": "../core/components/configurator.json#/definitions/customerSelection"
+    {
+      "oneOf": [
+        {
+          "required": ["leg", "meta", "terms", "tspProduct", "cost"]
+        },
+        {
+          "required": ["leg", "meta", "terms", "tspProduct", "configurator"]
+        }
+      ]
     }
-  },
-  "required": ["leg", "meta", "terms", "tspProduct"],
+  ],
   "definitions": {
+    "content": {
+      "leg": {
+        "$ref": "#/definitions/leg"
+      },
+      "terms": {
+        "$ref": "../core/booking.json#/definitions/terms"
+      },
+      "meta": {
+        "$ref": "../core/booking.json#/definitions/meta"
+      },
+      "tspProduct": {
+        "$ref": "#/definitions/tspProduct"
+      },
+      "configurator": {
+        "$ref": "../core/components/configurator.json"
+      },
+      "cost": {
+        "$ref": "../core/components/cost.json"
+      }
+    },
     "leg": {
       "type": "object",
       "description": "A subset of the standard leg (../core/leg.json)",
@@ -53,13 +67,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "mode",
-        "startTime",
-        "endTime",
-        "from",
-        "to"
-      ]
+      "required": ["mode", "startTime", "endTime", "from", "to"]
     },
     "legDelta": {
       "type": "object",

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -13,6 +13,12 @@
     "endTime": {
       "$ref": "../../core/components/units.json#/definitions/time"
     },
+    "startTimeReturn": {
+      "$ref": "../../core/components/units.json#/definitions/time"
+    },
+    "endTimeReturn": {
+      "$ref": "../../core/components/units.json#/definitions/time"
+    },
     "from": {
       "$ref": "../../core/components/units-geo.json#/definitions/shortLocationString"
     },

--- a/schemas/tsp/journey-planner/request.json
+++ b/schemas/tsp/journey-planner/request.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://api.maas.global/tsp/journey-planner/request",
+  "description": "Request schema for getting journey options from a TSP adapter.",
+  "type": "object",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/payload",
+      "description": "Permit leaveAt",
+      "required": ["from", "to", "leaveAt"]
+    },
+    {
+      "$ref": "#/definitions/payload",
+      "description": "Permit arriveBy",
+      "required": ["from", "to", "arriveBy"]
+    }
+  ],
+  "definitions": {
+    "payload": {
+      "from": {
+        "$ref": "../../core/components/units-geo.json#/definitions/shortLocationString"
+      },
+      "fromName": {
+        "$ref": "../../core/components/address.json#/definitions/placeName"
+      },
+      "fromAddress": {
+        "description": "Componentized from address",
+        "$ref": "../../core/components/address.json#/definitions/componentAddress"
+      },
+      "to": {
+        "$ref": "../../core/components/units-geo.json#/definitions/shortLocationString"
+      },
+      "toName": {
+        "$ref": "../../core/components/address.json#/definitions/placeName"
+      },
+      "toAddress": {
+        "description": "Componentized to address",
+        "$ref": "../../core/components/address.json#/definitions/componentAddress"
+      },
+      "leaveAt": {
+        "$ref": "../../core/components/units.json#/definitions/time"
+      },
+      "arriveBy": {
+        "$ref": "../../core/components/units.json#/definitions/time"
+      },
+      "leaveAtReturn": {
+        "$ref": "../../core/components/units.json#/definitions/time"
+      },
+      "arriveByReturn": {
+        "$ref": "../../core/components/units.json#/definitions/time"
+      },
+      "mode": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/tsp/journey-planner/response.json
+++ b/schemas/tsp/journey-planner/response.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://api.maas.global/tsp/journey-planner/response",
+  "description": "Response schema for getting journey options from a TSP adapter.",
+  "type": "object"
+}


### PR DESCRIPTION
Contains:
- [x] Schemas for `configurator` and `customerSelection` object
- [x] Split routes-query response to have `outwards` and `returns` instead of a single `itineraries`
- [x] Product option schema to contain either fares or configurator, not both
- [x] Response and request schemas to bookings + itineraries endpoint to support configurator and customerSelection
- [x] Support `leaveAtReturn` and `arriveByReturn` for routes-query
- [x] New TSP endpoint schema `journey-planner
- [x] `units_geo.json#definitions/place` now have addional schema named `facilities`, an array of strings, containing features that the place has (station would have Toilets , BabyChange, AtmMachine ...)

*Every small tweak is to support the must-have configurator usage and OnTrack implementation*

NOTE: PR does not contain prebuilt version, for the sake of reviewing. Will prebuilt after prebuild