### PR TITLE
Added Subscriber Type to customer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/customer.json
+++ b/schemas/core/customer.json
@@ -66,6 +66,10 @@
           "$ref": "http://maasglobal.com/core/components/common.json#/definitions/ssid"
         }
       ]
+    },
+    "subscriberType": {
+      "description": "Subscriber Type",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/maas-backend/customers/customer.json
+++ b/schemas/maas-backend/customers/customer.json
@@ -56,6 +56,10 @@
               "$ref": "http://maasglobal.com/core/components/common.json#/definitions/ssid"
             }
           ]
+        },
+        "subscriberType": {
+          "description": "Subscriber Type",
+          "type": "string"
         }
       },
       "required": [],

--- a/test/schemas/core/customer.js
+++ b/test/schemas/core/customer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const schema = require('../../../schemas/core/components/common.json');
+const customerSchema = require('../../../schemas/core/customer.json');
 const { generateTestCases } = require('../../test-lib');
 
 describe('customer.firstName', () => {
@@ -49,4 +50,8 @@ describe('customer.email', () => {
     '#"€"€#"@gmail.com',
     'very@very@unsual.com',
   ]);
+});
+
+describe('customer.subscriberType', () => {
+  generateTestCases(customerSchema.properties.subscriberType, true, ['non-subscriber']);
 });


### PR DESCRIPTION
## What has been implemented?

After enabling in `personalDataCreateAllow` - `subscriberType` - schema needs changes as otherwise schemaUtils.validate removes `subscriberType` 

https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logEventViewer:group=/aws/lambda/maas-tsp-redbox-booking-hertz;stream=2019/02/04/%5B$LATEST%5D859cabd9c86e4ae48aa4bf00e136e219;refid=34550478892055942944282606572979443016612537028765810796;reftime=1549297056420

Example request (customer part only):
```
"customer": {
            "email": "arkadiusz@jaworski.pl",
            "phone": "+48793396001",
            "locale": "en",
            "clientId": "whim",
            "lastName": "Jaworski",
            "opaqueId": "96f6fcf016c98010584cc4855109a0d99cc770752ff3e1baf20911aa57807a15",
            "firstName": "Arek",
            "subscriberType": "non-subscriber"
        },
```
