### PR TITLE
TSP customer auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/common.json
+++ b/schemas/core/components/common.json
@@ -76,7 +76,8 @@
     "nonce": {
       "description": "Nonce value",
       "type": "string",
-      "minLength": 255
+      "minLength": 32,
+      "maxLength": 8192
     }
   }
 }

--- a/schemas/core/components/common.json
+++ b/schemas/core/components/common.json
@@ -72,6 +72,11 @@
       "description": "Social Security ID",
       "type": "string",
       "minLength": 4
+    },
+    "nonce": {
+      "description": "Nonce value",
+      "type": "string",
+      "minLength": 255
     }
   }
 }

--- a/schemas/tsp/customer-auth/request.json
+++ b/schemas/tsp/customer-auth/request.json
@@ -4,11 +4,15 @@
   "type": "object",
   "properties": {
     "nonce": {
-      "$ref": "http://maasglobal.com/core/components/common#/definitions/nonce"
+      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/nonce"
+    },
+    "returnUrl": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
     }
   },
   "required": [
-    "nonce"
+    "nonce",
+    "returnUrl"
   ],
   "additionalProperties": false
 }

--- a/schemas/tsp/customer-auth/request.json
+++ b/schemas/tsp/customer-auth/request.json
@@ -7,6 +7,7 @@
       "$ref": "http://maasglobal.com/core/components/common.json#/definitions/nonce"
     },
     "returnUrl": {
+      "description": "URL where client is returned after authorization flow is completed.",
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
     }
   },

--- a/schemas/tsp/customer-auth/request.json
+++ b/schemas/tsp/customer-auth/request.json
@@ -1,0 +1,14 @@
+{
+  "$id": "http://maasglobal.com/tsp/customer-auth/request.json",
+  "description": "Request schema for initiating customer authorization for TSP",
+  "type": "object",
+  "properties": {
+    "nonce": {
+      "$ref": "http://maasglobal.com/core/components/common#/definitions/nonce"
+    }
+  },
+  "required": [
+    "nonce"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/tsp/customer-auth/response.json
+++ b/schemas/tsp/customer-auth/response.json
@@ -3,8 +3,8 @@
   "description": "Response schema for initiating customer authorization for TSP",
   "type": "object",
   "properties": {
-    "nonce": {
-      "$ref": "http://maasglobal.com/core/components/common#/definitions/nonce"
+    "authUrl": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
     }
   },
   "required": [

--- a/schemas/tsp/customer-auth/response.json
+++ b/schemas/tsp/customer-auth/response.json
@@ -1,0 +1,14 @@
+{
+  "$id": "http://maasglobal.com/tsp/customer-auth/response.json",
+  "description": "Response schema for initiating customer authorization for TSP",
+  "type": "object",
+  "properties": {
+    "nonce": {
+      "$ref": "http://maasglobal.com/core/components/common#/definitions/nonce"
+    }
+  },
+  "required": [
+    "authUrl"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Request and response schema for customer-auth endpoint. Customer-auth endpoint is used to support customer authentication with TSP.

E.g. HSL requires authentication directly with user to resolve eligibility for season tickets. Schema provides support for TSP specific authentication flows, where this first iteration supports web based authentication.

Overall steps in flow (omitting details)
1. Client calls BE to initiate auth flow
2. BE calls TSP adapter, which creates TSP specific authUrl with nonce and `returnUrl` provided by BE
3. Backend passes crafted authentication url to client
4. Client / user performs required custom authentication steps in web view
5. On flow completion web view is redirected to `returnUrl` specified by BE
6. BE delegates decoding of return parameters to TSP adapter
7. TSP adapter responds with nonce and authToken (separate PR)

