### PR TITLE
customer-auth-validate TSP endpoint request / response schema

### DIFF
--- a/schemas/core/components/common.json
+++ b/schemas/core/components/common.json
@@ -72,6 +72,18 @@
       "description": "Social Security ID",
       "type": "string",
       "minLength": 4
+    },
+    "authToken": {
+      "description": "Authentication Token",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 255
+    },
+    "state": {
+      "description": "Authentication Response State",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
     }
   }
 }

--- a/schemas/tsp/booking-customer-auth-validate/request.json
+++ b/schemas/tsp/booking-customer-auth-validate/request.json
@@ -1,0 +1,10 @@
+{
+  "$id": "http://maasglobal.com/tsp/customer-auth-validate/request.json",
+  "description": "Request schema for completing customer authorization for TSP",
+  "type": "object",
+  "authToken": {
+    "$ref": "http://maasglobal.com/core/components/common.json#/definitions/state"
+  },
+  "required": ["state"],
+  "additionalProperties": true
+}

--- a/schemas/tsp/booking-customer-auth-validate/response.json
+++ b/schemas/tsp/booking-customer-auth-validate/response.json
@@ -1,0 +1,18 @@
+{
+  "$id": "http://maasglobal.com/tsp/customer-auth-validate/response.json",
+  "description": "Response schema for completing customer authorization for TSP",
+  "type": "object",
+  "properties": {
+    "authToken": {
+      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/authToken"
+    },
+    "validTo": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
+    },
+    "nonce": {
+      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/nonce"
+    }
+  },
+  "required": ["authToken", "validTo", "nonce"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## What has been implemented?

Request and response schema for customer-auth-validate endpoint. Customer-auth-validate endpoint is used to support customer authentication with TSP.

Related to PR #345