### PR TITLE
`id` for MODE_CAR

### DIFF
--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -652,6 +652,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,
@@ -1570,6 +1575,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/core/itinerary.json
+++ b/prebuilt/core/itinerary.json
@@ -1263,6 +1263,11 @@
                 "description": "Schemas for MODE_CAR meta field",
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "name": {
                     "type": "string",
                     "minLength": 1,

--- a/prebuilt/core/modes/MODE_CAR.json
+++ b/prebuilt/core/modes/MODE_CAR.json
@@ -3,6 +3,11 @@
   "description": "Schemas for MODE_CAR meta field",
   "type": "object",
   "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
     "name": {
       "type": "string",
       "minLength": 1,

--- a/prebuilt/core/plan.json
+++ b/prebuilt/core/plan.json
@@ -1334,6 +1334,11 @@
                       "description": "Schemas for MODE_CAR meta field",
                       "type": "object",
                       "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 256
+                        },
                         "name": {
                           "type": "string",
                           "minLength": 1,

--- a/prebuilt/core/product-option.json
+++ b/prebuilt/core/product-option.json
@@ -383,6 +383,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
@@ -665,6 +665,11 @@
                 "description": "Schemas for MODE_CAR meta field",
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "name": {
                     "type": "string",
                     "minLength": 1,
@@ -1574,6 +1579,11 @@
                 "description": "Schemas for MODE_CAR meta field",
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "name": {
                     "type": "string",
                     "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -659,6 +659,11 @@
                   "description": "Schemas for MODE_CAR meta field",
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 256
+                    },
                     "name": {
                       "type": "string",
                       "minLength": 1,
@@ -1577,6 +1582,11 @@
                   "description": "Schemas for MODE_CAR meta field",
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 256
+                    },
                     "name": {
                       "type": "string",
                       "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-create/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/request.json
@@ -664,6 +664,11 @@
                   "description": "Schemas for MODE_CAR meta field",
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 256
+                    },
                     "name": {
                       "type": "string",
                       "minLength": 1,
@@ -1582,6 +1587,11 @@
                   "description": "Schemas for MODE_CAR meta field",
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 256
+                    },
                     "name": {
                       "type": "string",
                       "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -658,6 +658,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,
@@ -1576,6 +1581,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -661,6 +661,11 @@
                 "description": "Schemas for MODE_CAR meta field",
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "name": {
                     "type": "string",
                     "minLength": 1,
@@ -1579,6 +1584,11 @@
                 "description": "Schemas for MODE_CAR meta field",
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "name": {
                     "type": "string",
                     "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -658,6 +658,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,
@@ -1576,6 +1581,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-update/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/request.json
@@ -667,6 +667,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,
@@ -1585,6 +1590,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -658,6 +658,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,
@@ -1576,6 +1581,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/prebuilt/maas-backend/itineraries/itinerary-create/request.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/request.json
@@ -1269,6 +1269,11 @@
                     "description": "Schemas for MODE_CAR meta field",
                     "type": "object",
                     "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256
+                      },
                       "name": {
                         "type": "string",
                         "minLength": 1,

--- a/prebuilt/maas-backend/itineraries/itinerary-create/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/response.json
@@ -1269,6 +1269,11 @@
                     "description": "Schemas for MODE_CAR meta field",
                     "type": "object",
                     "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256
+                      },
                       "name": {
                         "type": "string",
                         "minLength": 1,

--- a/prebuilt/maas-backend/itineraries/itinerary-list/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-list/response.json
@@ -1272,6 +1272,11 @@
                       "description": "Schemas for MODE_CAR meta field",
                       "type": "object",
                       "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 256
+                        },
                         "name": {
                           "type": "string",
                           "minLength": 1,

--- a/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
@@ -1269,6 +1269,11 @@
                     "description": "Schemas for MODE_CAR meta field",
                     "type": "object",
                     "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256
+                      },
                       "name": {
                         "type": "string",
                         "minLength": 1,

--- a/prebuilt/maas-backend/provider/routes/response.json
+++ b/prebuilt/maas-backend/provider/routes/response.json
@@ -1340,6 +1340,11 @@
                               "description": "Schemas for MODE_CAR meta field",
                               "type": "object",
                               "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 256
+                                },
                                 "name": {
                                   "type": "string",
                                   "minLength": 1,

--- a/prebuilt/maas-backend/routes/routes-query/response.json
+++ b/prebuilt/maas-backend/routes/routes-query/response.json
@@ -1340,6 +1340,11 @@
                               "description": "Schemas for MODE_CAR meta field",
                               "type": "object",
                               "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 256
+                                },
                                 "name": {
                                   "type": "string",
                                   "minLength": 1,

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
@@ -557,6 +557,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
@@ -561,6 +561,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,
@@ -1459,6 +1464,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/prebuilt/tsp/booking-cancel/response.json
+++ b/prebuilt/tsp/booking-cancel/response.json
@@ -554,6 +554,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/booking-create/request.json
+++ b/prebuilt/tsp/booking-create/request.json
@@ -495,6 +495,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/booking-create/response.json
+++ b/prebuilt/tsp/booking-create/response.json
@@ -556,6 +556,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/booking-option.json
+++ b/prebuilt/tsp/booking-option.json
@@ -579,6 +579,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/booking-options-list/response.json
+++ b/prebuilt/tsp/booking-options-list/response.json
@@ -587,6 +587,11 @@
                 "description": "Schemas for MODE_CAR meta field",
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "name": {
                     "type": "string",
                     "minLength": 1,

--- a/prebuilt/tsp/booking-read-by-id/response.json
+++ b/prebuilt/tsp/booking-read-by-id/response.json
@@ -547,6 +547,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/booking-update/response.json
+++ b/prebuilt/tsp/booking-update/response.json
@@ -546,6 +546,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/webhooks-bookings-update/remote-request.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-request.json
@@ -546,6 +546,11 @@
           "description": "Schemas for MODE_CAR meta field",
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
             "name": {
               "type": "string",
               "minLength": 1,

--- a/prebuilt/tsp/webhooks-bookings-update/remote-response.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-response.json
@@ -561,6 +561,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,
@@ -1459,6 +1464,11 @@
               "description": "Schemas for MODE_CAR meta field",
               "type": "object",
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
                 "name": {
                   "type": "string",
                   "minLength": 1,

--- a/schemas/core/modes/MODE_CAR.json
+++ b/schemas/core/modes/MODE_CAR.json
@@ -16,8 +16,7 @@
     "image": {
       "$ref": "../components/units.json#/definitions/url"
     },
-    "terms": {
-    },
+    "terms": {},
     "car": {
       "type": "object",
       "properties": {
@@ -53,17 +52,7 @@
           "enum": ["manual", "automatic", null]
         },
         "fuel": {
-          "enum": [
-            "diesel",
-            "electric",
-            "ethanol",
-            "gasoline",
-            "hybrid",
-            "hydrogen",
-            "lpg",
-            "multifuel",
-            null
-          ]
+          "enum": ["diesel", "electric", "ethanol", "gasoline", "hybrid", "hydrogen", "lpg", "multifuel", null]
         },
         "classification": {
           "$ref": "../components/acriss.json"

--- a/schemas/core/modes/MODE_CAR.json
+++ b/schemas/core/modes/MODE_CAR.json
@@ -3,6 +3,11 @@
   "description": "Schemas for MODE_CAR meta field",
   "type": "object",
   "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
     "name": {
       "type": "string",
       "minLength": 1,


### PR DESCRIPTION
During [schemas refactor](https://github.com/maasglobal/maas-schemas/pull/214) `additionalProperties: false` was added to MODE_CAR and that in turn made ALD tests fail in MTB.

This ensures that propertly on which ALD TSP depends in allowed in MODE_CAR.

`id` is vendor specific car id (not license plate, more as db id). In context of ALD we need to pass it to create request when we initialize the booking.