### PR TITLE
Purchasing app instance id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/booking-options-list/request.json
+++ b/schemas/tsp/booking-options-list/request.json
@@ -96,6 +96,10 @@
       "description": "Request for possible booking extension options for tspId",
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
     },
+    "purchasingAppInstanceId": {
+      "description": "appInstanceId to use for options and purchase",
+      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/appInstanceId"
+    },
     "patternProperties": {
       "^(optionalParameters).+": {
         "type": ["string", "number", "boolean"]


### PR DESCRIPTION
Booking options list query to tsp has parameter for `purchasingAppInstanceId` to allow using different appInstanceId for options and to purchase than actual callee app instance id is.