### PR TITLE
feat(tspProductIds-to-tsp)

### DIFF
--- a/prebuilt/tsp/booking-options-list/request.json
+++ b/prebuilt/tsp/booking-options-list/request.json
@@ -229,6 +229,11 @@
       "description": "An arbitrary string passed on a per-TSP basis, e.g. user's subscription period",
       "type": "string",
       "minLength": 0
+    },
+    "tspProductIds": {
+      "description": "Comma-separated list of tspProductIds that the user has access to",
+      "type": "string",
+      "minLength": 0
     }
   },
   "required": [

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -87,6 +87,11 @@
       "description": "An arbitrary string passed on a per-TSP basis, e.g. user's subscription period",
       "type": "string",
       "minLength": 0
+    },
+    "tspProductIds": {
+      "description": "Comma-separated list of tspProductIds that the user has access to",
+      "type": "string",
+      "minLength": 0
     }
   },
   "required": ["startTime", "from"],


### PR DESCRIPTION
 Extend tsp booking-options-list query to allow tspProductIds field.
This is to allow the backend to indicate to the tsp which products it is interested in.