### PR TITLE
Customer's payment source update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/customers/payment-sources/paymentSource.json
+++ b/schemas/maas-backend/customers/payment-sources/paymentSource.json
@@ -59,6 +59,9 @@
         "billingZip": {
           "$ref": "http://maasglobal.com/core/components/address.json#/definitions/zipCode"
         },
+        "isValid": {
+          "type": "boolean"
+        },
         "isDefault": {
           "type": "boolean"
         },

--- a/schemas/maas-backend/customers/payment-sources/update/request.json
+++ b/schemas/maas-backend/customers/payment-sources/update/request.json
@@ -6,6 +6,7 @@
   "required": [
     "identityId",
     "customerId",
+    "paymentSourceId",
     "payload",
     "headers"
   ],

--- a/schemas/maas-backend/customers/payment-sources/update/request.json
+++ b/schemas/maas-backend/customers/payment-sources/update/request.json
@@ -1,6 +1,6 @@
 {
   "$id": "http://maasglobal.com/maas-backend/customers/payment-sources/update/request.json",
-  "description": "MaaS customer payment sources create",
+  "description": "MaaS customer payment sources update",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -25,9 +25,7 @@
         "paymentSource": {
           "type": "object",
           "properties": {
-            "isDefault": {
-              "type": { "enum": [ true ] }
-            },
+            "isDefault": { "enum": [ true ] },
             "alias": {
               "$ref": "http://maasglobal.com/maas-backend/customers/payment-sources/paymentSource.json#/definitions/alias"
             }

--- a/schemas/maas-backend/customers/payment-sources/update/request.json
+++ b/schemas/maas-backend/customers/payment-sources/update/request.json
@@ -1,0 +1,45 @@
+{
+  "$id": "http://maasglobal.com/maas-backend/customers/payment-sources/update/request.json",
+  "description": "MaaS customer payment sources create",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "identityId",
+    "customerId",
+    "payload",
+    "headers"
+  ],
+  "properties": {
+    "identityId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
+    "customerId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
+    "paymentSourceId": {
+      "$ref": "http://maasglobal.com/maas-backend/customers/payment-sources/paymentSource.json#/definitions/paymentSourceId"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "paymentSource": {
+          "type": "object",
+          "properties": {
+            "isDefault": {
+              "type": { "enum": [ true ] }
+            },
+            "alias": {
+              "$ref": "http://maasglobal.com/maas-backend/customers/payment-sources/paymentSource.json#/definitions/alias"
+            }
+          },
+          "anyOf": [ "isDefault", "alias" ],
+          "additionalProperties": false
+        }
+      },
+      "required": [ "paymentSource" ]
+    },
+    "headers": {
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
+    }
+  }
+}

--- a/schemas/maas-backend/customers/payment-sources/update/request.json
+++ b/schemas/maas-backend/customers/payment-sources/update/request.json
@@ -30,7 +30,10 @@
               "$ref": "http://maasglobal.com/maas-backend/customers/payment-sources/paymentSource.json#/definitions/alias"
             }
           },
-          "anyOf": [ "isDefault", "alias" ],
+          "anyOf": [
+            { "required": ["isDefault"] },
+            { "required": ["alias"] }
+          ],
           "additionalProperties": false
         }
       },

--- a/schemas/maas-backend/customers/payment-sources/update/response.json
+++ b/schemas/maas-backend/customers/payment-sources/update/response.json
@@ -1,0 +1,13 @@
+{
+  "$id": "http://maasglobal.com/maas-backend/customers/payment-sources/update/response.json",
+  "description": "MaaS customer payment sources update response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [ "paymentSource" ],
+  "properties": {
+    "paymentSource": {
+      "$ref": "http://maasglobal.com/maas-backend/customers/payment-sources/paymentSource.json#/definitions/paymentSource"
+    },
+    "debug": { "type": "object" }
+  }
+}

--- a/schemas/maas-backend/customers/payment-sources/update/response.json
+++ b/schemas/maas-backend/customers/payment-sources/update/response.json
@@ -7,7 +7,6 @@
   "properties": {
     "paymentSource": {
       "$ref": "http://maasglobal.com/maas-backend/customers/payment-sources/paymentSource.json#/definitions/paymentSource"
-    },
-    "debug": { "type": "object" }
+    }
   }
 }


### PR DESCRIPTION
Schema changes for customer's payment source update. 
Schema has intentional restriction for `isDefault` boolean property to have it either true or not present at all. This flag controls primary payment source assignment in Chargebee, which Chargebee uses for subscription payment, to have always card assigned for subscription payment, it is possible to change primary card but not remove the primary flag from card.