### PR TITLE
Allow currency USD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/units.json
+++ b/schemas/core/components/units.json
@@ -27,7 +27,7 @@
     "currency": {
       "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",
       "type": "string",
-      "enum": [ "EUR", "GBP", "SGD" ]
+      "enum": [ "EUR", "GBP", "SGD", "USD" ]
     },
     "time": {
       "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",


### PR DESCRIPTION
Travis Build failed because:

    1) karhoo
           options-list
             success with multiple results
               should trigger a valid response:
         ValidationError: Multiple validation errors: 
    '.options[0].cost.currency' should be equal to one of the allowed values, got '"USD"'

Source:
https://travis-ci.com/maasglobal/maas-transport-booking/jobs/160789796#L1159

**Solution**: Allow USD

Discussed here:
https://maasfi.slack.com/archives/C5K4W0LSX/p1543235980009000