### PR TITLE
Improve Jest handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,15 +50,7 @@ gulp.task('deref-schemas', () => {
 gulp.task('validate', ['jsonclint', 'jsonlint', 'eslint']);
 
 gulp.task('test', ['validate'], () => {
-  return gulp.src('./test').pipe(
-    jest({
-      verbose: true,
-      bail: false,
-      testEnvironment: 'node',
-      testMatch: ['**/test/**/*.js'],
-      setupTestFrameworkScriptFile: './jest.setupEnvironment.js',
-    })
-  );
+  return gulp.src('./test').pipe(jest(require('./jest.config')));
 });
 
 gulp.task('watch', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = {
+  verbose: true,
+  bail: false,
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.js'],
+  setupTestFrameworkScriptFile: path.resolve('./jest.setupEnvironment.js'),
+};


### PR DESCRIPTION
With current setup is not possible to run Jest on chosen test file.

This patch makes Jest setup independent of Gulp, and allows to use `jest` command to run tests directly