### PR TITLE
In car component allow classification: null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/car-rental.json
+++ b/schemas/core/components/car-rental.json
@@ -57,7 +57,17 @@
           "enum": ["manual", "automatic", null]
         },
         "fuel": {
-          "enum": ["diesel", "electric", "ethanol", "gasoline", "hybrid", "hydrogen", "lpg", "multifuel", null]
+          "enum": [
+            "diesel",
+            "electric",
+            "ethanol",
+            "gasoline",
+            "hybrid",
+            "hydrogen",
+            "lpg",
+            "multifuel",
+            null
+          ]
         },
         "classification": {
           "$ref": "ACRISS.json"

--- a/schemas/core/components/car-rental.json
+++ b/schemas/core/components/car-rental.json
@@ -70,7 +70,14 @@
           ]
         },
         "classification": {
-          "$ref": "ACRISS.json"
+          "anyOf": [
+            {
+              "$ref": "ACRISS.json"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "registrationPlate": {
           "description": "Registration plate (e.g. if we know the actual car already)",


### PR DESCRIPTION
We require ACRISS code, still it's mainly used by car rental and some caring sharing services (as Singapore Car Club) do not provide it.

Discussed at: https://maasfi.slack.com/archives/CE8P8P64R/p1544606970002600