### PR TITLE
Allow email address up to 255 characters

### DIFF
--- a/schemas/core/components/units.json
+++ b/schemas/core/components/units.json
@@ -91,7 +91,7 @@
       "description": "Rough validation of a valid e-mail address, see https://davidcel.is/posts/stop-validating-email-addresses-with-regex/",
       "type": "string",
       "pattern": "^.+@.+\\..+$",
-      "maxLength": 64
+      "maxLength": 255
     },
     "paymentSourceId": {
       "type": "string",


### PR DESCRIPTION
Customers would like to use longer email address than current 64-character limit, allowing up to db max of 255 characters.
https://maasglobal.atlassian.net/browse/WS-3022