### PR TITLE
Add paymentParameters, tokenId & token

### DIFF
--- a/schemas/maas-backend/bookings/v2/bookings-create/response.json
+++ b/schemas/maas-backend/bookings/v2/bookings-create/response.json
@@ -6,11 +6,65 @@
     "booking": {
       "$ref": "http://maasglobal.com/core/booking.json"
     },
+    "paymentParameters": {
+      "description": "Payment parameters for asynchronous payment methods",
+      "type": "object",
+      "properties": {
+        "avainpay": { "$ref": "#/definitions/avainpayPaymentParameters" }
+      }
+    },
     "debug": {
       "type": "object",
       "additionalProperties": true
     }
   },
   "required": ["booking"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "avainpayPaymentParameters": {
+      "type": "object",
+      "properties": {
+        "return_code": {
+          "description": "The return code, usually 'SUCCESS'",
+          "type": "string"
+        },
+        "appid": {
+          "description": "App ID",
+          "type": "string"
+        },
+        "mch_id": {
+          "description": "Merchant ID",
+          "type": "string"
+        },
+        "sub_mch_id": {
+          "description": "Our sub-merchant ID",
+          "type": "string"
+        },
+        "nonce_str": {
+          "description": "Nonce",
+          "type": "string"
+        },
+        "result_code": {
+          "description": "The result code, usually 'SUCCESS'",
+          "type": "string"
+        },
+        "prepay_id": {
+          "description": "WeChat's prepay ID",
+          "type": "string"
+        },
+        "trade_type": {
+          "description": "The trade type, usually 'APP'",
+          "type": "string"
+        },
+        "code_url": {
+          "description": "WeChat's code URL",
+          "type": "string"
+        },
+        "sign": {
+          "description": "WeChat's message signature",
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/schemas/maas-backend/bookings/v2/bookings-create/response.json
+++ b/schemas/maas-backend/bookings/v2/bookings-create/response.json
@@ -11,7 +11,8 @@
       "type": "object",
       "properties": {
         "avainpay": { "$ref": "#/definitions/avainpayPaymentParameters" }
-      }
+      },
+      "additionalProperties": false
     },
     "debug": {
       "type": "object",
@@ -64,7 +65,8 @@
           "description": "WeChat's message signature",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/schemas/maas-backend/invoices/invoiceLineItem.json
+++ b/schemas/maas-backend/invoices/invoiceLineItem.json
@@ -45,6 +45,13 @@
         },
         "referenceInvoiceLineItemId": {
           "$ref": "#/definitions/InvoiceLineItemId"
+        },
+        "tokenId": {
+          "$ref": "http://maasglobal.com/core/components/fare.json#/properties/tokenId"
+        },
+        "token": {
+          "description": "Arbitrary token data, e.g. payment parameters for async payment gateways",
+          "type": "object"
         }
        },
       "required": [ "id", "gatewayId", "description", "amount", "currency", "type" ],

--- a/test/feature-validate.js
+++ b/test/feature-validate.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 const utils = require('..');
 const bookingOptionsRequest = require('./valid-booking-options-request.json');
 const bookingOptionsResponse = require('./valid-booking-options-response.json');
+const validBookingResponseWithPaymentParameters = require('./valid-booking-response-v2-payment-parameters.json');
 const validBookingResponse = require('./valid-booking-response.json');
 const bookingTicketRequestRequest = require('./valid-booking-ticket-request.json');
 const bookingTicketRequestResponse = require('./valid-booking-ticket-response.json');
@@ -68,6 +69,16 @@ describe('Schema validation', () => {
 
     it('should succeed without error', () => {
       expect(utils.validate(schema, bookingTicketRequestResponse)).to.exist;
+    });
+  });
+
+  describe('validate schemas booking response schema with paymentParameters', () => {
+    const schema = require('../schemas/maas-backend/bookings/v2/bookings-create/response.json');
+
+    it('should succeed without error', () => {
+      const validated = utils.validate(schema, validBookingResponseWithPaymentParameters);
+      expect(validated).to.exist;
+      expect(validated.paymentParameters).to.deep.equal(validBookingResponseWithPaymentParameters.paymentParameters);
     });
   });
 });

--- a/test/valid-booking-response-v2-payment-parameters.json
+++ b/test/valid-booking-response-v2-payment-parameters.json
@@ -1,0 +1,88 @@
+{
+  "booking": {
+    "id": "6e05e000-feb3-11e8-8d64-e19805ef49db",
+    "state": "PENDING",
+    "leg": {
+      "to": {
+        "lat": 48.209148,
+        "lon": 16.372895
+      },
+      "from": {
+        "lat": 48.209148,
+        "lon": 16.372895
+      },
+      "mode": "BUS",
+      "endTime": 1543065547506,
+      "agencyId": "example-agency",
+      "startTime": 1542892747506
+    },
+    "customer": {
+      "identityId": "eu-west-1:00000000-0000-0000-0000-000000000000",
+      "email": "example@example.com",
+      "phone": "+99000000000",
+      "locale": "en",
+      "clientId": "whim",
+      "lastName": "Example",
+      "firstName": "Example"
+    },
+    "token": {},
+    "terms": {
+      "type": "24h card",
+      "reusable": true,
+      "validity": {
+        "endTime": 1543065547506,
+        "startTime": 1542892747506
+      },
+      "reconcilable": false
+    },
+    "meta": {
+      "MODE_TRANSIT": {
+        "productCode": "example_agency_24h_card",
+        "productName": "24 card"
+      }
+    },
+    "fares": [
+      {
+        "amount": 800,
+        "currency": "WMP",
+        "productionAmount": 800,
+        "type": "charge"
+      }
+    ],
+    "product": {
+      "id": "example-agency-24h-public-transport",
+      "name": "Example agency 24h card",
+      "description": "Example agency 24h card",
+      "priority": 3,
+      "agencyId": "example-agency",
+      "tspProductId": "example_agency_24h_card",
+      "icon": "http://example.com/test.png"
+    },
+    "stateLog": [
+      {
+        "reason": {},
+        "invalid": false,
+        "newState": "PENDING",
+        "oldState": "START",
+        "timestamp": 1544691509551
+      }
+    ],
+    "cancelling": false,
+    "configurator": {},
+    "customerSelection": {}
+  },
+  "paymentParameters": {
+    "avainpay": {
+      "return_code": "1",
+      "appid": "dummy",
+      "mch_id": "1234567890",
+      "sub_mch_id": "123456",
+      "nonce_str": "89dd456aedf456aef456ff4f456afeaa",
+      "result_code": "SUCCESS",
+      "prepay_id": "qq8491267490264027474747474747474747",
+      "trade_type": "TEST",
+      "code_url": "example://example.com",
+      "sign": "dummy-sign"
+    }
+  }
+}


### PR DESCRIPTION
## What has been implemented?

Add payment parameters to the v2 bookings-create response that may be used to enable asynchronous payment methods. Related to the same matter there's a new `token` field in InvoiceLineItem to allow for storing data regarding payments.

`tokenId` is present in the backend but was not added to the schemas.
