### PR TITLE
Routes query request schema to accept bookingIdToExtend parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/routes/routes-query/request.json
+++ b/schemas/maas-backend/routes/routes-query/request.json
@@ -67,6 +67,10 @@
         },
         "options": {
           "type": "object"
+        },
+        "bookingIdToExtend": {
+          "description": "bookingId to fetch possible extension options for",
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
         }
       },
       "patternProperties": {


### PR DESCRIPTION
This parameter allows to propose booking extension options as part of routes query response. Similar to bookings-agency-options.