### PR TITLE
Correct exit code returned when tests fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "gulp validate",
-    "test": "gulp test",
+    "test": "jest",
     "watch": "gulp watch",
     "build": "gulp"
   },
@@ -44,8 +44,8 @@
     "gulp-jsonschema-deref": "0.0.2",
     "gulp-mocha": "^3.0.1",
     "gulp-transform": "^1.1.0",
-    "jest": "^21.2.1",
-    "jest-cli": "^21.2.1",
+    "jest": "^22.4.3",
+    "jest-cli": "^22.4.3",
     "jsonpath": "^0.2.11",
     "mocha": "^2.5.3",
     "regexpu-core": "^4.1.3"


### PR DESCRIPTION
Gulp-jest plugin returns always with exit code 0, causing Travis to show build passed when in reality tests failed. This is fixed by invoking jest directly instead of through Gulp.