### PR TITLE
Leg: introduce 'SHARED_CAR' mode value

### DIFF
--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -304,35 +304,36 @@
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -1416,35 +1417,36 @@
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/core/components/travel-mode.json
+++ b/prebuilt/core/components/travel-mode.json
@@ -13,43 +13,44 @@
       "description": "A mode that involves changing transports",
       "type": "string",
       "enum": [
-        "TRANSFER",
-        "LEG_SWITCH"
+        "LEG_SWITCH",
+        "TRANSFER"
       ]
     },
     {
       "description": "A mode that involves using your personal vehicle or legs",
       "type": "string",
       "enum": [
-        "WALK",
         "BICYCLE",
-        "CAR"
+        "CAR",
+        "WALK"
       ]
     },
     {
       "description": "A mode that involves transit with fixed schedules",
       "type": "string",
       "enum": [
-        "TRAM",
-        "SUBWAY",
-        "RAIL",
+        "AEROPLANE",
         "BUS",
         "FERRY",
-        "TRANSIT",
+        "RAIL",
+        "SUBWAY",
         "TRAIN",
-        "AEROPLANE"
+        "TRAM",
+        "TRANSIT"
       ]
     },
     {
       "description": "A mode that is available on-demand for your personal use",
       "type": "string",
       "enum": [
-        "CAR",
-        "TAXI",
-        "CABLE_CAR",
-        "GONDOLA",
-        "FUNICULAR",
         "BUSISH",
+        "CABLE_CAR",
+        "CAR",
+        "FUNICULAR",
+        "GONDOLA",
+        "SHARED_CAR",
+        "TAXI",
         "TRAINISH"
       ]
     }
@@ -66,43 +67,44 @@
       "description": "A mode that involves changing transports",
       "type": "string",
       "enum": [
-        "TRANSFER",
-        "LEG_SWITCH"
+        "LEG_SWITCH",
+        "TRANSFER"
       ]
     },
     "personalMode": {
       "description": "A mode that involves using your personal vehicle or legs",
       "type": "string",
       "enum": [
-        "WALK",
         "BICYCLE",
-        "CAR"
+        "CAR",
+        "WALK"
       ]
     },
     "publicTransitMode": {
       "description": "A mode that involves transit with fixed schedules",
       "type": "string",
       "enum": [
-        "TRAM",
-        "SUBWAY",
-        "RAIL",
+        "AEROPLANE",
         "BUS",
         "FERRY",
-        "TRANSIT",
+        "RAIL",
+        "SUBWAY",
         "TRAIN",
-        "AEROPLANE"
+        "TRAM",
+        "TRANSIT"
       ]
     },
     "privateTransitMode": {
       "description": "A mode that is available on-demand for your personal use",
       "type": "string",
       "enum": [
-        "CAR",
-        "TAXI",
-        "CABLE_CAR",
-        "GONDOLA",
-        "FUNICULAR",
         "BUSISH",
+        "CABLE_CAR",
+        "CAR",
+        "FUNICULAR",
+        "GONDOLA",
+        "SHARED_CAR",
+        "TAXI",
         "TRAINISH"
       ]
     }

--- a/prebuilt/core/itinerary.json
+++ b/prebuilt/core/itinerary.json
@@ -292,35 +292,36 @@
                             "description": "A mode that involves using your personal vehicle or legs",
                             "type": "string",
                             "enum": [
-                              "WALK",
                               "BICYCLE",
-                              "CAR"
+                              "CAR",
+                              "WALK"
                             ]
                           },
                           {
                             "description": "A mode that involves transit with fixed schedules",
                             "type": "string",
                             "enum": [
-                              "TRAM",
-                              "SUBWAY",
-                              "RAIL",
+                              "AEROPLANE",
                               "BUS",
                               "FERRY",
-                              "TRANSIT",
+                              "RAIL",
+                              "SUBWAY",
                               "TRAIN",
-                              "AEROPLANE"
+                              "TRAM",
+                              "TRANSIT"
                             ]
                           },
                           {
                             "description": "A mode that is available on-demand for your personal use",
                             "type": "string",
                             "enum": [
-                              "CAR",
-                              "TAXI",
-                              "CABLE_CAR",
-                              "GONDOLA",
-                              "FUNICULAR",
                               "BUSISH",
+                              "CABLE_CAR",
+                              "CAR",
+                              "FUNICULAR",
+                              "GONDOLA",
+                              "SHARED_CAR",
+                              "TAXI",
                               "TRAINISH"
                             ]
                           }
@@ -471,8 +472,8 @@
                         "description": "A mode that involves changing transports",
                         "type": "string",
                         "enum": [
-                          "TRANSFER",
-                          "LEG_SWITCH"
+                          "LEG_SWITCH",
+                          "TRANSFER"
                         ]
                       }
                     },
@@ -686,35 +687,36 @@
                       "description": "A mode that involves using your personal vehicle or legs",
                       "type": "string",
                       "enum": [
-                        "WALK",
                         "BICYCLE",
-                        "CAR"
+                        "CAR",
+                        "WALK"
                       ]
                     },
                     {
                       "description": "A mode that involves transit with fixed schedules",
                       "type": "string",
                       "enum": [
-                        "TRAM",
-                        "SUBWAY",
-                        "RAIL",
+                        "AEROPLANE",
                         "BUS",
                         "FERRY",
-                        "TRANSIT",
+                        "RAIL",
+                        "SUBWAY",
                         "TRAIN",
-                        "AEROPLANE"
+                        "TRAM",
+                        "TRANSIT"
                       ]
                     },
                     {
                       "description": "A mode that is available on-demand for your personal use",
                       "type": "string",
                       "enum": [
-                        "CAR",
-                        "TAXI",
-                        "CABLE_CAR",
-                        "GONDOLA",
-                        "FUNICULAR",
                         "BUSISH",
+                        "CABLE_CAR",
+                        "CAR",
+                        "FUNICULAR",
+                        "GONDOLA",
+                        "SHARED_CAR",
+                        "TAXI",
                         "TRAINISH"
                       ]
                     }
@@ -865,8 +867,8 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 }
               },

--- a/prebuilt/core/leg.json
+++ b/prebuilt/core/leg.json
@@ -205,35 +205,36 @@
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -384,8 +385,8 @@
                 "description": "A mode that involves changing transports",
                 "type": "string",
                 "enum": [
-                  "TRANSFER",
-                  "LEG_SWITCH"
+                  "LEG_SWITCH",
+                  "TRANSFER"
                 ]
               }
             },
@@ -599,35 +600,36 @@
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -778,8 +780,8 @@
           "description": "A mode that involves changing transports",
           "type": "string",
           "enum": [
-            "TRANSFER",
-            "LEG_SWITCH"
+            "LEG_SWITCH",
+            "TRANSFER"
           ]
         }
       },

--- a/prebuilt/core/plan.json
+++ b/prebuilt/core/plan.json
@@ -368,35 +368,36 @@
                                   "description": "A mode that involves using your personal vehicle or legs",
                                   "type": "string",
                                   "enum": [
-                                    "WALK",
                                     "BICYCLE",
-                                    "CAR"
+                                    "CAR",
+                                    "WALK"
                                   ]
                                 },
                                 {
                                   "description": "A mode that involves transit with fixed schedules",
                                   "type": "string",
                                   "enum": [
-                                    "TRAM",
-                                    "SUBWAY",
-                                    "RAIL",
+                                    "AEROPLANE",
                                     "BUS",
                                     "FERRY",
-                                    "TRANSIT",
+                                    "RAIL",
+                                    "SUBWAY",
                                     "TRAIN",
-                                    "AEROPLANE"
+                                    "TRAM",
+                                    "TRANSIT"
                                   ]
                                 },
                                 {
                                   "description": "A mode that is available on-demand for your personal use",
                                   "type": "string",
                                   "enum": [
-                                    "CAR",
-                                    "TAXI",
-                                    "CABLE_CAR",
-                                    "GONDOLA",
-                                    "FUNICULAR",
                                     "BUSISH",
+                                    "CABLE_CAR",
+                                    "CAR",
+                                    "FUNICULAR",
+                                    "GONDOLA",
+                                    "SHARED_CAR",
+                                    "TAXI",
                                     "TRAINISH"
                                   ]
                                 }
@@ -547,8 +548,8 @@
                               "description": "A mode that involves changing transports",
                               "type": "string",
                               "enum": [
-                                "TRANSFER",
-                                "LEG_SWITCH"
+                                "LEG_SWITCH",
+                                "TRANSFER"
                               ]
                             }
                           },
@@ -762,35 +763,36 @@
                             "description": "A mode that involves using your personal vehicle or legs",
                             "type": "string",
                             "enum": [
-                              "WALK",
                               "BICYCLE",
-                              "CAR"
+                              "CAR",
+                              "WALK"
                             ]
                           },
                           {
                             "description": "A mode that involves transit with fixed schedules",
                             "type": "string",
                             "enum": [
-                              "TRAM",
-                              "SUBWAY",
-                              "RAIL",
+                              "AEROPLANE",
                               "BUS",
                               "FERRY",
-                              "TRANSIT",
+                              "RAIL",
+                              "SUBWAY",
                               "TRAIN",
-                              "AEROPLANE"
+                              "TRAM",
+                              "TRANSIT"
                             ]
                           },
                           {
                             "description": "A mode that is available on-demand for your personal use",
                             "type": "string",
                             "enum": [
-                              "CAR",
-                              "TAXI",
-                              "CABLE_CAR",
-                              "GONDOLA",
-                              "FUNICULAR",
                               "BUSISH",
+                              "CABLE_CAR",
+                              "CAR",
+                              "FUNICULAR",
+                              "GONDOLA",
+                              "SHARED_CAR",
+                              "TAXI",
                               "TRAINISH"
                             ]
                           }
@@ -941,8 +943,8 @@
                         "description": "A mode that involves changing transports",
                         "type": "string",
                         "enum": [
-                          "TRANSFER",
-                          "LEG_SWITCH"
+                          "LEG_SWITCH",
+                          "TRANSFER"
                         ]
                       }
                     },

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/request.json
@@ -33,43 +33,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -86,43 +87,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -233,43 +235,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -286,43 +289,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
@@ -317,35 +317,36 @@
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -1420,35 +1421,36 @@
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -311,35 +311,36 @@
                       "description": "A mode that involves using your personal vehicle or legs",
                       "type": "string",
                       "enum": [
-                        "WALK",
                         "BICYCLE",
-                        "CAR"
+                        "CAR",
+                        "WALK"
                       ]
                     },
                     {
                       "description": "A mode that involves transit with fixed schedules",
                       "type": "string",
                       "enum": [
-                        "TRAM",
-                        "SUBWAY",
-                        "RAIL",
+                        "AEROPLANE",
                         "BUS",
                         "FERRY",
-                        "TRANSIT",
+                        "RAIL",
+                        "SUBWAY",
                         "TRAIN",
-                        "AEROPLANE"
+                        "TRAM",
+                        "TRANSIT"
                       ]
                     },
                     {
                       "description": "A mode that is available on-demand for your personal use",
                       "type": "string",
                       "enum": [
-                        "CAR",
-                        "TAXI",
-                        "CABLE_CAR",
-                        "GONDOLA",
-                        "FUNICULAR",
                         "BUSISH",
+                        "CABLE_CAR",
+                        "CAR",
+                        "FUNICULAR",
+                        "GONDOLA",
+                        "SHARED_CAR",
+                        "TAXI",
                         "TRAINISH"
                       ]
                     }
@@ -1423,35 +1424,36 @@
                       "description": "A mode that involves using your personal vehicle or legs",
                       "type": "string",
                       "enum": [
-                        "WALK",
                         "BICYCLE",
-                        "CAR"
+                        "CAR",
+                        "WALK"
                       ]
                     },
                     {
                       "description": "A mode that involves transit with fixed schedules",
                       "type": "string",
                       "enum": [
-                        "TRAM",
-                        "SUBWAY",
-                        "RAIL",
+                        "AEROPLANE",
                         "BUS",
                         "FERRY",
-                        "TRANSIT",
+                        "RAIL",
+                        "SUBWAY",
                         "TRAIN",
-                        "AEROPLANE"
+                        "TRAM",
+                        "TRANSIT"
                       ]
                     },
                     {
                       "description": "A mode that is available on-demand for your personal use",
                       "type": "string",
                       "enum": [
-                        "CAR",
-                        "TAXI",
-                        "CABLE_CAR",
-                        "GONDOLA",
-                        "FUNICULAR",
                         "BUSISH",
+                        "CABLE_CAR",
+                        "CAR",
+                        "FUNICULAR",
+                        "GONDOLA",
+                        "SHARED_CAR",
+                        "TAXI",
                         "TRAINISH"
                       ]
                     }

--- a/prebuilt/maas-backend/bookings/bookings-create/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/request.json
@@ -316,35 +316,36 @@
                       "description": "A mode that involves using your personal vehicle or legs",
                       "type": "string",
                       "enum": [
-                        "WALK",
                         "BICYCLE",
-                        "CAR"
+                        "CAR",
+                        "WALK"
                       ]
                     },
                     {
                       "description": "A mode that involves transit with fixed schedules",
                       "type": "string",
                       "enum": [
-                        "TRAM",
-                        "SUBWAY",
-                        "RAIL",
+                        "AEROPLANE",
                         "BUS",
                         "FERRY",
-                        "TRANSIT",
+                        "RAIL",
+                        "SUBWAY",
                         "TRAIN",
-                        "AEROPLANE"
+                        "TRAM",
+                        "TRANSIT"
                       ]
                     },
                     {
                       "description": "A mode that is available on-demand for your personal use",
                       "type": "string",
                       "enum": [
-                        "CAR",
-                        "TAXI",
-                        "CABLE_CAR",
-                        "GONDOLA",
-                        "FUNICULAR",
                         "BUSISH",
+                        "CABLE_CAR",
+                        "CAR",
+                        "FUNICULAR",
+                        "GONDOLA",
+                        "SHARED_CAR",
+                        "TAXI",
                         "TRAINISH"
                       ]
                     }
@@ -1428,35 +1429,36 @@
                       "description": "A mode that involves using your personal vehicle or legs",
                       "type": "string",
                       "enum": [
-                        "WALK",
                         "BICYCLE",
-                        "CAR"
+                        "CAR",
+                        "WALK"
                       ]
                     },
                     {
                       "description": "A mode that involves transit with fixed schedules",
                       "type": "string",
                       "enum": [
-                        "TRAM",
-                        "SUBWAY",
-                        "RAIL",
+                        "AEROPLANE",
                         "BUS",
                         "FERRY",
-                        "TRANSIT",
+                        "RAIL",
+                        "SUBWAY",
                         "TRAIN",
-                        "AEROPLANE"
+                        "TRAM",
+                        "TRANSIT"
                       ]
                     },
                     {
                       "description": "A mode that is available on-demand for your personal use",
                       "type": "string",
                       "enum": [
-                        "CAR",
-                        "TAXI",
-                        "CABLE_CAR",
-                        "GONDOLA",
-                        "FUNICULAR",
                         "BUSISH",
+                        "CABLE_CAR",
+                        "CAR",
+                        "FUNICULAR",
+                        "GONDOLA",
+                        "SHARED_CAR",
+                        "TAXI",
                         "TRAINISH"
                       ]
                     }

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -310,35 +310,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1422,35 +1423,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -313,35 +313,36 @@
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -1425,35 +1426,36 @@
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -310,35 +310,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1422,35 +1423,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/prebuilt/maas-backend/bookings/bookings-update/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/request.json
@@ -319,35 +319,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1431,35 +1432,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -310,35 +310,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1422,35 +1423,36 @@
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/prebuilt/maas-backend/itineraries/itinerary-create/request.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/request.json
@@ -298,35 +298,36 @@
                                 "description": "A mode that involves using your personal vehicle or legs",
                                 "type": "string",
                                 "enum": [
-                                  "WALK",
                                   "BICYCLE",
-                                  "CAR"
+                                  "CAR",
+                                  "WALK"
                                 ]
                               },
                               {
                                 "description": "A mode that involves transit with fixed schedules",
                                 "type": "string",
                                 "enum": [
-                                  "TRAM",
-                                  "SUBWAY",
-                                  "RAIL",
+                                  "AEROPLANE",
                                   "BUS",
                                   "FERRY",
-                                  "TRANSIT",
+                                  "RAIL",
+                                  "SUBWAY",
                                   "TRAIN",
-                                  "AEROPLANE"
+                                  "TRAM",
+                                  "TRANSIT"
                                 ]
                               },
                               {
                                 "description": "A mode that is available on-demand for your personal use",
                                 "type": "string",
                                 "enum": [
-                                  "CAR",
-                                  "TAXI",
-                                  "CABLE_CAR",
-                                  "GONDOLA",
-                                  "FUNICULAR",
                                   "BUSISH",
+                                  "CABLE_CAR",
+                                  "CAR",
+                                  "FUNICULAR",
+                                  "GONDOLA",
+                                  "SHARED_CAR",
+                                  "TAXI",
                                   "TRAINISH"
                                 ]
                               }
@@ -477,8 +478,8 @@
                             "description": "A mode that involves changing transports",
                             "type": "string",
                             "enum": [
-                              "TRANSFER",
-                              "LEG_SWITCH"
+                              "LEG_SWITCH",
+                              "TRANSFER"
                             ]
                           }
                         },
@@ -692,35 +693,36 @@
                           "description": "A mode that involves using your personal vehicle or legs",
                           "type": "string",
                           "enum": [
-                            "WALK",
                             "BICYCLE",
-                            "CAR"
+                            "CAR",
+                            "WALK"
                           ]
                         },
                         {
                           "description": "A mode that involves transit with fixed schedules",
                           "type": "string",
                           "enum": [
-                            "TRAM",
-                            "SUBWAY",
-                            "RAIL",
+                            "AEROPLANE",
                             "BUS",
                             "FERRY",
-                            "TRANSIT",
+                            "RAIL",
+                            "SUBWAY",
                             "TRAIN",
-                            "AEROPLANE"
+                            "TRAM",
+                            "TRANSIT"
                           ]
                         },
                         {
                           "description": "A mode that is available on-demand for your personal use",
                           "type": "string",
                           "enum": [
-                            "CAR",
-                            "TAXI",
-                            "CABLE_CAR",
-                            "GONDOLA",
-                            "FUNICULAR",
                             "BUSISH",
+                            "CABLE_CAR",
+                            "CAR",
+                            "FUNICULAR",
+                            "GONDOLA",
+                            "SHARED_CAR",
+                            "TAXI",
                             "TRAINISH"
                           ]
                         }
@@ -871,8 +873,8 @@
                       "description": "A mode that involves changing transports",
                       "type": "string",
                       "enum": [
-                        "TRANSFER",
-                        "LEG_SWITCH"
+                        "LEG_SWITCH",
+                        "TRANSFER"
                       ]
                     }
                   },

--- a/prebuilt/maas-backend/itineraries/itinerary-create/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-create/response.json
@@ -298,35 +298,36 @@
                                 "description": "A mode that involves using your personal vehicle or legs",
                                 "type": "string",
                                 "enum": [
-                                  "WALK",
                                   "BICYCLE",
-                                  "CAR"
+                                  "CAR",
+                                  "WALK"
                                 ]
                               },
                               {
                                 "description": "A mode that involves transit with fixed schedules",
                                 "type": "string",
                                 "enum": [
-                                  "TRAM",
-                                  "SUBWAY",
-                                  "RAIL",
+                                  "AEROPLANE",
                                   "BUS",
                                   "FERRY",
-                                  "TRANSIT",
+                                  "RAIL",
+                                  "SUBWAY",
                                   "TRAIN",
-                                  "AEROPLANE"
+                                  "TRAM",
+                                  "TRANSIT"
                                 ]
                               },
                               {
                                 "description": "A mode that is available on-demand for your personal use",
                                 "type": "string",
                                 "enum": [
-                                  "CAR",
-                                  "TAXI",
-                                  "CABLE_CAR",
-                                  "GONDOLA",
-                                  "FUNICULAR",
                                   "BUSISH",
+                                  "CABLE_CAR",
+                                  "CAR",
+                                  "FUNICULAR",
+                                  "GONDOLA",
+                                  "SHARED_CAR",
+                                  "TAXI",
                                   "TRAINISH"
                                 ]
                               }
@@ -477,8 +478,8 @@
                             "description": "A mode that involves changing transports",
                             "type": "string",
                             "enum": [
-                              "TRANSFER",
-                              "LEG_SWITCH"
+                              "LEG_SWITCH",
+                              "TRANSFER"
                             ]
                           }
                         },
@@ -692,35 +693,36 @@
                           "description": "A mode that involves using your personal vehicle or legs",
                           "type": "string",
                           "enum": [
-                            "WALK",
                             "BICYCLE",
-                            "CAR"
+                            "CAR",
+                            "WALK"
                           ]
                         },
                         {
                           "description": "A mode that involves transit with fixed schedules",
                           "type": "string",
                           "enum": [
-                            "TRAM",
-                            "SUBWAY",
-                            "RAIL",
+                            "AEROPLANE",
                             "BUS",
                             "FERRY",
-                            "TRANSIT",
+                            "RAIL",
+                            "SUBWAY",
                             "TRAIN",
-                            "AEROPLANE"
+                            "TRAM",
+                            "TRANSIT"
                           ]
                         },
                         {
                           "description": "A mode that is available on-demand for your personal use",
                           "type": "string",
                           "enum": [
-                            "CAR",
-                            "TAXI",
-                            "CABLE_CAR",
-                            "GONDOLA",
-                            "FUNICULAR",
                             "BUSISH",
+                            "CABLE_CAR",
+                            "CAR",
+                            "FUNICULAR",
+                            "GONDOLA",
+                            "SHARED_CAR",
+                            "TAXI",
                             "TRAINISH"
                           ]
                         }
@@ -871,8 +873,8 @@
                       "description": "A mode that involves changing transports",
                       "type": "string",
                       "enum": [
-                        "TRANSFER",
-                        "LEG_SWITCH"
+                        "LEG_SWITCH",
+                        "TRANSFER"
                       ]
                     }
                   },

--- a/prebuilt/maas-backend/itineraries/itinerary-list/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-list/response.json
@@ -301,35 +301,36 @@
                                   "description": "A mode that involves using your personal vehicle or legs",
                                   "type": "string",
                                   "enum": [
-                                    "WALK",
                                     "BICYCLE",
-                                    "CAR"
+                                    "CAR",
+                                    "WALK"
                                   ]
                                 },
                                 {
                                   "description": "A mode that involves transit with fixed schedules",
                                   "type": "string",
                                   "enum": [
-                                    "TRAM",
-                                    "SUBWAY",
-                                    "RAIL",
+                                    "AEROPLANE",
                                     "BUS",
                                     "FERRY",
-                                    "TRANSIT",
+                                    "RAIL",
+                                    "SUBWAY",
                                     "TRAIN",
-                                    "AEROPLANE"
+                                    "TRAM",
+                                    "TRANSIT"
                                   ]
                                 },
                                 {
                                   "description": "A mode that is available on-demand for your personal use",
                                   "type": "string",
                                   "enum": [
-                                    "CAR",
-                                    "TAXI",
-                                    "CABLE_CAR",
-                                    "GONDOLA",
-                                    "FUNICULAR",
                                     "BUSISH",
+                                    "CABLE_CAR",
+                                    "CAR",
+                                    "FUNICULAR",
+                                    "GONDOLA",
+                                    "SHARED_CAR",
+                                    "TAXI",
                                     "TRAINISH"
                                   ]
                                 }
@@ -480,8 +481,8 @@
                               "description": "A mode that involves changing transports",
                               "type": "string",
                               "enum": [
-                                "TRANSFER",
-                                "LEG_SWITCH"
+                                "LEG_SWITCH",
+                                "TRANSFER"
                               ]
                             }
                           },
@@ -695,35 +696,36 @@
                             "description": "A mode that involves using your personal vehicle or legs",
                             "type": "string",
                             "enum": [
-                              "WALK",
                               "BICYCLE",
-                              "CAR"
+                              "CAR",
+                              "WALK"
                             ]
                           },
                           {
                             "description": "A mode that involves transit with fixed schedules",
                             "type": "string",
                             "enum": [
-                              "TRAM",
-                              "SUBWAY",
-                              "RAIL",
+                              "AEROPLANE",
                               "BUS",
                               "FERRY",
-                              "TRANSIT",
+                              "RAIL",
+                              "SUBWAY",
                               "TRAIN",
-                              "AEROPLANE"
+                              "TRAM",
+                              "TRANSIT"
                             ]
                           },
                           {
                             "description": "A mode that is available on-demand for your personal use",
                             "type": "string",
                             "enum": [
-                              "CAR",
-                              "TAXI",
-                              "CABLE_CAR",
-                              "GONDOLA",
-                              "FUNICULAR",
                               "BUSISH",
+                              "CABLE_CAR",
+                              "CAR",
+                              "FUNICULAR",
+                              "GONDOLA",
+                              "SHARED_CAR",
+                              "TAXI",
                               "TRAINISH"
                             ]
                           }
@@ -874,8 +876,8 @@
                         "description": "A mode that involves changing transports",
                         "type": "string",
                         "enum": [
-                          "TRANSFER",
-                          "LEG_SWITCH"
+                          "LEG_SWITCH",
+                          "TRANSFER"
                         ]
                       }
                     },

--- a/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
+++ b/prebuilt/maas-backend/itineraries/itinerary-retrieve/response.json
@@ -298,35 +298,36 @@
                                 "description": "A mode that involves using your personal vehicle or legs",
                                 "type": "string",
                                 "enum": [
-                                  "WALK",
                                   "BICYCLE",
-                                  "CAR"
+                                  "CAR",
+                                  "WALK"
                                 ]
                               },
                               {
                                 "description": "A mode that involves transit with fixed schedules",
                                 "type": "string",
                                 "enum": [
-                                  "TRAM",
-                                  "SUBWAY",
-                                  "RAIL",
+                                  "AEROPLANE",
                                   "BUS",
                                   "FERRY",
-                                  "TRANSIT",
+                                  "RAIL",
+                                  "SUBWAY",
                                   "TRAIN",
-                                  "AEROPLANE"
+                                  "TRAM",
+                                  "TRANSIT"
                                 ]
                               },
                               {
                                 "description": "A mode that is available on-demand for your personal use",
                                 "type": "string",
                                 "enum": [
-                                  "CAR",
-                                  "TAXI",
-                                  "CABLE_CAR",
-                                  "GONDOLA",
-                                  "FUNICULAR",
                                   "BUSISH",
+                                  "CABLE_CAR",
+                                  "CAR",
+                                  "FUNICULAR",
+                                  "GONDOLA",
+                                  "SHARED_CAR",
+                                  "TAXI",
                                   "TRAINISH"
                                 ]
                               }
@@ -477,8 +478,8 @@
                             "description": "A mode that involves changing transports",
                             "type": "string",
                             "enum": [
-                              "TRANSFER",
-                              "LEG_SWITCH"
+                              "LEG_SWITCH",
+                              "TRANSFER"
                             ]
                           }
                         },
@@ -692,35 +693,36 @@
                           "description": "A mode that involves using your personal vehicle or legs",
                           "type": "string",
                           "enum": [
-                            "WALK",
                             "BICYCLE",
-                            "CAR"
+                            "CAR",
+                            "WALK"
                           ]
                         },
                         {
                           "description": "A mode that involves transit with fixed schedules",
                           "type": "string",
                           "enum": [
-                            "TRAM",
-                            "SUBWAY",
-                            "RAIL",
+                            "AEROPLANE",
                             "BUS",
                             "FERRY",
-                            "TRANSIT",
+                            "RAIL",
+                            "SUBWAY",
                             "TRAIN",
-                            "AEROPLANE"
+                            "TRAM",
+                            "TRANSIT"
                           ]
                         },
                         {
                           "description": "A mode that is available on-demand for your personal use",
                           "type": "string",
                           "enum": [
-                            "CAR",
-                            "TAXI",
-                            "CABLE_CAR",
-                            "GONDOLA",
-                            "FUNICULAR",
                             "BUSISH",
+                            "CABLE_CAR",
+                            "CAR",
+                            "FUNICULAR",
+                            "GONDOLA",
+                            "SHARED_CAR",
+                            "TAXI",
                             "TRAINISH"
                           ]
                         }
@@ -871,8 +873,8 @@
                       "description": "A mode that involves changing transports",
                       "type": "string",
                       "enum": [
-                        "TRANSFER",
-                        "LEG_SWITCH"
+                        "LEG_SWITCH",
+                        "TRANSFER"
                       ]
                     }
                   },

--- a/prebuilt/maas-backend/provider/routes/request.json
+++ b/prebuilt/maas-backend/provider/routes/request.json
@@ -93,43 +93,44 @@
           "description": "A mode that involves changing transports",
           "type": "string",
           "enum": [
-            "TRANSFER",
-            "LEG_SWITCH"
+            "LEG_SWITCH",
+            "TRANSFER"
           ]
         },
         {
           "description": "A mode that involves using your personal vehicle or legs",
           "type": "string",
           "enum": [
-            "WALK",
             "BICYCLE",
-            "CAR"
+            "CAR",
+            "WALK"
           ]
         },
         {
           "description": "A mode that involves transit with fixed schedules",
           "type": "string",
           "enum": [
-            "TRAM",
-            "SUBWAY",
-            "RAIL",
+            "AEROPLANE",
             "BUS",
             "FERRY",
-            "TRANSIT",
+            "RAIL",
+            "SUBWAY",
             "TRAIN",
-            "AEROPLANE"
+            "TRAM",
+            "TRANSIT"
           ]
         },
         {
           "description": "A mode that is available on-demand for your personal use",
           "type": "string",
           "enum": [
-            "CAR",
-            "TAXI",
-            "CABLE_CAR",
-            "GONDOLA",
-            "FUNICULAR",
             "BUSISH",
+            "CABLE_CAR",
+            "CAR",
+            "FUNICULAR",
+            "GONDOLA",
+            "SHARED_CAR",
+            "TAXI",
             "TRAINISH"
           ]
         }
@@ -146,43 +147,44 @@
           "description": "A mode that involves changing transports",
           "type": "string",
           "enum": [
-            "TRANSFER",
-            "LEG_SWITCH"
+            "LEG_SWITCH",
+            "TRANSFER"
           ]
         },
         "personalMode": {
           "description": "A mode that involves using your personal vehicle or legs",
           "type": "string",
           "enum": [
-            "WALK",
             "BICYCLE",
-            "CAR"
+            "CAR",
+            "WALK"
           ]
         },
         "publicTransitMode": {
           "description": "A mode that involves transit with fixed schedules",
           "type": "string",
           "enum": [
-            "TRAM",
-            "SUBWAY",
-            "RAIL",
+            "AEROPLANE",
             "BUS",
             "FERRY",
-            "TRANSIT",
+            "RAIL",
+            "SUBWAY",
             "TRAIN",
-            "AEROPLANE"
+            "TRAM",
+            "TRANSIT"
           ]
         },
         "privateTransitMode": {
           "description": "A mode that is available on-demand for your personal use",
           "type": "string",
           "enum": [
-            "CAR",
-            "TAXI",
-            "CABLE_CAR",
-            "GONDOLA",
-            "FUNICULAR",
             "BUSISH",
+            "CABLE_CAR",
+            "CAR",
+            "FUNICULAR",
+            "GONDOLA",
+            "SHARED_CAR",
+            "TAXI",
             "TRAINISH"
           ]
         }

--- a/prebuilt/maas-backend/provider/routes/response.json
+++ b/prebuilt/maas-backend/provider/routes/response.json
@@ -369,35 +369,36 @@
                                           "description": "A mode that involves using your personal vehicle or legs",
                                           "type": "string",
                                           "enum": [
-                                            "WALK",
                                             "BICYCLE",
-                                            "CAR"
+                                            "CAR",
+                                            "WALK"
                                           ]
                                         },
                                         {
                                           "description": "A mode that involves transit with fixed schedules",
                                           "type": "string",
                                           "enum": [
-                                            "TRAM",
-                                            "SUBWAY",
-                                            "RAIL",
+                                            "AEROPLANE",
                                             "BUS",
                                             "FERRY",
-                                            "TRANSIT",
+                                            "RAIL",
+                                            "SUBWAY",
                                             "TRAIN",
-                                            "AEROPLANE"
+                                            "TRAM",
+                                            "TRANSIT"
                                           ]
                                         },
                                         {
                                           "description": "A mode that is available on-demand for your personal use",
                                           "type": "string",
                                           "enum": [
-                                            "CAR",
-                                            "TAXI",
-                                            "CABLE_CAR",
-                                            "GONDOLA",
-                                            "FUNICULAR",
                                             "BUSISH",
+                                            "CABLE_CAR",
+                                            "CAR",
+                                            "FUNICULAR",
+                                            "GONDOLA",
+                                            "SHARED_CAR",
+                                            "TAXI",
                                             "TRAINISH"
                                           ]
                                         }
@@ -548,8 +549,8 @@
                                       "description": "A mode that involves changing transports",
                                       "type": "string",
                                       "enum": [
-                                        "TRANSFER",
-                                        "LEG_SWITCH"
+                                        "LEG_SWITCH",
+                                        "TRANSFER"
                                       ]
                                     }
                                   },
@@ -763,35 +764,36 @@
                                     "description": "A mode that involves using your personal vehicle or legs",
                                     "type": "string",
                                     "enum": [
-                                      "WALK",
                                       "BICYCLE",
-                                      "CAR"
+                                      "CAR",
+                                      "WALK"
                                     ]
                                   },
                                   {
                                     "description": "A mode that involves transit with fixed schedules",
                                     "type": "string",
                                     "enum": [
-                                      "TRAM",
-                                      "SUBWAY",
-                                      "RAIL",
+                                      "AEROPLANE",
                                       "BUS",
                                       "FERRY",
-                                      "TRANSIT",
+                                      "RAIL",
+                                      "SUBWAY",
                                       "TRAIN",
-                                      "AEROPLANE"
+                                      "TRAM",
+                                      "TRANSIT"
                                     ]
                                   },
                                   {
                                     "description": "A mode that is available on-demand for your personal use",
                                     "type": "string",
                                     "enum": [
-                                      "CAR",
-                                      "TAXI",
-                                      "CABLE_CAR",
-                                      "GONDOLA",
-                                      "FUNICULAR",
                                       "BUSISH",
+                                      "CABLE_CAR",
+                                      "CAR",
+                                      "FUNICULAR",
+                                      "GONDOLA",
+                                      "SHARED_CAR",
+                                      "TAXI",
                                       "TRAINISH"
                                     ]
                                   }
@@ -942,8 +944,8 @@
                                 "description": "A mode that involves changing transports",
                                 "type": "string",
                                 "enum": [
-                                  "TRANSFER",
-                                  "LEG_SWITCH"
+                                  "LEG_SWITCH",
+                                  "TRANSFER"
                                 ]
                               }
                             },

--- a/prebuilt/maas-backend/routes/routes-query/response.json
+++ b/prebuilt/maas-backend/routes/routes-query/response.json
@@ -378,35 +378,36 @@
                                           "description": "A mode that involves using your personal vehicle or legs",
                                           "type": "string",
                                           "enum": [
-                                            "WALK",
                                             "BICYCLE",
-                                            "CAR"
+                                            "CAR",
+                                            "WALK"
                                           ]
                                         },
                                         {
                                           "description": "A mode that involves transit with fixed schedules",
                                           "type": "string",
                                           "enum": [
-                                            "TRAM",
-                                            "SUBWAY",
-                                            "RAIL",
+                                            "AEROPLANE",
                                             "BUS",
                                             "FERRY",
-                                            "TRANSIT",
+                                            "RAIL",
+                                            "SUBWAY",
                                             "TRAIN",
-                                            "AEROPLANE"
+                                            "TRAM",
+                                            "TRANSIT"
                                           ]
                                         },
                                         {
                                           "description": "A mode that is available on-demand for your personal use",
                                           "type": "string",
                                           "enum": [
-                                            "CAR",
-                                            "TAXI",
-                                            "CABLE_CAR",
-                                            "GONDOLA",
-                                            "FUNICULAR",
                                             "BUSISH",
+                                            "CABLE_CAR",
+                                            "CAR",
+                                            "FUNICULAR",
+                                            "GONDOLA",
+                                            "SHARED_CAR",
+                                            "TAXI",
                                             "TRAINISH"
                                           ]
                                         }
@@ -557,8 +558,8 @@
                                       "description": "A mode that involves changing transports",
                                       "type": "string",
                                       "enum": [
-                                        "TRANSFER",
-                                        "LEG_SWITCH"
+                                        "LEG_SWITCH",
+                                        "TRANSFER"
                                       ]
                                     }
                                   },
@@ -772,35 +773,36 @@
                                     "description": "A mode that involves using your personal vehicle or legs",
                                     "type": "string",
                                     "enum": [
-                                      "WALK",
                                       "BICYCLE",
-                                      "CAR"
+                                      "CAR",
+                                      "WALK"
                                     ]
                                   },
                                   {
                                     "description": "A mode that involves transit with fixed schedules",
                                     "type": "string",
                                     "enum": [
-                                      "TRAM",
-                                      "SUBWAY",
-                                      "RAIL",
+                                      "AEROPLANE",
                                       "BUS",
                                       "FERRY",
-                                      "TRANSIT",
+                                      "RAIL",
+                                      "SUBWAY",
                                       "TRAIN",
-                                      "AEROPLANE"
+                                      "TRAM",
+                                      "TRANSIT"
                                     ]
                                   },
                                   {
                                     "description": "A mode that is available on-demand for your personal use",
                                     "type": "string",
                                     "enum": [
-                                      "CAR",
-                                      "TAXI",
-                                      "CABLE_CAR",
-                                      "GONDOLA",
-                                      "FUNICULAR",
                                       "BUSISH",
+                                      "CABLE_CAR",
+                                      "CAR",
+                                      "FUNICULAR",
+                                      "GONDOLA",
+                                      "SHARED_CAR",
+                                      "TAXI",
                                       "TRAINISH"
                                     ]
                                   }
@@ -951,8 +953,8 @@
                                 "description": "A mode that involves changing transports",
                                 "type": "string",
                                 "enum": [
-                                  "TRANSFER",
-                                  "LEG_SWITCH"
+                                  "LEG_SWITCH",
+                                  "TRANSFER"
                                 ]
                               }
                             },

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
@@ -97,43 +97,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -150,43 +151,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 "personalMode": {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 "publicTransitMode": {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 "privateTransitMode": {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
@@ -89,43 +89,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -142,43 +143,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 "personalMode": {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 "publicTransitMode": {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 "privateTransitMode": {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1149,43 +1151,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1202,43 +1205,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 "personalMode": {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 "publicTransitMode": {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 "privateTransitMode": {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/prebuilt/tsp/booking-cancel/response.json
+++ b/prebuilt/tsp/booking-cancel/response.json
@@ -82,43 +82,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -135,43 +136,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/booking-create/request.json
+++ b/prebuilt/tsp/booking-create/request.json
@@ -23,43 +23,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -76,43 +77,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/booking-create/response.json
+++ b/prebuilt/tsp/booking-create/response.json
@@ -84,43 +84,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -137,43 +138,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/booking-option.json
+++ b/prebuilt/tsp/booking-option.json
@@ -72,43 +72,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -125,43 +126,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -1045,43 +1047,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -1098,43 +1101,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -1320,43 +1324,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -1373,43 +1378,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/booking-options-list/request.json
+++ b/prebuilt/tsp/booking-options-list/request.json
@@ -19,43 +19,44 @@
           "description": "A mode that involves changing transports",
           "type": "string",
           "enum": [
-            "TRANSFER",
-            "LEG_SWITCH"
+            "LEG_SWITCH",
+            "TRANSFER"
           ]
         },
         {
           "description": "A mode that involves using your personal vehicle or legs",
           "type": "string",
           "enum": [
-            "WALK",
             "BICYCLE",
-            "CAR"
+            "CAR",
+            "WALK"
           ]
         },
         {
           "description": "A mode that involves transit with fixed schedules",
           "type": "string",
           "enum": [
-            "TRAM",
-            "SUBWAY",
-            "RAIL",
+            "AEROPLANE",
             "BUS",
             "FERRY",
-            "TRANSIT",
+            "RAIL",
+            "SUBWAY",
             "TRAIN",
-            "AEROPLANE"
+            "TRAM",
+            "TRANSIT"
           ]
         },
         {
           "description": "A mode that is available on-demand for your personal use",
           "type": "string",
           "enum": [
-            "CAR",
-            "TAXI",
-            "CABLE_CAR",
-            "GONDOLA",
-            "FUNICULAR",
             "BUSISH",
+            "CABLE_CAR",
+            "CAR",
+            "FUNICULAR",
+            "GONDOLA",
+            "SHARED_CAR",
+            "TAXI",
             "TRAINISH"
           ]
         }
@@ -72,43 +73,44 @@
           "description": "A mode that involves changing transports",
           "type": "string",
           "enum": [
-            "TRANSFER",
-            "LEG_SWITCH"
+            "LEG_SWITCH",
+            "TRANSFER"
           ]
         },
         "personalMode": {
           "description": "A mode that involves using your personal vehicle or legs",
           "type": "string",
           "enum": [
-            "WALK",
             "BICYCLE",
-            "CAR"
+            "CAR",
+            "WALK"
           ]
         },
         "publicTransitMode": {
           "description": "A mode that involves transit with fixed schedules",
           "type": "string",
           "enum": [
-            "TRAM",
-            "SUBWAY",
-            "RAIL",
+            "AEROPLANE",
             "BUS",
             "FERRY",
-            "TRANSIT",
+            "RAIL",
+            "SUBWAY",
             "TRAIN",
-            "AEROPLANE"
+            "TRAM",
+            "TRANSIT"
           ]
         },
         "privateTransitMode": {
           "description": "A mode that is available on-demand for your personal use",
           "type": "string",
           "enum": [
-            "CAR",
-            "TAXI",
-            "CABLE_CAR",
-            "GONDOLA",
-            "FUNICULAR",
             "BUSISH",
+            "CABLE_CAR",
+            "CAR",
+            "FUNICULAR",
+            "GONDOLA",
+            "SHARED_CAR",
+            "TAXI",
             "TRAINISH"
           ]
         }

--- a/prebuilt/tsp/booking-options-list/response.json
+++ b/prebuilt/tsp/booking-options-list/response.json
@@ -80,43 +80,44 @@
                     "description": "A mode that involves changing transports",
                     "type": "string",
                     "enum": [
-                      "TRANSFER",
-                      "LEG_SWITCH"
+                      "LEG_SWITCH",
+                      "TRANSFER"
                     ]
                   },
                   {
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -133,43 +134,44 @@
                     "description": "A mode that involves changing transports",
                     "type": "string",
                     "enum": [
-                      "TRANSFER",
-                      "LEG_SWITCH"
+                      "LEG_SWITCH",
+                      "TRANSFER"
                     ]
                   },
                   "personalMode": {
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   "publicTransitMode": {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   "privateTransitMode": {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -1053,43 +1055,44 @@
                     "description": "A mode that involves changing transports",
                     "type": "string",
                     "enum": [
-                      "TRANSFER",
-                      "LEG_SWITCH"
+                      "LEG_SWITCH",
+                      "TRANSFER"
                     ]
                   },
                   {
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -1106,43 +1109,44 @@
                     "description": "A mode that involves changing transports",
                     "type": "string",
                     "enum": [
-                      "TRANSFER",
-                      "LEG_SWITCH"
+                      "LEG_SWITCH",
+                      "TRANSFER"
                     ]
                   },
                   "personalMode": {
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   "publicTransitMode": {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   "privateTransitMode": {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -1328,43 +1332,44 @@
                     "description": "A mode that involves changing transports",
                     "type": "string",
                     "enum": [
-                      "TRANSFER",
-                      "LEG_SWITCH"
+                      "LEG_SWITCH",
+                      "TRANSFER"
                     ]
                   },
                   {
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }
@@ -1381,43 +1386,44 @@
                     "description": "A mode that involves changing transports",
                     "type": "string",
                     "enum": [
-                      "TRANSFER",
-                      "LEG_SWITCH"
+                      "LEG_SWITCH",
+                      "TRANSFER"
                     ]
                   },
                   "personalMode": {
                     "description": "A mode that involves using your personal vehicle or legs",
                     "type": "string",
                     "enum": [
-                      "WALK",
                       "BICYCLE",
-                      "CAR"
+                      "CAR",
+                      "WALK"
                     ]
                   },
                   "publicTransitMode": {
                     "description": "A mode that involves transit with fixed schedules",
                     "type": "string",
                     "enum": [
-                      "TRAM",
-                      "SUBWAY",
-                      "RAIL",
+                      "AEROPLANE",
                       "BUS",
                       "FERRY",
-                      "TRANSIT",
+                      "RAIL",
+                      "SUBWAY",
                       "TRAIN",
-                      "AEROPLANE"
+                      "TRAM",
+                      "TRANSIT"
                     ]
                   },
                   "privateTransitMode": {
                     "description": "A mode that is available on-demand for your personal use",
                     "type": "string",
                     "enum": [
-                      "CAR",
-                      "TAXI",
-                      "CABLE_CAR",
-                      "GONDOLA",
-                      "FUNICULAR",
                       "BUSISH",
+                      "CABLE_CAR",
+                      "CAR",
+                      "FUNICULAR",
+                      "GONDOLA",
+                      "SHARED_CAR",
+                      "TAXI",
                       "TRAINISH"
                     ]
                   }

--- a/prebuilt/tsp/booking-read-by-id/response.json
+++ b/prebuilt/tsp/booking-read-by-id/response.json
@@ -87,43 +87,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -140,43 +141,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/booking-update/response.json
+++ b/prebuilt/tsp/booking-update/response.json
@@ -86,43 +86,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -139,43 +140,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/webhooks-bookings-update/remote-request.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-request.json
@@ -86,43 +86,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }
@@ -139,43 +140,44 @@
               "description": "A mode that involves changing transports",
               "type": "string",
               "enum": [
-                "TRANSFER",
-                "LEG_SWITCH"
+                "LEG_SWITCH",
+                "TRANSFER"
               ]
             },
             "personalMode": {
               "description": "A mode that involves using your personal vehicle or legs",
               "type": "string",
               "enum": [
-                "WALK",
                 "BICYCLE",
-                "CAR"
+                "CAR",
+                "WALK"
               ]
             },
             "publicTransitMode": {
               "description": "A mode that involves transit with fixed schedules",
               "type": "string",
               "enum": [
-                "TRAM",
-                "SUBWAY",
-                "RAIL",
+                "AEROPLANE",
                 "BUS",
                 "FERRY",
-                "TRANSIT",
+                "RAIL",
+                "SUBWAY",
                 "TRAIN",
-                "AEROPLANE"
+                "TRAM",
+                "TRANSIT"
               ]
             },
             "privateTransitMode": {
               "description": "A mode that is available on-demand for your personal use",
               "type": "string",
               "enum": [
-                "CAR",
-                "TAXI",
-                "CABLE_CAR",
-                "GONDOLA",
-                "FUNICULAR",
                 "BUSISH",
+                "CABLE_CAR",
+                "CAR",
+                "FUNICULAR",
+                "GONDOLA",
+                "SHARED_CAR",
+                "TAXI",
                 "TRAINISH"
               ]
             }

--- a/prebuilt/tsp/webhooks-bookings-update/remote-response.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-response.json
@@ -89,43 +89,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -142,43 +143,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 "personalMode": {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 "publicTransitMode": {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 "privateTransitMode": {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1149,43 +1151,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }
@@ -1202,43 +1205,44 @@
                   "description": "A mode that involves changing transports",
                   "type": "string",
                   "enum": [
-                    "TRANSFER",
-                    "LEG_SWITCH"
+                    "LEG_SWITCH",
+                    "TRANSFER"
                   ]
                 },
                 "personalMode": {
                   "description": "A mode that involves using your personal vehicle or legs",
                   "type": "string",
                   "enum": [
-                    "WALK",
                     "BICYCLE",
-                    "CAR"
+                    "CAR",
+                    "WALK"
                   ]
                 },
                 "publicTransitMode": {
                   "description": "A mode that involves transit with fixed schedules",
                   "type": "string",
                   "enum": [
-                    "TRAM",
-                    "SUBWAY",
-                    "RAIL",
+                    "AEROPLANE",
                     "BUS",
                     "FERRY",
-                    "TRANSIT",
+                    "RAIL",
+                    "SUBWAY",
                     "TRAIN",
-                    "AEROPLANE"
+                    "TRAM",
+                    "TRANSIT"
                   ]
                 },
                 "privateTransitMode": {
                   "description": "A mode that is available on-demand for your personal use",
                   "type": "string",
                   "enum": [
-                    "CAR",
-                    "TAXI",
-                    "CABLE_CAR",
-                    "GONDOLA",
-                    "FUNICULAR",
                     "BUSISH",
+                    "CABLE_CAR",
+                    "CAR",
+                    "FUNICULAR",
+                    "GONDOLA",
+                    "SHARED_CAR",
+                    "TAXI",
                     "TRAINISH"
                   ]
                 }

--- a/schemas/core/components/travel-mode.json
+++ b/schemas/core/components/travel-mode.json
@@ -22,53 +22,27 @@
     "waitingMode": {
       "description": "A mode that only involves waiting in the current location",
       "type": "string",
-      "enum": [
-        "WAIT"
-      ]
+      "enum": ["WAIT"]
     },
     "transferMode": {
       "description": "A mode that involves changing transports",
       "type": "string",
-      "enum": [
-        "TRANSFER",
-        "LEG_SWITCH"
-      ]
+      "enum": ["TRANSFER", "LEG_SWITCH"]
     },
     "personalMode": {
       "description": "A mode that involves using your personal vehicle or legs",
       "type": "string",
-      "enum": [
-        "WALK",
-        "BICYCLE",
-        "CAR"
-      ]
+      "enum": ["WALK", "BICYCLE", "CAR"]
     },
     "publicTransitMode": {
       "description": "A mode that involves transit with fixed schedules",
       "type": "string",
-      "enum": [
-        "TRAM",
-        "SUBWAY",
-        "RAIL",
-        "BUS",
-        "FERRY",
-        "TRANSIT",
-        "TRAIN",
-        "AEROPLANE"
-      ]
+      "enum": ["TRAM", "SUBWAY", "RAIL", "BUS", "FERRY", "TRANSIT", "TRAIN", "AEROPLANE"]
     },
     "privateTransitMode": {
       "description": "A mode that is available on-demand for your personal use",
       "type": "string",
-      "enum": [
-        "CAR",
-        "TAXI",
-        "CABLE_CAR",
-        "GONDOLA",
-        "FUNICULAR",
-        "BUSISH",
-        "TRAINISH"
-      ]
+      "enum": ["CAR", "TAXI", "CABLE_CAR", "GONDOLA", "FUNICULAR", "BUSISH", "TRAINISH"]
     }
   }
 }

--- a/schemas/core/components/travel-mode.json
+++ b/schemas/core/components/travel-mode.json
@@ -32,7 +32,16 @@
     "privateTransitMode": {
       "description": "A mode that is available on-demand for your personal use",
       "type": "string",
-      "enum": ["BUSISH", "CABLE_CAR", "CAR", "FUNICULAR", "GONDOLA", "TAXI", "TRAINISH"]
+      "enum": [
+        "BUSISH",
+        "CABLE_CAR",
+        "CAR",
+        "FUNICULAR",
+        "GONDOLA",
+        "SHARED_CAR",
+        "TAXI",
+        "TRAINISH"
+      ]
     }
   }
 }

--- a/schemas/core/components/travel-mode.json
+++ b/schemas/core/components/travel-mode.json
@@ -27,22 +27,22 @@
     "transferMode": {
       "description": "A mode that involves changing transports",
       "type": "string",
-      "enum": ["TRANSFER", "LEG_SWITCH"]
+      "enum": ["LEG_SWITCH", "TRANSFER"]
     },
     "personalMode": {
       "description": "A mode that involves using your personal vehicle or legs",
       "type": "string",
-      "enum": ["WALK", "BICYCLE", "CAR"]
+      "enum": ["BICYCLE", "CAR", "WALK"]
     },
     "publicTransitMode": {
       "description": "A mode that involves transit with fixed schedules",
       "type": "string",
-      "enum": ["TRAM", "SUBWAY", "RAIL", "BUS", "FERRY", "TRANSIT", "TRAIN", "AEROPLANE"]
+      "enum": ["AEROPLANE", "BUS", "FERRY", "RAIL", "SUBWAY", "TRAIN", "TRAM", "TRANSIT"]
     },
     "privateTransitMode": {
       "description": "A mode that is available on-demand for your personal use",
       "type": "string",
-      "enum": ["CAR", "TAXI", "CABLE_CAR", "GONDOLA", "FUNICULAR", "BUSISH", "TRAINISH"]
+      "enum": ["BUSISH", "CABLE_CAR", "CAR", "FUNICULAR", "GONDOLA", "TAXI", "TRAINISH"]
     }
   }
 }

--- a/schemas/core/components/travel-mode.json
+++ b/schemas/core/components/travel-mode.json
@@ -2,21 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Transfer modes used for MaaS internal services",
   "anyOf": [
-    {
-      "$ref": "#/definitions/waitingMode"
-    },
-    {
-      "$ref": "#/definitions/transferMode"
-    },
-    {
-      "$ref": "#/definitions/personalMode"
-    },
-    {
-      "$ref": "#/definitions/publicTransitMode"
-    },
-    {
-      "$ref": "#/definitions/privateTransitMode"
-    }
+    { "$ref": "#/definitions/waitingMode" },
+    { "$ref": "#/definitions/transferMode" },
+    { "$ref": "#/definitions/personalMode" },
+    { "$ref": "#/definitions/publicTransitMode" },
+    { "$ref": "#/definitions/privateTransitMode" }
   ],
   "definitions": {
     "waitingMode": {


### PR DESCRIPTION
As in ALD we expose `meta.MODE_SHARED_CAR` but `leg.mode` still returns `'CAR'`, that feels not consistent.

This change on its own doesn't break anything, change to ALD adapter will be proposed once this one is merged.

Additionally introduced alphabetical order in modes list for better maintanance