### PR TITLE
Add optional radius property to product provider schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/products/provider.json
+++ b/schemas/maas-backend/products/provider.json
@@ -67,36 +67,42 @@
       ],
       "additionalProperties": false
     },
-    "radius": {
+    "extra": {
       "type": "object",
       "properties": {
-        "fixedFareAmount": {
-          "description": "The amount of the maximum fixed fare",
-          "type": "number",
-          "minimum": 0,
-          "multipleOf": 0.01
-        },
-        "fixedFareCurrency": {
-          "oneOf": [
-            {
-              "description": "The currency of the maximum fixed fare",
-              "$ref": "http://maasglobal.com/core/components/units.json#/definitions/currency"
+        "radius": {
+          "type": "object",
+          "properties": {
+            "fixedFareAmount": {
+              "description": "The amount of the maximum fixed fare",
+              "type": "number",
+              "minimum": 0,
+              "multipleOf": 0.01
             },
-            {
-              "type": "string",
-              "enum": [
-                "WMP",
-                "TOKEN"
+            "fixedFareCurrency": {
+              "oneOf": [
+                {
+                  "description": "The currency of the maximum fixed fare",
+                  "$ref": "http://maasglobal.com/core/components/units.json#/definitions/currency"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "WMP",
+                    "TOKEN"
+                  ]
+                }
               ]
+            },
+            "maxRadiusMetres": {
+              "description": "The maximum radius to which the maximum fixed fare applies",
+              "type": "integer",
+              "minValue": 0
             }
-          ]
-        },
-        "maxRadiusMetres": {
-          "description": "The maximum radius to which the maximum fixed fare applies",
-          "type": "integer",
-          "minValue": 0
+          }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "optionalParameters": {
       "type": "array",

--- a/schemas/maas-backend/products/provider.json
+++ b/schemas/maas-backend/products/provider.json
@@ -67,6 +67,37 @@
       ],
       "additionalProperties": false
     },
+    "radius": {
+      "type": "object",
+      "properties": {
+        "fixedFareAmount": {
+          "description": "The amount of the maximum fixed fare",
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 0.01
+        },
+        "fixedFareCurrency": {
+          "oneOf": [
+            {
+              "description": "The currency of the maximum fixed fare",
+              "$ref": "http://maasglobal.com/core/components/units.json#/definitions/currency"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "WMP",
+                "TOKEN"
+              ]
+            }
+          ]
+        },
+        "maxRadiusMetres": {
+          "description": "The maximum radius to which the maximum fixed fare applies",
+          "type": "integer",
+          "minValue": 0
+        }
+      }
+    },
     "optionalParameters": {
       "type": "array",
       "items": {

--- a/schemas/maas-backend/products/provider.json
+++ b/schemas/maas-backend/products/provider.json
@@ -95,11 +95,17 @@
               ]
             },
             "maxRadiusMetres": {
-              "description": "The maximum radius to which the maximum fixed fare applies",
+              "description": "The maximum radius to which the maximum fixed fare applies, in metres",
               "type": "integer",
               "minValue": 0
             }
-          }
+          },
+          "required": [
+            "fixedFareAmount",
+            "fixedFareCurrency",
+            "maxRadiusMetres"
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## What has been implemented?
A radius property for product provider, to support 5km indicator circles for taxis