### PR TITLE
Use api-common headers definition instead of separate accept and user agent

### DIFF
--- a/schemas/maas-backend/itineraries/itinerary-retrieve/request.json
+++ b/schemas/maas-backend/itineraries/itinerary-retrieve/request.json
@@ -7,12 +7,7 @@
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": [ "itineraryId" ],

--- a/schemas/maas-backend/products/products-providers-options/request.json
+++ b/schemas/maas-backend/products/products-providers-options/request.json
@@ -10,12 +10,7 @@
       "$ref": "#/definitions/payload"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["identityId", "payload"],

--- a/schemas/maas-backend/products/products-providers-retrieve/request.json
+++ b/schemas/maas-backend/products/products-providers-retrieve/request.json
@@ -10,12 +10,7 @@
       "$ref": "#/definitions/payload"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["identityId", "payload"],

--- a/schemas/maas-backend/profile/profile-devices-put/request.json
+++ b/schemas/maas-backend/profile/profile-devices-put/request.json
@@ -27,12 +27,7 @@
       "additionalProperties": false
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "additionalProperties": false

--- a/schemas/maas-backend/profile/profile-favoriteLocations-add/request.json
+++ b/schemas/maas-backend/profile/profile-favoriteLocations-add/request.json
@@ -10,12 +10,7 @@
       "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/place"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "additionalProperties": false

--- a/schemas/maas-backend/regions/regions-options/request.json
+++ b/schemas/maas-backend/regions/regions-options/request.json
@@ -7,12 +7,7 @@
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["identityId"],

--- a/schemas/maas-backend/routes/routes-query/request.json
+++ b/schemas/maas-backend/routes/routes-query/request.json
@@ -10,12 +10,7 @@
       "$ref": "#/definitions/payload"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["identityId", "payload"],

--- a/schemas/maas-backend/stations/stations-list/request.json
+++ b/schemas/maas-backend/stations/stations-list/request.json
@@ -55,12 +55,7 @@
       ]
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["identityId", "payload"],

--- a/schemas/maas-backend/stations/stations-retrieve/request.json
+++ b/schemas/maas-backend/stations/stations-retrieve/request.json
@@ -19,12 +19,7 @@
       }
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["identityId", "payload"],

--- a/schemas/maas-backend/subscriptions/subscriptions-customer-retrieve/request.json
+++ b/schemas/maas-backend/subscriptions/subscriptions-customer-retrieve/request.json
@@ -10,12 +10,7 @@
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["customerId"],

--- a/schemas/maas-backend/subscriptions/subscriptions-estimate/request.json
+++ b/schemas/maas-backend/subscriptions/subscriptions-estimate/request.json
@@ -19,12 +19,7 @@
       "$ref": "http://maasglobal.com/maas-backend/subscriptions/subscription.json#/definitions/subscriptionBase"
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["customerId", "userId", "payload"],

--- a/schemas/maas-backend/subscriptions/subscriptions-retrieve/request.json
+++ b/schemas/maas-backend/subscriptions/subscriptions-retrieve/request.json
@@ -14,12 +14,7 @@
       "default": false
     },
     "headers": {
-      "Accept": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/acceptHeader"
-      },
-      "X-Whim-User-Agent": {
-        "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/userAgentHeader"
-      }
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "required": ["customerId", "userId"],


### PR DESCRIPTION
## What has been implemented?'

In some places, where api-common `headers` definitions can be used `Accept` and `X-Whim-User-Agent` are separately defined. This PR changes those to use api-common `headers` definition.

## Todos:
* [ ] Write tests

## Versioning:
* [ ] Breaking change
