### PR TITLE
fix missing paymentSourceId itinerary update request schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/itineraries/itinerary-create/request.json
+++ b/schemas/maas-backend/itineraries/itinerary-create/request.json
@@ -21,16 +21,16 @@
           "$ref": "http://maasglobal.com/core/components/common.json#/definitions/paymentSourceId"
         },
         "outward": {
-          "$ref": "#/definitions/payload"
+          "$ref": "#/definitions/outwardReturnWrapper"
         },
         "return": {
-          "$ref": "#/definitions/payload"
+          "$ref": "#/definitions/outwardReturnWrapper"
         }
       }
     }
   },
   "definitions": {
-    "payload": {
+    "outwardReturnWrapper": {
       "itinerary": {
         "$ref": "http://maasglobal.com/core/itinerary.json"
       },

--- a/schemas/maas-backend/itineraries/itinerary-update/request.json
+++ b/schemas/maas-backend/itineraries/itinerary-update/request.json
@@ -16,6 +16,9 @@
     "payload": {
       "type": "object",
       "properties": {
+        "paymentSourceId": {
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/paymentSourceId"
+        },
         "itinerary": {
           "$ref": "http://maasglobal.com/core/itinerary.json"
         },


### PR DESCRIPTION
## What has been implemented?
Fix `itinerary-update-v2` request schema missing paymentSourceId, leading to that property being removed as being additional property

This is a __patch__ since it's not a new feature but a fix