### PR TITLE
feat: Add description property to ProductProvider.extra.radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/products/provider.json
+++ b/schemas/maas-backend/products/provider.json
@@ -98,6 +98,10 @@
               "description": "The maximum radius to which the maximum fixed fare applies, in metres",
               "type": "integer",
               "minValue": 0
+            },
+            "description": {
+              "description": "User facing description of the radius rule",
+              "type": "string"
             }
           },
           "required": [


### PR DESCRIPTION
## What has been implemented?
Add a "description" property to ProductProvider.extra.radius.
This should be a user-readable description of the radius rule that clients can display, e.g. above the map.

## Versioning:
* [ ] Breaking change
