### PR TITLE
feat(hertz-singapore): Added support for Singapore currency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/units.json
+++ b/schemas/core/components/units.json
@@ -27,7 +27,7 @@
     "currency": {
       "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
       "type": "string",
-      "enum": [ "EUR", "GBP" ]
+      "enum": [ "EUR", "GBP", "SGD" ]
     },
     "agencyId": {
       "type": "string",


### PR DESCRIPTION
## What has been implemented?

Added support for 'SGD' currency  - Singapore dollar which is required for our new TSP Singapore Hertz.
