### PR TITLE
Extend tsp state for update endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/booking-update/request.json
+++ b/schemas/tsp/booking-update/request.json
@@ -7,7 +7,7 @@
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
     },
     "state": {
-      "enum": ["RESERVED", "CONFIRMED", "ACTIVATED", "ON_HOLD", "EXPIRED"]
+      "enum": ["RESERVED", "ACTIVATED", "ON_HOLD", "EXPIRED"]
     },
     "configurator": {
       "$ref": "../../core/booking.json#/properties/configurator"
@@ -22,6 +22,6 @@
       "$ref": "../../core/booking.json#/properties/customerSelection"
     }
   },
-  "required": ["tspId", "state"],
+  "required": ["tspId"],
   "additionalProperties": true
 }

--- a/schemas/tsp/booking-update/request.json
+++ b/schemas/tsp/booking-update/request.json
@@ -7,7 +7,7 @@
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
     },
     "state": {
-      "enum": ["RESERVED", "ACTIVATED", "ON_HOLD", "EXPIRED"]
+      "enum": ["RESERVED", "CONFIRMED", "ACTIVATED", "ON_HOLD", "EXPIRED"]
     },
     "configurator": {
       "$ref": "../../core/booking.json#/properties/configurator"


### PR DESCRIPTION
## What has been implemented?
Allow to send `CONFIRMED` state in update endpoint.

## Why ?
In case of mobit we can have booking in `CONFIRMED` state. In this state user might to use `UPDATE` endpoint to use findIt function. This function calls 'beep' sound on lock.
