### PR TITLE
Allow pdf content for tickets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/booking-ticket/response.json
+++ b/schemas/tsp/booking-ticket/response.json
@@ -8,11 +8,11 @@
     },
     "type": {
       "type": "string",
-      "enum": ["html", "pdf","svg"]
+      "enum": ["html","pdf","svg"]
     },
     "contentType": {
       "type": "string",
-      "enum": ["application/pdf", "image/svg+xml","text/html"]
+      "enum": ["application/pdf","image/svg+xml","text/html"]
     }
   },
   "required": [

--- a/schemas/tsp/booking-ticket/response.json
+++ b/schemas/tsp/booking-ticket/response.json
@@ -8,11 +8,11 @@
     },
     "type": {
       "type": "string",
-      "enum": ["html","svg"]
+      "enum": ["html", "pdf","svg"]
     },
     "contentType": {
       "type": "string",
-      "enum": ["image/svg+xml","text/html"]
+      "enum": ["application/pdf", "image/svg+xml","text/html"]
     }
   },
   "required": [


### PR DESCRIPTION
## What has been implemented?

The ticket response schema now allows PDF documents as content in the response.

## Todos:
* [ ] Write tests

## Versioning:
* [ ] Breaking change