### PR TITLE
Fix missing viaAvoid in TSP stations request schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/stations-list/request.json
+++ b/schemas/tsp/stations-list/request.json
@@ -26,7 +26,7 @@
           "minimum": 1
         },
         "type": {
-          "enum": ["origin", "destination"]
+          "enum": ["origin", "destination", "viaAvoid"]
         }
       },
       "required": ["name", "type"]


### PR DESCRIPTION
## What has been implemented?
BUG FIX: viaAvoid is added as one of queriable type by maas-backend but not on TSP. Added to TSP