### PR TITLE
Allow empty descriptions for subscriptions, addons, coupons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/subscriptions/subscription.json
+++ b/schemas/maas-backend/subscriptions/subscription.json
@@ -62,8 +62,7 @@
           "minLength": 2
         },
         "description": {
-          "type": "string",
-          "minLength": 2
+          "type": "string"
         },
         "meta": {
           "description": "Arbitrary metadata on whatever app might need to display",
@@ -109,8 +108,7 @@
           "minLength": 1
         },
         "description": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "price": {
           "$ref": "#/definitions/price"
@@ -131,8 +129,7 @@
           "minLength": 1
         },
         "description": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "quantity": {
           "type": "integer",
@@ -159,8 +156,7 @@
           "minLength": 1
         },
         "description": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         }
       },
       "required": ["id"]


### PR DESCRIPTION
## What has been implemented?
Allow empty descriptions for addon, subscription, and coupon.

## Todos:

- [ ] Write tests

## Versioning:

- [ ] Breaking change
