### PR TITLE
feat(ticket): support token data path

### DIFF
--- a/prebuilt/core/booking.json
+++ b/prebuilt/core/booking.json
@@ -429,7 +429,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2245,7 +2251,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-agency-options/response.json
@@ -442,7 +442,13 @@
               },
               "data": {
                 "description": "Arbitrary ticket data for the client",
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "ticket": {
+                    "type": "string",
+                    "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                  }
+                }
               },
               "meta": {
                 "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2249,7 +2255,13 @@
               },
               "data": {
                 "description": "Arbitrary ticket data for the client",
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "ticket": {
+                    "type": "string",
+                    "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                  }
+                }
               },
               "meta": {
                 "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-cancel/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-cancel/response.json
@@ -436,7 +436,13 @@
                 },
                 "data": {
                   "description": "Arbitrary ticket data for the client",
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ticket": {
+                      "type": "string",
+                      "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                    }
+                  }
                 },
                 "meta": {
                   "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2252,7 +2258,13 @@
                 },
                 "data": {
                   "description": "Arbitrary ticket data for the client",
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ticket": {
+                      "type": "string",
+                      "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                    }
+                  }
                 },
                 "meta": {
                   "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-create/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/request.json
@@ -441,7 +441,13 @@
                 },
                 "data": {
                   "description": "Arbitrary ticket data for the client",
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ticket": {
+                      "type": "string",
+                      "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                    }
+                  }
                 },
                 "meta": {
                   "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2257,7 +2263,13 @@
                 },
                 "data": {
                   "description": "Arbitrary ticket data for the client",
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ticket": {
+                      "type": "string",
+                      "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                    }
+                  }
                 },
                 "meta": {
                   "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-create/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-create/response.json
@@ -435,7 +435,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2251,7 +2257,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-list/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-list/response.json
@@ -438,7 +438,13 @@
               },
               "data": {
                 "description": "Arbitrary ticket data for the client",
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "ticket": {
+                    "type": "string",
+                    "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                  }
+                }
               },
               "meta": {
                 "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2254,7 +2260,13 @@
               },
               "data": {
                 "description": "Arbitrary ticket data for the client",
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "ticket": {
+                    "type": "string",
+                    "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                  }
+                }
               },
               "meta": {
                 "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-retrieve/response.json
@@ -435,7 +435,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2251,7 +2257,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-update/request.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/request.json
@@ -444,7 +444,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2260,7 +2266,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/bookings/bookings-update/response.json
+++ b/prebuilt/maas-backend/bookings/bookings-update/response.json
@@ -435,7 +435,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2251,7 +2257,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/request.json
@@ -1056,7 +1056,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
+++ b/prebuilt/maas-backend/webhooks/webhooks-bookings-update/response.json
@@ -1065,7 +1065,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2231,7 +2237,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/booking-cancel/response.json
+++ b/prebuilt/tsp/booking-cancel/response.json
@@ -1052,7 +1052,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/booking-create/response.json
+++ b/prebuilt/tsp/booking-create/response.json
@@ -1054,7 +1054,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/booking-read-by-id/response.json
+++ b/prebuilt/tsp/booking-read-by-id/response.json
@@ -1045,7 +1045,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/booking-ticket/request.json
+++ b/prebuilt/tsp/booking-ticket/request.json
@@ -50,7 +50,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/booking-update/response.json
+++ b/prebuilt/tsp/booking-update/response.json
@@ -1044,7 +1044,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/webhooks-bookings-update/remote-request.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-request.json
@@ -1045,7 +1045,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/prebuilt/tsp/webhooks-bookings-update/remote-response.json
+++ b/prebuilt/tsp/webhooks-bookings-update/remote-response.json
@@ -1065,7 +1065,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
@@ -2231,7 +2237,13 @@
             },
             "data": {
               "description": "Arbitrary ticket data for the client",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+                }
+              }
             },
             "meta": {
               "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",

--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -153,7 +153,13 @@
         },
         "data": {
           "description": "Arbitrary ticket data for the client",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "description": "Ticket path used by client to fetch ticket body (e.g ticket.html)"
+            }
+          }
         },
         "meta": {
           "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",


### PR DESCRIPTION
Added ticket to `token.data` so it's clear which field to use for ticket path.