### PR TITLE
Personal data query parameter validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/personal-data-query.json
+++ b/schemas/core/components/personal-data-query.json
@@ -1,0 +1,75 @@
+{
+  "$id": "http://maasglobal.com/core/components/personal-data-query.json",
+  "description": "MaaS personal data query parameters schema",
+  "definitions": {
+    "queryParams": {
+      "type": "object",
+      "properties": {
+        "customer[identityId]": {
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+        },
+        "customer[firstName]": {
+          "description": "First name of the customer (e.g. John)",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+        },
+        "customer[lastName]": {
+          "description": "Last name of the customer (e.g. Doe)",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+        },
+        "customer[phone]": {
+          "description": "ITU-T E.164 phone number",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone"
+        },
+        "customer[email]": {
+          "description": "Rough validation of a valid e-mail address",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email"
+        },
+        "email": {
+          "description": "Rough validation of a valid e-mail address",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email"
+        },
+        "customer[address]": {
+          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/address"
+        },
+        "customer[city]": {
+          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/city"
+        },
+        "customer[country]": {
+          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/country"
+        },
+        "customer[zipCode]": {
+          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/zipCode"
+        },
+        "customer[locale]": {
+          "$ref": "http://maasglobal.com/core/components/i18n.json#/definitions/locale"
+        },
+        "customer[appInstanceId]": {
+          "description": "An id specific to a user device",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/appInstanceId"
+        },
+        "customer[opaqueId]": {
+          "description": "Typically the hash of the identityId",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/opaqueId"
+        },
+        "customer[clientId]": {
+          "description": "An id indicating the source of the client",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/clientId"
+        },
+        "customer[dob]": {
+          "description": "The customer's date of birth or boolean indicating if the value is already in DB",
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/isoDate"
+        },
+        "customer[ssid]": {
+          "description": "Social Security ID",
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/ssid"
+        },
+        "customer[subscriberType]": {
+          "description": "Can indicate if subscriber is using paid or free plan",
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        }
+      }
+    }
+  }
+}

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -2,102 +2,117 @@
   "$id": "http://maasglobal.com/tsp/bookings-options-list/request.json",
   "description": "Request schema for getting options from a TSP adapter.",
   "type": "object",
-  "properties": {
-    "mode": {
-      "$ref": "http://maasglobal.com/core/components/travel-mode.json"
+  "allOf": [
+    {
+      "$ref": "http://maasglobal.com/core/components/personal-data-query.json"
     },
-    "startTime": {
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
-    },
-    "endTime": {
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
-    },
-    "from": {
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/shortLocationString"
-    },
-    "fromName": {
-      "anyOf": [
-        {
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+    {
+      "properties": {
+        "mode": {
+          "$ref": "http://maasglobal.com/core/components/travel-mode.json"
         },
-        {
-          "type": "string",
-          "maxLength": 0
-        }
-      ]
-    },
-    "fromAddress": {
-      "anyOf": [
-        {
-          "description": "Componentized from address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+        "startTime": {
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
         },
-        {
-          "type": "string",
-          "maxLength": 0
-        }
-      ]
-    },
-    "fromRadius": {
-      "description": "'from' location radius in meters",
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
-    },
-    "to": {
-      "anyOf": [
-        {
+        "endTime": {
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
+        },
+        "from": {
           "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/shortLocationString"
         },
-        {
-          "type": "string",
-          "maxLength": 0
-        }
-      ]
-    },
-    "toName": {
-      "anyOf": [
-        {
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+        "fromName": {
+          "anyOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
-        {
-          "type": "string",
-          "maxLength": 0
-        }
-      ]
-    },
-    "toAddress": {
-      "anyOf": [
-        {
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+        "fromAddress": {
+          "anyOf": [
+            {
+              "description": "Componentized from address",
+              "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
-        {
+        "fromRadius": {
+          "description": "'from' location radius in meters",
+          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+        },
+        "to": {
+          "anyOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/shortLocationString"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
+        },
+        "toName": {
+          "anyOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
+        },
+        "toAddress": {
+          "anyOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
+        },
+        "toRadius": {
+          "description": "'to' location radius in meters",
+          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+        },
+        "distance": {
+          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+        },
+        "extraOptions": {
+          "description": "An arbitrary string passed on a per-TSP basis, e.g. user's subscription period",
           "type": "string",
-          "maxLength": 0
-        }
-      ]
-    },
-    "toRadius": {
-      "description": "'to' location radius in meters",
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
-    },
-    "distance": {
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
-    },
-    "extraOptions": {
-      "description": "An arbitrary string passed on a per-TSP basis, e.g. user's subscription period",
-      "type": "string",
-      "minLength": 0
-    },
-    "tspProductIds": {
-      "description": "Comma-separated list of tspProductIds that the user has access to",
-      "type": "string",
-      "minLength": 0
-    },
-    "patternProperties": {
-      "^(optionalParameters).+": {
-        "type": ["string", "number", "boolean"]
-      }
+          "minLength": 0
+        },
+        "tspProductIds": {
+          "description": "Comma-separated list of tspProductIds that the user has access to",
+          "type": "string",
+          "minLength": 0
+        },
+        "patternProperties": {
+          "^(optionalParameters).+": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        },
+        "$ref": "http://maasglobal.com/core/components/personal-data-query.json"
+      },
+      "required": [
+        "startTime",
+        "from"
+      ],
+      "additionalProperties": true
     }
-  },
-  "required": ["startTime", "from"],
-  "additionalProperties": true
+  ]
 }

--- a/schemas/tsp/booking-read-by-id/request.json
+++ b/schemas/tsp/booking-read-by-id/request.json
@@ -2,11 +2,19 @@
   "$id": "http://maasglobal.com/tsp/bookings-read-by-id/request.json",
   "description": "Request schema for getting a specific booking with a TSP ID from a TSP adapter",
   "type": "object",
-  "properties": {
-    "tspId": {
-      "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
+  "allOf": [
+    {
+      "properties": {
+        "tspId": {
+          "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
+        }
+      },
+      "required": [
+        "tspId"
+      ]
+    },
+    {
+      "$ref": "http://maasglobal.com/core/components/personal-data-query.json#/definitions/queryParams"
     }
-  },
-  "required": ["tspId"],
-  "additionalProperties": false
+  ]
 }

--- a/test/feature-validate.js
+++ b/test/feature-validate.js
@@ -8,6 +8,10 @@ const validBookingResponseWithPaymentParameters = require('./valid-booking-respo
 const validBookingResponse = require('./valid-booking-response.json');
 const bookingTicketRequestRequest = require('./valid-booking-ticket-request.json');
 const bookingTicketRequestResponse = require('./valid-booking-ticket-response.json');
+
+const tspReadByIdRequest = require('./valid-tsp-read-by-id-request.json');
+const tspOptionsListRequest = require('./valid-tsp-options-list-request.json');
+
 // Missing required fields [leg, customer, token] etc...
 const invalidBookingResponse = {
   customer: {
@@ -79,6 +83,24 @@ describe('Schema validation', () => {
       const validated = utils.validate(schema, validBookingResponseWithPaymentParameters);
       expect(validated).to.exist;
       expect(validated.paymentParameters).to.deep.equal(validBookingResponseWithPaymentParameters.paymentParameters);
+    });
+  });
+
+  describe('validate schemas TSP read by id query parameters', () => {
+    const schema = require('../schemas/tsp/booking-read-by-id/request.json');
+
+    it('should succeed without error', () => {
+      const validated = utils.validate(schema, tspReadByIdRequest);
+      expect(validated).to.deep.equal(tspReadByIdRequest);
+    });
+  });
+
+  describe('validate schemas TSP options list query parameters', () => {
+    const schema = require('../schemas/tsp/booking-options-list/request.json');
+
+    it('should succeed without error', () => {
+      const validated = utils.validate(schema, tspOptionsListRequest);
+      expect(validated).to.deep.equal(tspOptionsListRequest);
     });
   });
 });

--- a/test/valid-tsp-options-list-request.json
+++ b/test/valid-tsp-options-list-request.json
@@ -1,0 +1,10 @@
+{
+  "mode": "TAXI",
+  "startTime": 1475850000000,
+  "endTime": 1475860000000,
+  "from": "-60.00,24.00",
+  "to": "+60.05,-24.05",
+  "fromRadius": 100,
+  "toRadius": 10,
+  "customer[opaqueId]": "xxxx-xxxx-xxxx-xxxx"
+}

--- a/test/valid-tsp-read-by-id-request.json
+++ b/test/valid-tsp-read-by-id-request.json
@@ -1,0 +1,5 @@
+{
+  "tspId": "tsp-id",
+  "customer[notInSchema]": "passedThrough",
+  "customer[phone]": "+35855544433"
+}


### PR DESCRIPTION
Validate personal data query parameters that can be passed to TSP on `read-by-id` and `options-list` requests.

## Todos:
* [x] Write tests

## Versioning:
* [ ] Breaking change
