### PR TITLE
Add customer data schemas for the TSP side

### DIFF
--- a/schemas/core/components/units.json
+++ b/schemas/core/components/units.json
@@ -57,11 +57,43 @@
       "minLength": 1,
       "maxLength": 1024
     },
+    "isoDate": {
+      "description": "A date in the form YYYY-MM-DD without a time component",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+    },
     "htmlBlock": {
       "description": "HTML string of block level content",
       "type": "string",
       "pattern":
-        "^\\s*<(?:address|arcticle|aside|blockquote|div|dl|figcaption|figure|h1|h2|h3|h4|h5|h6|header|hgroup|main|nav|ol|output|p|pre|section|table|ul|video)>.*>\\s*$"
+        "^\\s*<(?:address|article|aside|blockquote|div|dl|figcaption|figure|h1|h2|h3|h4|h5|h6|header|hgroup|main|nav|ol|output|p|pre|section|table|ul|video)>.*>\\s*$"
+    },
+    "jsonParam": {
+      "description": "JSON encoded object or array",
+      "type": "string",
+      "minLength": "2"
+    },
+    "personalName": {
+      "description": "First or last name of a customer (e.g. John)",
+      "type": "string",
+      "pattern": "^(?:\\p{L})+(?:[`'´\\-\\.,]?\\s?(?:\\p{L})*)*$",
+      "maxLength": 255
+    },
+    "phone": {
+      "description": "ITU-T E.164 phone number, see https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s03.html",
+      "type": "string",
+      "pattern": "^\\+(?:\\d){6,14}\\d$"
+    },
+    "rawPhone": {
+      "description": "Slightly looser definition of phone number",
+      "type": "string",
+      "pattern": "^\\+?(?:\\d){6,14}\\d$"
+    },
+    "email": {
+      "description": "Rough validation of a valid e-mail address, see https://davidcel.is/posts/stop-validating-email-addresses-with-regex/",
+      "type": "string",
+      "pattern": "^.+@.+\\..+$",
+      "maxLength": 64
     }
   }
 }

--- a/schemas/core/customer.json
+++ b/schemas/core/customer.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "MaaS customer schema",
+  "type": "object",
+  "properties": {
+    "opaqueId": {
+      "description": "Typically the hash of the identityId",
+      "type": "string",
+      "pattern": "^[0-9abcdefABCDEF]+$"
+    },
+    "locale": {
+      "$ref": "./i18n.json#/definitions/locale"
+    },
+    "firstName": {
+      "description": "First name of the customer (e.g. John)",
+      "$ref": "./components/units.json#/definitions/personalName"
+    },
+    "lastName": {
+      "description": "Last name of the customer (e.g. Doe)",
+      "$ref": "./components/units.json#/definitions/personalName"
+    },
+    "phone": {
+      "description": "ITU-T E.164 phone number",
+      "$ref": "./components/units.json#/definitions/phone"
+    },
+    "rawPhone": {
+      "description": "Slightly looser definition of phone number",
+      "$ref": "./components/units.json#/definitions/rawPhone"
+    },
+    "email": {
+      "description": "Rough validation of a valid e-mail address",
+      "$ref": "./components/units.json#/definitions/email"
+    },
+    "note": {
+      "description": "A general purpose text string forwarded to the TSP if appropriate",
+      "type": "string",
+      "minLength": 0
+    },
+    "dob": {
+      "description": "The customer's date of birth",
+      "$ref": "./components/units.json#/definitions/isoDate"
+    },
+    "hasSubscription": {
+      "description": "Whether the customer has a recurring subscription",
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/tsp/booking-create/request.json
+++ b/schemas/tsp/booking-create/request.json
@@ -31,7 +31,8 @@
     "meta",
     "terms",
     "customer",
-    "tspProduct"
+    "tspProduct",
+    "customer"
   ],
   "additionalProperties": true
 }

--- a/schemas/tsp/booking-create/response.json
+++ b/schemas/tsp/booking-create/response.json
@@ -33,6 +33,9 @@
     },
     "customerSelection": {
       "$ref": "../../core/components/configurator.json#/definitions/customerSelection"
+    },
+    "customer": {
+      "$ref": "../../core/customer.json"
     }
   },
   "required": ["tspId", "state", "meta", "terms", "token", "tspProduct" ],

--- a/schemas/tsp/booking-option.json
+++ b/schemas/tsp/booking-option.json
@@ -37,6 +37,10 @@
       },
       "cost": {
         "$ref": "../core/components/cost.json"
+      },
+      "customer": {
+        "description": "MaaS customer data",
+        "$ref": "../core/customer.json"
       }
     },
     "leg": {

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -92,6 +92,10 @@
       "description": "Comma-separated list of tspProductIds that the user has access to",
       "type": "string",
       "minLength": 0
+    },
+    "customer": {
+      "description": "JSON encoded object which should be validated against /core/customer.json schema",
+      "$ref": "../../core/components/units.json#/definitions/jsonParam"
     }
   },
   "required": ["startTime", "from"],

--- a/schemas/tsp/webhooks-bookings-update/remote-response.json
+++ b/schemas/tsp/webhooks-bookings-update/remote-response.json
@@ -42,7 +42,7 @@
           "$ref": "../../core/booking.json#/definitions/token"
         },
         "customer": {
-          "$ref": "../../core/components/customer.json",
+          "$ref": "../../core/customer.json",
           "required": ["firstName", "lastName", "phone", "email"]
         }
       },

--- a/test/schemas/core/customer.js
+++ b/test/schemas/core/customer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const schema = require('../../../prebuilt/core/components/customer.json');
+const schema = require('../../../prebuilt/core/customer.json');
 const { generateTestCases } = require('../../../test-lib');
 
 describe('customer.firstName', () => {


### PR DESCRIPTION
This time, `schemas/tsp/webhooks-bookings-update/remote-response.json` does not make the new `locale` and `opaqueId` fields required.
