### PR TITLE
Add stateLog to Booking

### DIFF
--- a/schemas/core/booking.json
+++ b/schemas/core/booking.json
@@ -12,6 +12,9 @@
     "state": {
       "$ref": "components/state.json#/definitions/bookingState"
     },
+    "stateLog": {
+      "$ref": "components/state-log.json"
+    },
     "fares": {
       "type": "array",
       "items": {

--- a/schemas/core/components/state-log.json
+++ b/schemas/core/components/state-log.json
@@ -1,0 +1,50 @@
+{
+  "$id": "http://maasglobal.com/core/components/state-log.json",
+  "description": "Set of booking state transitions",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/bookingStateTransition"
+  },
+  "definitions": {
+    "obsoleteTime": {
+      "type": "string",
+      "pattern": "^[0-9]+$"
+    },
+    "bookingStateTransition": {
+      "type": "object",
+      "properties": {
+        "timestamp": {
+          "anyOf": [
+            {
+              "$ref": "units.json#/definitions/time"
+            },
+            {
+              "$ref": "#/definitions/obsoleteTime"
+            }
+          ]
+        },
+        "oldState": {
+          "$ref": "state.json#/definitions/maybeBookingState"
+        },
+        "newState": {
+          "$ref": "state.json#/definitions/maybeBookingState"
+        },
+        "invalid": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "errorCode": "number"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["newState", "oldState", "timestamp"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/core/components/state.json
+++ b/schemas/core/components/state.json
@@ -19,6 +19,12 @@
         "FINISHED"
       ]
     },
+    "bookingStateUnknown": {
+      "const": "UNKNOWN"
+    },
+    "maybeBookingState": {
+      "anyOf": [{ "$ref": "#/definitions/bookingState" }, { "$ref": "#/definitions/bookingStateUnknown" }]
+    },
     "legState": {
       "description": "The life-cycle state of a leg",
       "type": "string",

--- a/test/valid-booking-responses-v2-payment-parameters.json
+++ b/test/valid-booking-responses-v2-payment-parameters.json
@@ -66,6 +66,16 @@
           "newState": "PENDING",
           "oldState": "START",
           "timestamp": 1544691509551
+        },
+        {
+          "reason": {
+            "text": "Unexpectecd error",
+            "errorCode": 500
+          },
+          "invalid": false,
+          "newState": "UNKNOWN",
+          "oldState": "UNKNOWN",
+          "timestamp": "1545710094600"
         }
       ],
       "cancelling": false,


### PR DESCRIPTION
This pull request attempts to document stateLog that already exists in production bookings.
Needs some testing before merge. I'm opening the pull request to discus the topic.