### PR TITLE
Support querying station with new type viaavoid

### DIFF
--- a/schemas/maas-backend/stations/stations-list/request.json
+++ b/schemas/maas-backend/stations/stations-list/request.json
@@ -26,7 +26,7 @@
               "minimum": 0
             },
             "type": {
-              "enum": ["origin", "destination"]
+              "enum": ["origin", "destination", "viaAvoid"]
             }
           },
           "required": ["agencyId", "lat", "lon", "type"]
@@ -47,7 +47,7 @@
               "minimum": 1
             },
             "type": {
-              "enum": ["origin", "destination"]
+              "enum": ["origin", "destination", "viaAvoid"]
             }
           },
           "required": ["agencyId", "name", "count", "type"]


### PR DESCRIPTION
## What has been implemented?
New stations endpoint type for querying name `viaavoid`