### PR TITLE
Allow Boolean as DOB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/customer.json
+++ b/schemas/core/customer.json
@@ -50,8 +50,13 @@
       "$ref": "http://maasglobal.com/core/components/common.json#/definitions/clientId"
     },
     "dob": {
-      "description": "The customer's date of birth",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/isoDate"
+      "description": "The customer's date of birth or boolean indicating if the value is already in DB",
+      "anyOf": [
+        { "type": "boolean" },
+        {
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/isoDate"
+        }
+      ]
     },
     "ssid": {
       "description": "Social Security ID",

--- a/schemas/maas-backend/customers/customer.json
+++ b/schemas/maas-backend/customers/customer.json
@@ -40,8 +40,13 @@
           "$ref": "http://maasglobal.com/core/components/address.json#/definitions/zipCode"
         },
         "dob": {
-          "description": "The customer's date of birth",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/isoDate"
+          "description": "The customer's date of birth or boolean indicating if the value is already in DB",
+          "anyOf": [
+            { "type": "boolean" },
+            {
+              "$ref": "http://maasglobal.com/core/components/units.json#/definitions/isoDate"
+            }
+          ]
         },
         "ssid": {
           "description": "Social Security ID",


### PR DESCRIPTION
Here is a potential fix for issue where DOB is returned as Boolean value and then validation fails.

From https://apidocs.maas.global/#customers
> whereas for encrypted items (cannShowPlain=false) Only a boolean value is passed back to clients. 

For example, this happens when you use `itinerary-create-v2`

```
'.outward.bookings[0].customer.dob' should match pattern "^\d{4}-\d{2}-\d{2}", got '"true"'
```

BTW @konker Looking at the doc, I'd say same fix needs to be applied to `ssid`. Let me know what do you think about this change.