### PR TITLE
WS-1206 Support refreshInterval in ticket response

### DIFF
--- a/schemas/tsp/booking-ticket/response.json
+++ b/schemas/tsp/booking-ticket/response.json
@@ -6,6 +6,10 @@
     "ticket": {
       "type": "string"
     },
+    "refreshInterval": {
+      "description": "An interval in seconds with which frequency the client needs to refetch the ticket from the TSP",
+      "type": "integer"
+    },
     "type": {
       "type": "string",
       "enum": ["html", "pdf", "svg"]


### PR DESCRIPTION
## What has been implemented?

- `refreshInterval` to the ticket response which is an interval in seconds that some tickets need refreshing at. Done with PayiQ tickets in mind, since they update their signature on an interval.