### PR TITLE
Changing regex for zipCode - for NL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/address.json
+++ b/schemas/core/components/address.json
@@ -5,7 +5,7 @@
     "componentAddress": {
       "description": "Encoded address components in form country:Finland|state:Uusimaa|city:Helsinki|zipCode:00100|streetName:Ludviginkatu|streetNumber:6",
       "type": "string",
-      "pattern": "^(?:(?:(?:country:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:state:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:city:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:zipCode:(?:\\d{3,10}|(?:\\p{L}|\\d){2,4}(\\s(?:\\p{L}|\\d){2,4})?))|(?:streetName:[^|]+)|(?:streetNumber:\\d+))\\|?){4,6}$"
+      "pattern": "^(?:(?:(?:country:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:state:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:city:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:zipCode:(?:[a-zA-Z0-9 ]{3,10}|(?:\\p{L}|\\d){2,4}(\\s(?:\\p{L}|\\d){2,4})?))|(?:streetName:[^|]+)|(?:streetNumber:\\d+))\\|?){4,6}$"
     },
     "placeName": {
       "description": "Place name (given in autocomplete)",

--- a/schemas/core/components/geolocation.json
+++ b/schemas/core/components/geolocation.json
@@ -78,7 +78,9 @@
           "minLength": 1,
           "maxLength": 16
         },
-        "zipcode": { "type": "integer" }
+        "zipcode": {
+          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/zipCode"
+        }
       },
       "required": ["name"]
     }


### PR DESCRIPTION
The new rules for ZIP have been applied. In new TSP (taxiboeken.nl for Netherlandes) the postal code can have following formats: zipCode:1118AX or zipCode:1118 AX
