### PR TITLE
WS-3823 Loosen schema for booking.customer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -40,7 +40,7 @@
           "$ref": "http://maasglobal.com/core/customer.json"
         },
         {
-          "required": ["identityId", "firstName", "lastName", "phone", "email"]
+          "required": ["identityId"]
         }
       ]
     },


### PR DESCRIPTION
## What has been implemented?
All required properties for booking.customer have been removed, except for identityId.
This is because some TSPs do not require, e.g. phone (see weiner linen)

## Todos:

- [ ] Write tests

## Versioning:

- [ ] Breaking change
