### PR TITLE
Alter terms.seating schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "validator.js",
   "engine": {

--- a/schemas/core/components/terms.json
+++ b/schemas/core/components/terms.json
@@ -8,16 +8,11 @@
       "minLength": 0,
       "maxLength": 64
     },
-    "seating": {
-      "description": "Ticket's seat information for long distance trains, coaches or flights",
-      "type": "object",
-      "properties": {
-        "number": {
-          "type": ["string", "number"]
-        },
-        "coach": {
-          "type": ["string", "number"]
-        }
+    "seatings": {
+      "description": "In 1 booking for a journey, it can be valid for many of the journey's leg. Each item of seating is a seat on 1 specific route",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/seat"
       }
     },
     "validity": {
@@ -85,5 +80,25 @@
       }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "definitions": {
+    "seat": {
+      "description": "Ticket's seat information for long distance trains, coaches or flights",
+      "type": "object",
+      "properties": {
+        "route": {
+          "description": "The leg's route number that this seat info belongs",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "number": {
+          "type": ["string", "number"]
+        },
+        "coach": {
+          "type": ["string", "number"]
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What has been implemented?

Alter `terms.seat` to `terms.seating`
Explanation: 1 booking can be valid for multiple legs, therefore it can be valid also for multiple different seat numbers

## Todos:
* [ ] Write tests

## Versioning:
* [ ] Breaking change
