### PR TITLE
feat(schemas) Support REJECTED schema for remote request.

### DIFF
--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
@@ -75,7 +75,8 @@
             "CONFIRMED",
             "ACTIVATED",
             "EXPIRED",
-            "CANCELLED"
+            "CANCELLED",
+            "REJECTED"
           ]
         },
         "leg": {

--- a/prebuilt/tsp/webhooks-bookings-update/remote-request.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-request.json
@@ -64,7 +64,8 @@
         "CONFIRMED",
         "ACTIVATED",
         "EXPIRED",
-        "CANCELLED"
+        "CANCELLED",
+        "REJECTED"
       ]
     },
     "leg": {

--- a/schemas/tsp/webhooks-bookings-update/remote-request.json
+++ b/schemas/tsp/webhooks-bookings-update/remote-request.json
@@ -11,7 +11,7 @@
       "$ref": "../../core/booking.json#/properties/cost"
     },
     "state": {
-      "enum": [ "RESERVED", "CONFIRMED", "ACTIVATED", "EXPIRED", "CANCELLED" ]
+      "enum": [ "RESERVED", "CONFIRMED", "ACTIVATED", "EXPIRED", "CANCELLED", "REJECTED" ]
     },
     "leg": {
       "$ref": "../booking-option.json#/definitions/legDelta"


### PR DESCRIPTION
Support REJECTED schema.

Some providers may send refund callback to TSP,  then TSP needs to report status(REJECTED) to backend. 