### PR TITLE
v2 bookings create request and response schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/units.json
+++ b/schemas/core/components/units.json
@@ -92,6 +92,11 @@
       "type": "string",
       "pattern": "^.+@.+\\..+$",
       "maxLength": 64
+    },
+    "paymentSourceId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
     }
   }
 }

--- a/schemas/maas-backend/bookings/v2/bookings-create/request.json
+++ b/schemas/maas-backend/bookings/v2/bookings-create/request.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://maasglobal.com/maas-backend/bookings/v2/bookings-create/request.json",
+  "description": "Request schema for bookings-create v2",
+  "type": "object",
+  "properties": {
+    "identityId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "paymentSourceId": {
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/paymentSourceId"
+        },
+        "booking": {
+          "$ref": "http://maasglobal.com/maas-backend/bookings/bookings-agency-options/response.json#/definitions/option"
+        },
+        "customerSelection": {
+          "$ref": "http://maasglobal.com/core/components/configurator.json#/definitions/customerSelection"
+        }
+      },
+      "required": [ "paymentSourceId" ]
+    },
+    "headers": {
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
+    }
+  },
+  "required": [ "identityId", "payload" ],
+  "additionalProperties": false
+}

--- a/schemas/maas-backend/bookings/v2/bookings-create/response.json
+++ b/schemas/maas-backend/bookings/v2/bookings-create/response.json
@@ -1,0 +1,16 @@
+{
+  "$id": "http://maasglobal.com/maas-backend/bookings/v2/bookings-create/response.json",
+  "description": "Response schema for bookings-create v2",
+  "type": "object",
+  "properties": {
+    "booking": {
+      "$ref": "http://maasglobal.com/core/booking.json"
+    },
+    "debug": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": ["booking"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Request and response schema for bookings create v2.
Major difference to v1 is mandatory paymentSourceId.