### PR TITLE
Allow title in push notification request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "7.11.0",
+  "version": "7.12.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/maas-backend/push-notification/request.json
+++ b/schemas/maas-backend/push-notification/request.json
@@ -6,6 +6,7 @@
     "identityId": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
+    "title": { "type": "string", "minLength": 1, "maxLength": 50 },
     "message": { "type": "string", "minLength": 2, "maxLength": 256 },
     "badge": { "type": "integer", "minimum": 0, "maximum": 9999 },
     "sound": { "type": "string", "minLength": 2, "maxLength": 256 },


### PR DESCRIPTION
Title added as allowed property in push notification message request schema.
Max length of 50 is an arbitrary amount to not be too restrictive.