### PR TITLE
Allow png tickets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "7.14.0",
+  "version": "7.15.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/booking-ticket/response.json
+++ b/schemas/tsp/booking-ticket/response.json
@@ -8,11 +8,11 @@
     },
     "type": {
       "type": "string",
-      "enum": ["html", "pdf", "svg"]
+      "enum": ["html", "pdf", "svg", "png"]
     },
     "contentType": {
       "type": "string",
-      "enum": ["application/pdf", "image/svg+xml", "text/html"]
+      "enum": ["application/pdf", "image/svg+xml", "image/png", "text/html"]
     },
     "refreshAt": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",


### PR DESCRIPTION
## What has been implemented?

Vienna CAT tickets are now delivered as QR code images in PNG format. This requires a change to the schemas.