### PR TITLE
WS-3577 As agreed increased the value to 200000

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "5.12.0",
+  "version": "5.13.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/subscriptions/subscription.json
+++ b/schemas/maas-backend/subscriptions/subscription.json
@@ -131,7 +131,7 @@
         "quantity": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 100000,
+          "maximum": 200000,
           "default": 1
         },
         "unitPrice": {

--- a/test/schemas/maas-backend/subscriptions/subscription.js
+++ b/test/schemas/maas-backend/subscriptions/subscription.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const schema = require('../../../../schemas/maas-backend/subscriptions/subscription.json');
+const { generateTestCases } = require('../../../test-lib');
+
+describe('addon.quantity', () => {
+  generateTestCases(schema.definitions.addon.properties.quantity, true, [
+    0, // min value
+    151280, // In range
+    200000, // max value
+  ]);
+
+  generateTestCases(schema.definitions.addon.properties.quantity, false, [
+    200001, // Over
+  ]);
+});


### PR DESCRIPTION
## What has been implemented?

Increased the value to 200000 (€2000) as `subscriptions-estimate` was throwing validation error for rental values over €1000.

Check JIRA for all details: https://maasglobal.atlassian.net/browse/WS-3577