### PR TITLE
Fix mode-rail property name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "validator.js",
   "engine": {

--- a/schemas/core/modes/MODE_RAIL.json
+++ b/schemas/core/modes/MODE_RAIL.json
@@ -44,7 +44,7 @@
         "stationId": {
           "$ref": "../components/station.json#/definitions/id"
         },
-        "alternateCollections": {
+        "alternativeCollections": {
           "type": "string"
         }
       }


### PR DESCRIPTION
## What has been implemented?
Fix property name `alternateCollections` to `alternativeCollections` in mode `RAIL`

## Versioning:
* [x] Breaking change
This is breaking change (fix) to a schema part that is not used in production, for this reason doing only patch bump in version.
