### PR TITLE
Adds error name

### DIFF
--- a/lib/ValidationError.js
+++ b/lib/ValidationError.js
@@ -27,6 +27,7 @@ class ValidationError extends Error {
 
     this.object = object;
     this.errors = errors;
+    this.name = 'ValidationError';
   }
   /**
    * Factory to instantiate a ValidationError from AJV validation error array

--- a/test/feature-validate.js
+++ b/test/feature-validate.js
@@ -33,6 +33,7 @@ describe('Schema validation', () => {
       try {
         expect(utils.validate(schema, invalidBookingResponse)).to.not.exist;
       } catch (e) {
+        expect(e.name).to.equal('ValidationError');
         expect(e).to.exist;
       }
     });


### PR DESCRIPTION
## What has been implemented?
This PR will change the name of the error from `Error` to `ValidationError`. This is a breaking change -> if someone is expecting the ValidationError name to be `Error` as in default Error.

This will help in the cases where validation error will be handled differently than other errors that might occure in the same try block.

## Todos:
* [x] Write tests

## Versioning:
* [x] Breaking change
