### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## What has been implemented?
+
+## Todos:
+* [ ] Write tests
+
+## Versioning:
+* [ ] Breaking change

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "validator.js",
   "engine": {


### PR DESCRIPTION
This will bump version to 1.0.0. After this is merged and the package is published, semantic versioning has to be used when releasing a new package.