### PR TITLE
Remove legGeometry and recognize distance in options requests

### DIFF
--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -79,8 +79,8 @@
       "description": "'to' location radius in meters",
       "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
     },
-    "legGeometry": {
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/polyline"
+    "distance": {
+      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
     },
     "extraOptions": {
       "description": "An arbitrary string passed on a per-TSP basis, e.g. user's subscription period",


### PR DESCRIPTION
`legGeometry` appeared too large for requests, while original use case was to obtain a distance

This PR is just to maintain consistency, as otherwise changes in [TSP adapters](https://github.com/maasglobal/maas-transport-booking/pull/734) and [Backend](https://github.com/maasglobal/maas-backend/pull/1818) are fine without it