### PR TITLE
Jest security update

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "essentials": "1",
     "git-list-updated": "^1.1.2",
     "glob": "^7.1.3",
-    "jest": "^23.6",
-    "jest-cli": "^23.6",
+    "jest": "^24.5.0",
+    "jest-cli": "^24.5.0",
     "prettier": "^1.16.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
## What has been implemented?
Security update for Jest

## Versioning:

- [x] Breaking change in Jest version (23.6 -> 24.5.0)
