### PR TITLE
Ensure initialized schema is in all cases the same

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,11 @@ const ajv = new AJV();
 gulp.task('ajv-validate', () => {
   const schemas = fg.sync(['schemas/**/*.json'], { absolute: true });
   // Add to cache first
+  // eslint-disable-next-line import/no-dynamic-require
   schemas.forEach(schema => ajv.addSchema(require(schema)));
 
   // Validate that all schemas work properly with refs
+  // eslint-disable-next-line import/no-dynamic-require
   schemas.forEach(schema => ajv.compile(require(schema)));
 });
 

--- a/index.js
+++ b/index.js
@@ -9,16 +9,16 @@ let ajv;
 
 function init() {
   ajv = new AJV({
-    verbose: true,
-    allErrors: true,
-    validateSchema: false,
     addUsedSchema: false,
-    meta: false,
-    inlineRefs: false,
-    sourceCode: false,
+    allErrors: true,
     errorDataPath: 'property',
+    inlineRefs: false,
+    meta: false,
     multipleOfPrecision: 6,
     sanitize: false,
+    sourceCode: false,
+    validateSchema: false,
+    verbose: true,
   });
 
   Object.keys(registry).forEach(key => {

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function init() {
     inlineRefs: false,
     meta: false,
     multipleOfPrecision: 6,
+    removeAdditional: true,
     sanitize: false,
     sourceCode: false,
     validateSchema: false,

--- a/index.js
+++ b/index.js
@@ -7,24 +7,19 @@ const registry = require('./registry.js');
 
 let ajv;
 
-function init(options) {
-  ajv = new AJV(
-    Object.assign(
-      {
-        verbose: true,
-        allErrors: true,
-        validateSchema: false,
-        addUsedSchema: false,
-        meta: false,
-        inlineRefs: false,
-        sourceCode: false,
-        errorDataPath: 'property',
-        multipleOfPrecision: 6,
-        sanitize: false,
-      },
-      options
-    )
-  );
+function init() {
+  ajv = new AJV({
+    verbose: true,
+    allErrors: true,
+    validateSchema: false,
+    addUsedSchema: false,
+    meta: false,
+    inlineRefs: false,
+    sourceCode: false,
+    errorDataPath: 'property',
+    multipleOfPrecision: 6,
+    sanitize: false,
+  });
 
   Object.keys(registry).forEach(key => {
     const schema = registry[key];
@@ -38,7 +33,7 @@ function init(options) {
  * @param {Object} schema - schema json required from /schemas folder
  */
 function validate(schema, object, options = {}) {
-  if (!ajv) init(options);
+  if (!ajv) init();
   if (options.sanitize === true) {
     object = validator.sanitize(object);
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fast-glob": "^2.2.2"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "eslint": "^3.1.1",
     "eslint-config-airbnb-base": "^5.0.0",
     "eslint-plugin-import": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "eslint": "^5.6",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14",
-    "glob": "^7.0.5",
+    "glob": "^7.1.3",
     "gulp": "^3.9.1",
     "gulp-eslint": "5",
-    "gulp-jest": "^2.0.0",
+    "gulp-jest": "^4.0.2",
     "gulp-json-lint": "^0.1.0",
     "gulp-jsonlint": "^1.2.2",
-    "jest": "^22.4.3",
-    "jest-cli": "^22.4.3"
+    "jest": "^23.6",
+    "jest-cli": "^23.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/maasglobal/maas-schemas#readme",
   "dependencies": {
-    "ajv": "^6.5.2",
+    "ajv": "^6.5.4",
     "fast-glob": "^2.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,15 +38,15 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^3.1.1",
-    "eslint-config-airbnb-base": "^5.0.0",
-    "eslint-plugin-import": "^1.11.1",
+    "eslint": "^5.6",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.14",
     "glob": "^7.0.5",
     "gulp": "^3.9.1",
-    "gulp-eslint": "^3.0.1",
+    "gulp-eslint": "5",
     "gulp-jest": "^2.0.0",
     "gulp-json-lint": "^0.1.0",
-    "gulp-jsonlint": "^1.1.2",
+    "gulp-jsonlint": "^1.2.2",
     "jest": "^22.4.3",
     "jest-cli": "^22.4.3"
   }

--- a/test-lib.js
+++ b/test-lib.js
@@ -9,7 +9,7 @@ function generateTestCases(schema, positive, cases) {
   if (positive) {
     it('positive cases', () => {
       cases.forEach(value => {
-        expect(main.validate(transform(schema), value)).to.be.an.object;
+        expect(main.validate(transform(schema), value)).to.exist;
       });
     });
   } else {

--- a/test/feature-require-schemas.js
+++ b/test/feature-require-schemas.js
@@ -7,31 +7,28 @@ const ajvFactory = require('ajv');
 
 const ajv = ajvFactory({ allErrors: true });
 
-const globPromise = (pattern, options) => (
-  new Promise((resolve, reject) => {
-    glob(pattern, options || {}, (err, matches) => {
-      if (err) return reject(err);
-      return resolve(matches);
-    });
-  })
-);
+const globPromise = (pattern, options) => new Promise((resolve, reject) => {
+  glob(pattern, options || {}, (err, matches) => {
+    if (err) return reject(err);
+    return resolve(matches);
+  });
+});
 
 describe('Source schemas should be valid JSON Schemas', () => {
   before(() => {
-    return globPromise('schemas/**/*.json')
-      .then(schemaPaths => {
-        describe(`Validate ${schemaPaths.length} schemas`, () => {
-          schemaPaths.forEach(schemaPath => {
-            it(`should be a able to require a valid schema ${schemaPath}`, () => {
-              const filePath = path.resolve(__dirname, '..', schemaPath);
-              const schema = require(filePath);
-              const valid = ajv.validateSchema(schema);
-              expect(ajv.errors || []).to.eql([]);
-              expect(valid).to.be.true;
-            });
+    return globPromise('schemas/**/*.json').then(schemaPaths => {
+      describe(`Validate ${schemaPaths.length} schemas`, () => {
+        schemaPaths.forEach(schemaPath => {
+          it(`should be a able to require a valid schema ${schemaPath}`, () => {
+            const filePath = path.resolve(__dirname, '..', schemaPath);
+            const schema = require(filePath);
+            const valid = ajv.validateSchema(schema);
+            expect(ajv.errors || []).to.eql([]);
+            expect(valid).to.be.true;
           });
         });
       });
+    });
   });
 
   it('[placeholder to trigger before()]', () => {

--- a/test/feature-require-schemas.js
+++ b/test/feature-require-schemas.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const glob = require('glob');
 const ajvFactory = require('ajv');
 
@@ -21,6 +21,7 @@ describe('Source schemas should be valid JSON Schemas', () => {
         schemaPaths.forEach(schemaPath => {
           it(`should be a able to require a valid schema ${schemaPath}`, () => {
             const filePath = path.resolve(__dirname, '..', schemaPath);
+            // eslint-disable-next-line import/no-dynamic-require
             const schema = require(filePath);
             const valid = ajv.validateSchema(schema);
             expect(ajv.errors || []).to.eql([]);

--- a/test/feature-validate.js
+++ b/test/feature-validate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const utils = require('..');
 const bookingOptionsRequest = require('./valid-booking-options-request.json');
 const bookingOptionsResponse = require('./valid-booking-options-response.json');

--- a/test/schemas/core/address.js
+++ b/test/schemas/core/address.js
@@ -105,8 +105,8 @@ describe('address.city', () => {
     '💩',
     '',
     // Too long
-    'LRuwGi4XRMVgImvVm7OEsw58YBDsUsApuKGXrjAcQi9QDEWwFYUp2yrzspe2WHu5rGuFoSU6TKeFIf73QjEnzv5Lq6' +
-      'Wu1YTJAbN2bZws8SfwhEoDInr6K3zTgmFQEQnzaDheGZtO4IMzAGoDSUx2zw1Lv4inpE4uq6NBYELaSusrlxGM0p' +
-      'JEiUrYZwIlzGAS4MgRrOKfZIyuZLH9gARtzyKvstQZw9bMmnRE8yWPTNGKlWmYBHLjMTluZp5AcpbU',
+    'LRuwGi4XRMVgImvVm7OEsw58YBDsUsApuKGXrjAcQi9QDEWwFYUp2yrzspe2WHu5rGuFoSU6TKeFIf73QjEnzv5Lq6'
+      + 'Wu1YTJAbN2bZws8SfwhEoDInr6K3zTgmFQEQnzaDheGZtO4IMzAGoDSUx2zw1Lv4inpE4uq6NBYELaSusrlxGM0p'
+      + 'JEiUrYZwIlzGAS4MgRrOKfZIyuZLH9gARtzyKvstQZw9bMmnRE8yWPTNGKlWmYBHLjMTluZp5AcpbU',
   ]);
 });


### PR DESCRIPTION
Currently shape of used schema is influenced by options send with first schema validation.

All following validations rely on schemas compiled with previously passed options ignoring possibly different options send  in other validation cases. That makes validation not deterministic (e.g. schemas  may validate fine in tests but fail in lambda environment, and other way)

We discussed that  at https://maasfi.slack.com/archives/C5K4W0LSX/p1537864610000100
and decided that initialized schema should not accept input options, and in all cases result with same version of compiled schema. This patch brings that change.

This change may be breaking, and may require further adjustments in `maas-backend` and `maas-transport-booking` projects, therefore it was marked with major bump.

Additionally all dependencies were upgraded to latest versions (that required small adjustments to chai usage, and few lint fixes)