### PR TITLE
Terms.fareRate to support multiple rates

### DIFF
--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -1083,39 +1083,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true
@@ -2174,39 +2179,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/core/components/terms.json
+++ b/prebuilt/core/components/terms.json
@@ -30,39 +30,44 @@
         "endTime"
       ]
     },
-    "fareRate": {
-      "description": "Booking fare rate",
-      "type": "object",
-      "properties": {
-        "amount": {
-          "type": "number",
-          "minimum": 0,
-          "multipleOf": 0.01
+    "fareRates": {
+      "type": "array",
+      "items": {
+        "description": "Booking fare rate",
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 0.01
+          },
+          "currency": {
+            "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+            "type": "string",
+            "enum": [
+              "EUR",
+              "GBP"
+            ]
+          },
+          "timeInterval": {
+            "description": "Amount of seconds that fare rate is applied to",
+            "type": "number",
+            "minimum": 1,
+            "multipleOf": 1
+          },
+          "startAt": {
+            "description": "Amount of seconds after this fare rate should be applied to",
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 1
+          }
         },
-        "currency": {
-          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-          "type": "string",
-          "enum": [
-            "EUR",
-            "GBP"
-          ]
-        },
-        "timeUnit": {
-          "type": "string",
-          "enum": [
-            "1min",
-            "15min",
-            "30min",
-            "1hr",
-            "total"
-          ]
-        }
-      },
-      "required": [
-        "amount",
-        "currency",
-        "timeUnit"
-      ]
+        "required": [
+          "amount",
+          "currency",
+          "timeInterval"
+        ]
+      }
     }
   },
   "additionalProperties": true

--- a/prebuilt/core/itinerary.json
+++ b/prebuilt/core/itinerary.json
@@ -1051,39 +1051,44 @@
                   "endTime"
                 ]
               },
-              "fareRate": {
-                "description": "Booking fare rate",
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
+              "fareRates": {
+                "type": "array",
+                "items": {
+                  "description": "Booking fare rate",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 0.01
+                    },
+                    "currency": {
+                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                      "type": "string",
+                      "enum": [
+                        "EUR",
+                        "GBP"
+                      ]
+                    },
+                    "timeInterval": {
+                      "description": "Amount of seconds that fare rate is applied to",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 1
+                    },
+                    "startAt": {
+                      "description": "Amount of seconds after this fare rate should be applied to",
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 1
+                    }
                   },
-                  "currency": {
-                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                    "type": "string",
-                    "enum": [
-                      "EUR",
-                      "GBP"
-                    ]
-                  },
-                  "timeUnit": {
-                    "type": "string",
-                    "enum": [
-                      "1min",
-                      "15min",
-                      "30min",
-                      "1hr",
-                      "total"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency",
-                  "timeUnit"
-                ]
+                  "required": [
+                    "amount",
+                    "currency",
+                    "timeInterval"
+                  ]
+                }
               }
             },
             "additionalProperties": true

--- a/prebuilt/core/plan.json
+++ b/prebuilt/core/plan.json
@@ -1127,39 +1127,44 @@
                         "endTime"
                       ]
                     },
-                    "fareRate": {
-                      "description": "Booking fare rate",
-                      "type": "object",
-                      "properties": {
-                        "amount": {
-                          "type": "number",
-                          "minimum": 0,
-                          "multipleOf": 0.01
+                    "fareRates": {
+                      "type": "array",
+                      "items": {
+                        "description": "Booking fare rate",
+                        "type": "object",
+                        "properties": {
+                          "amount": {
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 0.01
+                          },
+                          "currency": {
+                            "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                            "type": "string",
+                            "enum": [
+                              "EUR",
+                              "GBP"
+                            ]
+                          },
+                          "timeInterval": {
+                            "description": "Amount of seconds that fare rate is applied to",
+                            "type": "number",
+                            "minimum": 1,
+                            "multipleOf": 1
+                          },
+                          "startAt": {
+                            "description": "Amount of seconds after this fare rate should be applied to",
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 1
+                          }
                         },
-                        "currency": {
-                          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                          "type": "string",
-                          "enum": [
-                            "EUR",
-                            "GBP"
-                          ]
-                        },
-                        "timeUnit": {
-                          "type": "string",
-                          "enum": [
-                            "1min",
-                            "15min",
-                            "30min",
-                            "1hr",
-                            "total"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "amount",
-                        "currency",
-                        "timeUnit"
-                      ]
+                        "required": [
+                          "amount",
+                          "currency",
+                          "timeInterval"
+                        ]
+                      }
                     }
                   },
                   "additionalProperties": true

--- a/prebuilt/core/product-option.json
+++ b/prebuilt/core/product-option.json
@@ -164,39 +164,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
@@ -1096,39 +1096,44 @@
                   "endTime"
                 ]
               },
-              "fareRate": {
-                "description": "Booking fare rate",
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
+              "fareRates": {
+                "type": "array",
+                "items": {
+                  "description": "Booking fare rate",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 0.01
+                    },
+                    "currency": {
+                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                      "type": "string",
+                      "enum": [
+                        "EUR",
+                        "GBP"
+                      ]
+                    },
+                    "timeInterval": {
+                      "description": "Amount of seconds that fare rate is applied to",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 1
+                    },
+                    "startAt": {
+                      "description": "Amount of seconds after this fare rate should be applied to",
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 1
+                    }
                   },
-                  "currency": {
-                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                    "type": "string",
-                    "enum": [
-                      "EUR",
-                      "GBP"
-                    ]
-                  },
-                  "timeUnit": {
-                    "type": "string",
-                    "enum": [
-                      "1min",
-                      "15min",
-                      "30min",
-                      "1hr",
-                      "total"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency",
-                  "timeUnit"
-                ]
+                  "required": [
+                    "amount",
+                    "currency",
+                    "timeInterval"
+                  ]
+                }
               }
             },
             "additionalProperties": true
@@ -2178,39 +2183,44 @@
                   "endTime"
                 ]
               },
-              "fareRate": {
-                "description": "Booking fare rate",
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
+              "fareRates": {
+                "type": "array",
+                "items": {
+                  "description": "Booking fare rate",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 0.01
+                    },
+                    "currency": {
+                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                      "type": "string",
+                      "enum": [
+                        "EUR",
+                        "GBP"
+                      ]
+                    },
+                    "timeInterval": {
+                      "description": "Amount of seconds that fare rate is applied to",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 1
+                    },
+                    "startAt": {
+                      "description": "Amount of seconds after this fare rate should be applied to",
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 1
+                    }
                   },
-                  "currency": {
-                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                    "type": "string",
-                    "enum": [
-                      "EUR",
-                      "GBP"
-                    ]
-                  },
-                  "timeUnit": {
-                    "type": "string",
-                    "enum": [
-                      "1min",
-                      "15min",
-                      "30min",
-                      "1hr",
-                      "total"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency",
-                  "timeUnit"
-                ]
+                  "required": [
+                    "amount",
+                    "currency",
+                    "timeInterval"
+                  ]
+                }
               }
             },
             "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -1090,39 +1090,44 @@
                     "endTime"
                   ]
                 },
-                "fareRate": {
-                  "description": "Booking fare rate",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "number",
-                      "minimum": 0,
-                      "multipleOf": 0.01
+                "fareRates": {
+                  "type": "array",
+                  "items": {
+                    "description": "Booking fare rate",
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 0.01
+                      },
+                      "currency": {
+                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                        "type": "string",
+                        "enum": [
+                          "EUR",
+                          "GBP"
+                        ]
+                      },
+                      "timeInterval": {
+                        "description": "Amount of seconds that fare rate is applied to",
+                        "type": "number",
+                        "minimum": 1,
+                        "multipleOf": 1
+                      },
+                      "startAt": {
+                        "description": "Amount of seconds after this fare rate should be applied to",
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 1
+                      }
                     },
-                    "currency": {
-                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                      "type": "string",
-                      "enum": [
-                        "EUR",
-                        "GBP"
-                      ]
-                    },
-                    "timeUnit": {
-                      "type": "string",
-                      "enum": [
-                        "1min",
-                        "15min",
-                        "30min",
-                        "1hr",
-                        "total"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "amount",
-                    "currency",
-                    "timeUnit"
-                  ]
+                    "required": [
+                      "amount",
+                      "currency",
+                      "timeInterval"
+                    ]
+                  }
                 }
               },
               "additionalProperties": true
@@ -2181,39 +2186,44 @@
                     "endTime"
                   ]
                 },
-                "fareRate": {
-                  "description": "Booking fare rate",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "number",
-                      "minimum": 0,
-                      "multipleOf": 0.01
+                "fareRates": {
+                  "type": "array",
+                  "items": {
+                    "description": "Booking fare rate",
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 0.01
+                      },
+                      "currency": {
+                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                        "type": "string",
+                        "enum": [
+                          "EUR",
+                          "GBP"
+                        ]
+                      },
+                      "timeInterval": {
+                        "description": "Amount of seconds that fare rate is applied to",
+                        "type": "number",
+                        "minimum": 1,
+                        "multipleOf": 1
+                      },
+                      "startAt": {
+                        "description": "Amount of seconds after this fare rate should be applied to",
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 1
+                      }
                     },
-                    "currency": {
-                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                      "type": "string",
-                      "enum": [
-                        "EUR",
-                        "GBP"
-                      ]
-                    },
-                    "timeUnit": {
-                      "type": "string",
-                      "enum": [
-                        "1min",
-                        "15min",
-                        "30min",
-                        "1hr",
-                        "total"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "amount",
-                    "currency",
-                    "timeUnit"
-                  ]
+                    "required": [
+                      "amount",
+                      "currency",
+                      "timeInterval"
+                    ]
+                  }
                 }
               },
               "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-create/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/request.json
@@ -1095,39 +1095,44 @@
                     "endTime"
                   ]
                 },
-                "fareRate": {
-                  "description": "Booking fare rate",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "number",
-                      "minimum": 0,
-                      "multipleOf": 0.01
+                "fareRates": {
+                  "type": "array",
+                  "items": {
+                    "description": "Booking fare rate",
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 0.01
+                      },
+                      "currency": {
+                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                        "type": "string",
+                        "enum": [
+                          "EUR",
+                          "GBP"
+                        ]
+                      },
+                      "timeInterval": {
+                        "description": "Amount of seconds that fare rate is applied to",
+                        "type": "number",
+                        "minimum": 1,
+                        "multipleOf": 1
+                      },
+                      "startAt": {
+                        "description": "Amount of seconds after this fare rate should be applied to",
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 1
+                      }
                     },
-                    "currency": {
-                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                      "type": "string",
-                      "enum": [
-                        "EUR",
-                        "GBP"
-                      ]
-                    },
-                    "timeUnit": {
-                      "type": "string",
-                      "enum": [
-                        "1min",
-                        "15min",
-                        "30min",
-                        "1hr",
-                        "total"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "amount",
-                    "currency",
-                    "timeUnit"
-                  ]
+                    "required": [
+                      "amount",
+                      "currency",
+                      "timeInterval"
+                    ]
+                  }
                 }
               },
               "additionalProperties": true
@@ -2186,39 +2191,44 @@
                     "endTime"
                   ]
                 },
-                "fareRate": {
-                  "description": "Booking fare rate",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "number",
-                      "minimum": 0,
-                      "multipleOf": 0.01
+                "fareRates": {
+                  "type": "array",
+                  "items": {
+                    "description": "Booking fare rate",
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 0.01
+                      },
+                      "currency": {
+                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                        "type": "string",
+                        "enum": [
+                          "EUR",
+                          "GBP"
+                        ]
+                      },
+                      "timeInterval": {
+                        "description": "Amount of seconds that fare rate is applied to",
+                        "type": "number",
+                        "minimum": 1,
+                        "multipleOf": 1
+                      },
+                      "startAt": {
+                        "description": "Amount of seconds after this fare rate should be applied to",
+                        "type": "number",
+                        "minimum": 0,
+                        "multipleOf": 1
+                      }
                     },
-                    "currency": {
-                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                      "type": "string",
-                      "enum": [
-                        "EUR",
-                        "GBP"
-                      ]
-                    },
-                    "timeUnit": {
-                      "type": "string",
-                      "enum": [
-                        "1min",
-                        "15min",
-                        "30min",
-                        "1hr",
-                        "total"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "amount",
-                    "currency",
-                    "timeUnit"
-                  ]
+                    "required": [
+                      "amount",
+                      "currency",
+                      "timeInterval"
+                    ]
+                  }
                 }
               },
               "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -1089,39 +1089,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true
@@ -2180,39 +2185,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -1092,39 +1092,44 @@
                   "endTime"
                 ]
               },
-              "fareRate": {
-                "description": "Booking fare rate",
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
+              "fareRates": {
+                "type": "array",
+                "items": {
+                  "description": "Booking fare rate",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 0.01
+                    },
+                    "currency": {
+                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                      "type": "string",
+                      "enum": [
+                        "EUR",
+                        "GBP"
+                      ]
+                    },
+                    "timeInterval": {
+                      "description": "Amount of seconds that fare rate is applied to",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 1
+                    },
+                    "startAt": {
+                      "description": "Amount of seconds after this fare rate should be applied to",
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 1
+                    }
                   },
-                  "currency": {
-                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                    "type": "string",
-                    "enum": [
-                      "EUR",
-                      "GBP"
-                    ]
-                  },
-                  "timeUnit": {
-                    "type": "string",
-                    "enum": [
-                      "1min",
-                      "15min",
-                      "30min",
-                      "1hr",
-                      "total"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency",
-                  "timeUnit"
-                ]
+                  "required": [
+                    "amount",
+                    "currency",
+                    "timeInterval"
+                  ]
+                }
               }
             },
             "additionalProperties": true
@@ -2183,39 +2188,44 @@
                   "endTime"
                 ]
               },
-              "fareRate": {
-                "description": "Booking fare rate",
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
+              "fareRates": {
+                "type": "array",
+                "items": {
+                  "description": "Booking fare rate",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 0.01
+                    },
+                    "currency": {
+                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                      "type": "string",
+                      "enum": [
+                        "EUR",
+                        "GBP"
+                      ]
+                    },
+                    "timeInterval": {
+                      "description": "Amount of seconds that fare rate is applied to",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 1
+                    },
+                    "startAt": {
+                      "description": "Amount of seconds after this fare rate should be applied to",
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 1
+                    }
                   },
-                  "currency": {
-                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                    "type": "string",
-                    "enum": [
-                      "EUR",
-                      "GBP"
-                    ]
-                  },
-                  "timeUnit": {
-                    "type": "string",
-                    "enum": [
-                      "1min",
-                      "15min",
-                      "30min",
-                      "1hr",
-                      "total"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency",
-                  "timeUnit"
-                ]
+                  "required": [
+                    "amount",
+                    "currency",
+                    "timeInterval"
+                  ]
+                }
               }
             },
             "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -1089,39 +1089,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true
@@ -2180,39 +2185,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-update/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/request.json
@@ -1098,39 +1098,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true
@@ -2189,39 +2194,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -1089,39 +1089,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true
@@ -2180,39 +2185,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/prebuilt/maas-backend/itineraries/itinerary-create/request.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/request.json
@@ -1057,39 +1057,44 @@
                       "endTime"
                     ]
                   },
-                  "fareRate": {
-                    "description": "Booking fare rate",
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "minimum": 0,
-                        "multipleOf": 0.01
+                  "fareRates": {
+                    "type": "array",
+                    "items": {
+                      "description": "Booking fare rate",
+                      "type": "object",
+                      "properties": {
+                        "amount": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.01
+                        },
+                        "currency": {
+                          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                          "type": "string",
+                          "enum": [
+                            "EUR",
+                            "GBP"
+                          ]
+                        },
+                        "timeInterval": {
+                          "description": "Amount of seconds that fare rate is applied to",
+                          "type": "number",
+                          "minimum": 1,
+                          "multipleOf": 1
+                        },
+                        "startAt": {
+                          "description": "Amount of seconds after this fare rate should be applied to",
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 1
+                        }
                       },
-                      "currency": {
-                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                        "type": "string",
-                        "enum": [
-                          "EUR",
-                          "GBP"
-                        ]
-                      },
-                      "timeUnit": {
-                        "type": "string",
-                        "enum": [
-                          "1min",
-                          "15min",
-                          "30min",
-                          "1hr",
-                          "total"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "amount",
-                      "currency",
-                      "timeUnit"
-                    ]
+                      "required": [
+                        "amount",
+                        "currency",
+                        "timeInterval"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": true

--- a/prebuilt/maas-backend/itineraries/itinerary-create/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/response.json
@@ -1057,39 +1057,44 @@
                       "endTime"
                     ]
                   },
-                  "fareRate": {
-                    "description": "Booking fare rate",
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "minimum": 0,
-                        "multipleOf": 0.01
+                  "fareRates": {
+                    "type": "array",
+                    "items": {
+                      "description": "Booking fare rate",
+                      "type": "object",
+                      "properties": {
+                        "amount": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.01
+                        },
+                        "currency": {
+                          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                          "type": "string",
+                          "enum": [
+                            "EUR",
+                            "GBP"
+                          ]
+                        },
+                        "timeInterval": {
+                          "description": "Amount of seconds that fare rate is applied to",
+                          "type": "number",
+                          "minimum": 1,
+                          "multipleOf": 1
+                        },
+                        "startAt": {
+                          "description": "Amount of seconds after this fare rate should be applied to",
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 1
+                        }
                       },
-                      "currency": {
-                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                        "type": "string",
-                        "enum": [
-                          "EUR",
-                          "GBP"
-                        ]
-                      },
-                      "timeUnit": {
-                        "type": "string",
-                        "enum": [
-                          "1min",
-                          "15min",
-                          "30min",
-                          "1hr",
-                          "total"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "amount",
-                      "currency",
-                      "timeUnit"
-                    ]
+                      "required": [
+                        "amount",
+                        "currency",
+                        "timeInterval"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": true

--- a/prebuilt/maas-backend/itineraries/itinerary-list/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-list/response.json
@@ -1060,39 +1060,44 @@
                         "endTime"
                       ]
                     },
-                    "fareRate": {
-                      "description": "Booking fare rate",
-                      "type": "object",
-                      "properties": {
-                        "amount": {
-                          "type": "number",
-                          "minimum": 0,
-                          "multipleOf": 0.01
+                    "fareRates": {
+                      "type": "array",
+                      "items": {
+                        "description": "Booking fare rate",
+                        "type": "object",
+                        "properties": {
+                          "amount": {
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 0.01
+                          },
+                          "currency": {
+                            "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                            "type": "string",
+                            "enum": [
+                              "EUR",
+                              "GBP"
+                            ]
+                          },
+                          "timeInterval": {
+                            "description": "Amount of seconds that fare rate is applied to",
+                            "type": "number",
+                            "minimum": 1,
+                            "multipleOf": 1
+                          },
+                          "startAt": {
+                            "description": "Amount of seconds after this fare rate should be applied to",
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 1
+                          }
                         },
-                        "currency": {
-                          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                          "type": "string",
-                          "enum": [
-                            "EUR",
-                            "GBP"
-                          ]
-                        },
-                        "timeUnit": {
-                          "type": "string",
-                          "enum": [
-                            "1min",
-                            "15min",
-                            "30min",
-                            "1hr",
-                            "total"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "amount",
-                        "currency",
-                        "timeUnit"
-                      ]
+                        "required": [
+                          "amount",
+                          "currency",
+                          "timeInterval"
+                        ]
+                      }
                     }
                   },
                   "additionalProperties": true

--- a/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
@@ -1057,39 +1057,44 @@
                       "endTime"
                     ]
                   },
-                  "fareRate": {
-                    "description": "Booking fare rate",
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "minimum": 0,
-                        "multipleOf": 0.01
+                  "fareRates": {
+                    "type": "array",
+                    "items": {
+                      "description": "Booking fare rate",
+                      "type": "object",
+                      "properties": {
+                        "amount": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.01
+                        },
+                        "currency": {
+                          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                          "type": "string",
+                          "enum": [
+                            "EUR",
+                            "GBP"
+                          ]
+                        },
+                        "timeInterval": {
+                          "description": "Amount of seconds that fare rate is applied to",
+                          "type": "number",
+                          "minimum": 1,
+                          "multipleOf": 1
+                        },
+                        "startAt": {
+                          "description": "Amount of seconds after this fare rate should be applied to",
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 1
+                        }
                       },
-                      "currency": {
-                        "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                        "type": "string",
-                        "enum": [
-                          "EUR",
-                          "GBP"
-                        ]
-                      },
-                      "timeUnit": {
-                        "type": "string",
-                        "enum": [
-                          "1min",
-                          "15min",
-                          "30min",
-                          "1hr",
-                          "total"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "amount",
-                      "currency",
-                      "timeUnit"
-                    ]
+                      "required": [
+                        "amount",
+                        "currency",
+                        "timeInterval"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": true

--- a/prebuilt/maas-backend/provider/routes/response.json
+++ b/prebuilt/maas-backend/provider/routes/response.json
@@ -1128,39 +1128,44 @@
                                 "endTime"
                               ]
                             },
-                            "fareRate": {
-                              "description": "Booking fare rate",
-                              "type": "object",
-                              "properties": {
-                                "amount": {
-                                  "type": "number",
-                                  "minimum": 0,
-                                  "multipleOf": 0.01
+                            "fareRates": {
+                              "type": "array",
+                              "items": {
+                                "description": "Booking fare rate",
+                                "type": "object",
+                                "properties": {
+                                  "amount": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "multipleOf": 0.01
+                                  },
+                                  "currency": {
+                                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                                    "type": "string",
+                                    "enum": [
+                                      "EUR",
+                                      "GBP"
+                                    ]
+                                  },
+                                  "timeInterval": {
+                                    "description": "Amount of seconds that fare rate is applied to",
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "multipleOf": 1
+                                  },
+                                  "startAt": {
+                                    "description": "Amount of seconds after this fare rate should be applied to",
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "multipleOf": 1
+                                  }
                                 },
-                                "currency": {
-                                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                                  "type": "string",
-                                  "enum": [
-                                    "EUR",
-                                    "GBP"
-                                  ]
-                                },
-                                "timeUnit": {
-                                  "type": "string",
-                                  "enum": [
-                                    "1min",
-                                    "15min",
-                                    "30min",
-                                    "1hr",
-                                    "total"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "amount",
-                                "currency",
-                                "timeUnit"
-                              ]
+                                "required": [
+                                  "amount",
+                                  "currency",
+                                  "timeInterval"
+                                ]
+                              }
                             }
                           },
                           "additionalProperties": true

--- a/prebuilt/maas-backend/routes/routes-query/response.json
+++ b/prebuilt/maas-backend/routes/routes-query/response.json
@@ -1137,39 +1137,44 @@
                                 "endTime"
                               ]
                             },
-                            "fareRate": {
-                              "description": "Booking fare rate",
-                              "type": "object",
-                              "properties": {
-                                "amount": {
-                                  "type": "number",
-                                  "minimum": 0,
-                                  "multipleOf": 0.01
+                            "fareRates": {
+                              "type": "array",
+                              "items": {
+                                "description": "Booking fare rate",
+                                "type": "object",
+                                "properties": {
+                                  "amount": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "multipleOf": 0.01
+                                  },
+                                  "currency": {
+                                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                                    "type": "string",
+                                    "enum": [
+                                      "EUR",
+                                      "GBP"
+                                    ]
+                                  },
+                                  "timeInterval": {
+                                    "description": "Amount of seconds that fare rate is applied to",
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "multipleOf": 1
+                                  },
+                                  "startAt": {
+                                    "description": "Amount of seconds after this fare rate should be applied to",
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "multipleOf": 1
+                                  }
                                 },
-                                "currency": {
-                                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                                  "type": "string",
-                                  "enum": [
-                                    "EUR",
-                                    "GBP"
-                                  ]
-                                },
-                                "timeUnit": {
-                                  "type": "string",
-                                  "enum": [
-                                    "1min",
-                                    "15min",
-                                    "30min",
-                                    "1hr",
-                                    "total"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "amount",
-                                "currency",
-                                "timeUnit"
-                              ]
+                                "required": [
+                                  "amount",
+                                  "currency",
+                                  "timeInterval"
+                                ]
+                              }
                             }
                           },
                           "additionalProperties": true

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
@@ -989,39 +989,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
@@ -993,39 +993,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true
@@ -2065,39 +2070,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/prebuilt/tsp/booking-cancel/response.json
+++ b/prebuilt/tsp/booking-cancel/response.json
@@ -986,39 +986,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/booking-create/request.json
+++ b/prebuilt/tsp/booking-create/request.json
@@ -927,39 +927,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/booking-create/response.json
+++ b/prebuilt/tsp/booking-create/response.json
@@ -988,39 +988,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/booking-option.json
+++ b/prebuilt/tsp/booking-option.json
@@ -362,39 +362,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/booking-options-list/response.json
+++ b/prebuilt/tsp/booking-options-list/response.json
@@ -370,39 +370,44 @@
                   "endTime"
                 ]
               },
-              "fareRate": {
-                "description": "Booking fare rate",
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
+              "fareRates": {
+                "type": "array",
+                "items": {
+                  "description": "Booking fare rate",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 0.01
+                    },
+                    "currency": {
+                      "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                      "type": "string",
+                      "enum": [
+                        "EUR",
+                        "GBP"
+                      ]
+                    },
+                    "timeInterval": {
+                      "description": "Amount of seconds that fare rate is applied to",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 1
+                    },
+                    "startAt": {
+                      "description": "Amount of seconds after this fare rate should be applied to",
+                      "type": "number",
+                      "minimum": 0,
+                      "multipleOf": 1
+                    }
                   },
-                  "currency": {
-                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                    "type": "string",
-                    "enum": [
-                      "EUR",
-                      "GBP"
-                    ]
-                  },
-                  "timeUnit": {
-                    "type": "string",
-                    "enum": [
-                      "1min",
-                      "15min",
-                      "30min",
-                      "1hr",
-                      "total"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency",
-                  "timeUnit"
-                ]
+                  "required": [
+                    "amount",
+                    "currency",
+                    "timeInterval"
+                  ]
+                }
               }
             },
             "additionalProperties": true

--- a/prebuilt/tsp/booking-read-by-id/response.json
+++ b/prebuilt/tsp/booking-read-by-id/response.json
@@ -979,39 +979,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/booking-update/response.json
+++ b/prebuilt/tsp/booking-update/response.json
@@ -978,39 +978,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/webhooks-bookings-update/remote-request.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-request.json
@@ -978,39 +978,44 @@
             "endTime"
           ]
         },
-        "fareRate": {
-          "description": "Booking fare rate",
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "minimum": 0,
-              "multipleOf": 0.01
+        "fareRates": {
+          "type": "array",
+          "items": {
+            "description": "Booking fare rate",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 0.01
+              },
+              "currency": {
+                "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                "type": "string",
+                "enum": [
+                  "EUR",
+                  "GBP"
+                ]
+              },
+              "timeInterval": {
+                "description": "Amount of seconds that fare rate is applied to",
+                "type": "number",
+                "minimum": 1,
+                "multipleOf": 1
+              },
+              "startAt": {
+                "description": "Amount of seconds after this fare rate should be applied to",
+                "type": "number",
+                "minimum": 0,
+                "multipleOf": 1
+              }
             },
-            "currency": {
-              "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-              "type": "string",
-              "enum": [
-                "EUR",
-                "GBP"
-              ]
-            },
-            "timeUnit": {
-              "type": "string",
-              "enum": [
-                "1min",
-                "15min",
-                "30min",
-                "1hr",
-                "total"
-              ]
-            }
-          },
-          "required": [
-            "amount",
-            "currency",
-            "timeUnit"
-          ]
+            "required": [
+              "amount",
+              "currency",
+              "timeInterval"
+            ]
+          }
         }
       },
       "additionalProperties": true

--- a/prebuilt/tsp/webhooks-bookings-update/remote-response.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-response.json
@@ -993,39 +993,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true
@@ -2065,39 +2070,44 @@
                 "endTime"
               ]
             },
-            "fareRate": {
-              "description": "Booking fare rate",
-              "type": "object",
-              "properties": {
-                "amount": {
-                  "type": "number",
-                  "minimum": 0,
-                  "multipleOf": 0.01
+            "fareRates": {
+              "type": "array",
+              "items": {
+                "description": "Booking fare rate",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 0.01
+                  },
+                  "currency": {
+                    "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
+                    "type": "string",
+                    "enum": [
+                      "EUR",
+                      "GBP"
+                    ]
+                  },
+                  "timeInterval": {
+                    "description": "Amount of seconds that fare rate is applied to",
+                    "type": "number",
+                    "minimum": 1,
+                    "multipleOf": 1
+                  },
+                  "startAt": {
+                    "description": "Amount of seconds after this fare rate should be applied to",
+                    "type": "number",
+                    "minimum": 0,
+                    "multipleOf": 1
+                  }
                 },
-                "currency": {
-                  "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-                  "type": "string",
-                  "enum": [
-                    "EUR",
-                    "GBP"
-                  ]
-                },
-                "timeUnit": {
-                  "type": "string",
-                  "enum": [
-                    "1min",
-                    "15min",
-                    "30min",
-                    "1hr",
-                    "total"
-                  ]
-                }
-              },
-              "required": [
-                "amount",
-                "currency",
-                "timeUnit"
-              ]
+                "required": [
+                  "amount",
+                  "currency",
+                  "timeInterval"
+                ]
+              }
             }
           },
           "additionalProperties": true

--- a/schemas/core/components/terms.json
+++ b/schemas/core/components/terms.json
@@ -17,26 +17,35 @@
       },
       "required": ["startTime", "endTime"]
     },
-    "fareRate": {
-      "description": "Booking fare rate",
-      "type": "object",
-      "properties": {
-        "amount": {
-          "type": "number",
-          "minimum": 0,
-          "multipleOf": 0.01
+    "fareRates": {
+      "type": "array",
+      "items": {
+        "description": "Booking fare rate",
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 0.01
+          },
+          "currency": {
+            "$ref": "./units.json#/definitions/currency"
+          },
+          "timeInterval": {
+            "description": "Amount of seconds that fare rate is applied to",
+            "type": "number",
+            "minimum": 1,
+            "multipleOf": 1
+          },
+          "startAt": {
+            "description": "Amount of seconds after this fare rate should be applied to",
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 1
+          }
         },
-        "currency": {
-          "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
-          "type": "string",
-          "enum": ["EUR", "GBP"]
-        },
-        "timeUnit": {
-          "type": "string",
-          "enum": ["1min", "15min", "30min", "1hr", "total"]
-        }
-      },
-      "required": ["amount", "currency", "timeUnit"]
+        "required": ["amount", "currency", "timeUnit"]
+      }
     }
   },
   "additionalProperties": true

--- a/schemas/core/components/terms.json
+++ b/schemas/core/components/terms.json
@@ -44,7 +44,7 @@
             "multipleOf": 1
           }
         },
-        "required": ["amount", "currency", "timeUnit"]
+        "required": ["amount", "currency", "timeInterval"]
       }
     }
   },


### PR DESCRIPTION
Citybikes requires support for multiple fare rates and also start time when those rates should be applied. There should be three tiers:
* 0-30min -> 0€
* 30min - 5hrs -> 1€/30min
* 5+hrs -> 80€ -- Not sure if this one will be included

In addition proposal includes fine grained control (s) for time unit and start time when rate should be applied.