### PR TITLE
Improve npm scripts setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
 - "4.2"
-script: npm test
+script:
+- npm run lint
+- npm test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,46 +16,49 @@ const jsFiles = ['*.js', 'test/**/*.js'];
 gulp.task('jsonclint', () => {
   // Unfortunately does not support failOnError at the moment
   // See https://github.com/panuhorsmalahti/gulp-json-lint/issues/2
-  return gulp.src(jsoncFiles)
+  return gulp
+    .src(jsoncFiles)
     .pipe(jsonclint({ comments: true }))
     .pipe(jsonclint.report('verbose'));
 });
 
 gulp.task('jsonlint', () => {
-  return gulp.src(jsonFiles)
+  return gulp
+    .src(jsonFiles)
     .pipe(jsonlint())
     .pipe(jsonlint.reporter())
     .pipe(jsonlint.failOnError());
 });
 
 gulp.task('eslint', () => {
-  return gulp.src(jsFiles)
+  return gulp
+    .src(jsFiles)
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
 });
 
 gulp.task('deref-schemas', () => {
-  return gulp.src('./schemas/**/*.json')
-      .pipe(deref())
-      .pipe(transformUnicode.transform())
-      .pipe(jsonFormat(2))
-      .pipe(gulp.dest('prebuilt'));
+  return gulp
+    .src('./schemas/**/*.json')
+    .pipe(deref())
+    .pipe(transformUnicode.transform())
+    .pipe(jsonFormat(2))
+    .pipe(gulp.dest('prebuilt'));
 });
 
 gulp.task('validate', ['jsonclint', 'jsonlint', 'eslint']);
 
 gulp.task('test', ['validate'], () => {
-  return gulp.src('./test')
-    .pipe(jest({
+  return gulp.src('./test').pipe(
+    jest({
       verbose: true,
       bail: false,
       testEnvironment: 'node',
-      testMatch: [
-        '**/test/**/*.js',
-      ],
+      testMatch: ['**/test/**/*.js'],
       setupTestFrameworkScriptFile: './jest.setupEnvironment.js',
-    }));
+    })
+  );
 });
 
 gulp.task('watch', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('deref-schemas', () => {
 
 gulp.task('validate', ['jsonclint', 'jsonlint', 'eslint']);
 
-gulp.task('test', ['validate'], () => {
+gulp.task('test', () => {
   return gulp.src('./test').pipe(
     jest({
       verbose: true,
@@ -62,7 +62,7 @@ gulp.task('test', ['validate'], () => {
 });
 
 gulp.task('watch', () => {
-  gulp.watch([].concat(jsonFiles, jsoncFiles, jsFiles), ['test', 'deref-schemas']);
+  gulp.watch([].concat(jsonFiles, jsoncFiles, jsFiles), ['test', 'validate', 'deref-schemas']);
 });
 
-gulp.task('default', ['test', 'deref-schemas']);
+gulp.task('default', ['test', 'validate', 'deref-schemas']);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
+    "lint": "gulp validate",
     "test": "gulp test",
     "watch": "gulp watch",
     "build": "gulp"

--- a/package.json
+++ b/package.json
@@ -15,17 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/maasglobal/maas-schemas.git"
   },
-  "keywords": [
-    "schemas",
-    "maas",
-    "JSON"
-  ],
+  "keywords": ["schemas", "maas", "JSON"],
   "author": "",
-  "contributors": [
-    "James Nguyen",
-    "Klaus Dahlen",
-    "Lauri Svan"
-  ],
+  "contributors": ["James Nguyen", "Klaus Dahlen", "Lauri Svan"],
   "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/maasglobal/maas-schemas/issues"


### PR DESCRIPTION
- Make `npm test` to run only tests (implied `lint` seems not clean, and counter productive when we want to just confirm on tests)
- Introduce `lint` script
- Style improvements