### PR TITLE
Extend and improve fareRates type

### DIFF
--- a/schemas/core/components/fare-rates.json
+++ b/schemas/core/components/fare-rates.json
@@ -1,0 +1,87 @@
+{
+  "description": "Booking fare rate, describes pricing schema for given product type",
+  "type": "object",
+  "definitions": {
+    "time": {
+      "type": "object",
+      "properties": {
+        "startAt": {
+          "description": "Amount of seconds after this fare rate should be applied to",
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 1
+        },
+        "timeInterval": {
+          "description": "Amount of seconds that fare rate is applied to",
+          "type": "number",
+          "minimum": 1,
+          "multipleOf": 1
+        }
+      },
+      "required": ["timeInterval"]
+    },
+    "amount": {
+      "type": "number",
+      "minimum": 0,
+      "multipleOf": 0.01
+    },
+    "rates": {
+      "description": "List of consequent fare rates to be applied in specified time frames",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "allOf": [
+            { "$ref": "#/definitions/time" },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "maxAmount": {
+                      "description": "Maximum cost that should be charged for given time interval",
+                      "type": "number",
+                      "minimum": 1,
+                      "multipleOf": 0.01
+                    },
+                    "rates": { "$ref": "#/definitions/rates" },
+                    "required": ["rates"]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "amount": { "$ref": "#/definitions/amount" },
+                    "required": ["amount"]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "properties": {
+    "type": "object",
+    "properties": {
+      "currency": { "$ref": "./units.json#/definitions/currency" },
+      "maxTime": {
+        "description": "Maximum allowed time of rental",
+        "type": "number",
+        "minimum": 1,
+        "multipleOf": 1
+      },
+      "maxTimePenaltyAmount": {
+        "description": "Amount of penalty cost if rental will exceed maximum allowed time",
+        "type": "number",
+        "minimum": 0,
+        "multipleOf": 0.01
+      },
+      "rates": { "$ref": "#/definitions/rates" }
+    },
+    "required": ["currency", "rates"]
+  }
+}


### PR DESCRIPTION
Proposed changes:
- Expose definition as an object (switch from array) so we can expose some top level properties. List of fare rates are to be kept at top level  `fares` property (array type)
- Mention `currency` once (and not among each fare item) as top level property
- Introduce `maxTime` top level property (maximum allowed rental time)
- Introduce `maxTimePenaltyAmount` top level property (penalty to pay if rental time exceeds max time)
- No need to list _initial free time_ fare (allow to make first fare have e.g. `startTime: 1800`)
- Support nesting of `fares` gruop  to allow repeteable fare patterns (Nextbike case)
- Support `maxAmount` property on `fares` group (to support case as 1 GBP per hour but not more than 10 GBP per day)

Pushed schema that I believe covers that.

Having that, configuration for existing bike services may look like:

### Nextbike

```json
{
  "currency": "GBP",
  "rates": [
    {
      "timeInterval": 86400,
      "maxAmount": 10,
      "rates": [
        {
          "timeInterval": 1800,
          "amount": 1
        }
      ]
    }
  ]
}
```

### Citybikes

```json
{
  "currency": "EUR",
  "maxTime": 18000,
  "maxTimePenaltyAmount": 80,
  "rates": [
    {
      "startAt": 1800,
      "timeInterval": 1800,
      "amount": 1
    }
  ]
}

```