### PR TITLE
feat(mobit): Remove 'state' as mandatory from schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/booking-update/response.json
+++ b/schemas/tsp/booking-update/response.json
@@ -28,6 +28,6 @@
       "$ref": "http://maasglobal.com/core/booking-option.json#/definitions/tspProduct"
     }
   },
-  "required": ["tspId", "state"],
+  "required": ["tspId"],
   "additionalProperties": false
 }


### PR DESCRIPTION

## What has been implemented?

Remove 'state' as mandatory parameter from booking-update response.

## Why
In case mobit we can have booking-update that doesn't affect state of booking but send additional commands. 
In this case we don't want to send `state` at all and we just use meta.
