### PR TITLE
Ensure commonly used options in generated schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function init() {
   ajv = new AJV({
     addUsedSchema: false,
     allErrors: true,
+    coerceTypes: true,
     errorDataPath: 'property',
     inlineRefs: false,
     meta: false,
@@ -18,6 +19,7 @@ function init() {
     removeAdditional: true,
     sanitize: false,
     sourceCode: false,
+    useDefaults: true,
     validateSchema: false,
     verbose: true,
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {


### PR DESCRIPTION
It's an errata to https://github.com/maasglobal/maas-schemas/pull/324

After testing the change against `maas-transport-booking`. It appeared that numerous adapters take advantage on initially not added options (but which appeared in most validation invocations).

They're also helpful as avoid manual data normalization operations.