### PR TITLE
Update identityId to support uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/units.json
+++ b/schemas/core/components/units.json
@@ -19,8 +19,15 @@
       "maxLength": 256
     },
     "identityId": {
-      "type": "string",
-      "pattern": "^[aepus]{2}-[\\w]{4}-\\d:[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$"
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[aepus]{2}-[\\w]{4}-\\d:[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$"
+        },
+        {
+          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+        }
+      ]
     },
     "currency": {
       "description": "Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1",


### PR DESCRIPTION
## What has been implemented?

Because of cognito deletion, we will created user identityIds with help of uuid. This change will allow for uuids to validate everywhere while supporting the old cognito ids.
