### PR TITLE
Add customer-stats request and response schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/customers/stats/request.json
+++ b/schemas/maas-backend/customers/stats/request.json
@@ -1,0 +1,18 @@
+{
+  "$id": "http://maasglobal.com/maas-backend/customers/stats/request.json",
+  "description": "MaaS customer stats. Give lifetime stats of customer e.g total number of bookings and itineraries",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "identityId",
+    "headers"
+  ],
+  "properties": {
+    "identityId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
+    "headers": {
+      "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
+    }
+  }
+}

--- a/schemas/maas-backend/customers/stats/response.json
+++ b/schemas/maas-backend/customers/stats/response.json
@@ -1,0 +1,28 @@
+{
+  "$id": "http://maasglobal.com/maas-backend/customers/stats/response.json",
+  "description": "MaaS customer stats. Give lifetime stats of customer e.g total number of bookings and itineraries",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "identityId",
+    "lifetimeBookingsCount",
+    "lifetimeItinerariesCount",
+    "profileCreationTimestamp"
+  ],
+  "properties": {
+    "identityId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
+    "lifetimeBookingsCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "lifetimeItinerariesCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "profileCreationTimestamp": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
+    }
+  }
+}


### PR DESCRIPTION
## What has been implemented?
Customer stats request and response endpoint
Gives stat about customer's lifetime records : bookings count, itineraries count etc ...

Includes minor version bump