### PR TITLE
Booking extension options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@maasglobal/maas-schemas",
+  "name": "maas-schemas",
   "version": "7.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "maas-schemas",
-  "version": "7.5.0",
+  "name": "@maasglobal/maas-schemas",
+  "version": "7.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/bookings/bookings-agency-options/request.json
+++ b/schemas/maas-backend/bookings/bookings-agency-options/request.json
@@ -60,7 +60,7 @@
         "toRadius": {
           "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
         },
-        "extensionOptionsForBookingId": {
+        "bookingIdToExtend": {
           "description": "bookingId to fetch possible extension options for",
           "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
         }

--- a/schemas/maas-backend/bookings/bookings-agency-options/request.json
+++ b/schemas/maas-backend/bookings/bookings-agency-options/request.json
@@ -59,6 +59,10 @@
         },
         "toRadius": {
           "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+        },
+        "extensionOptionsForBookingId": {
+          "description": "bookingId to fetch possible extension options for",
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
         }
       },
       "patternProperties": {

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -92,6 +92,10 @@
       "type": "string",
       "minLength": 0
     },
+    "extensionOptionsForTspId": {
+      "description": "Request for possible booking extension options for tspId",
+      "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
+    },
     "patternProperties": {
       "^(optionalParameters).+": {
         "type": ["string", "number", "boolean"]

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0
     },
-    "extensionOptionsForTspId": {
+    "tspIdToExtend": {
       "description": "Request for possible booking extension options for tspId",
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
     },


### PR DESCRIPTION
## Support for booking extension options
Some bookings allow extensions like HSL with their monthly ticket. To support querying options for extensions backend API has optional parameter for bookingId to be extended and for TSP tspId for booking to be extended.