### PR TITLE
Fix - Allow choice to have default property set to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/configurator.json
+++ b/schemas/core/components/configurator.json
@@ -50,7 +50,7 @@
           "items": {
             "$ref": "#/definitions/choice"
           },
-          "contains": { "required": ["default"] }
+          "contains": { "properties": { "default": { "const": true } } }
         }
       },
       "required": ["type", "name", "choices"]
@@ -72,7 +72,7 @@
           "type": "string"
         },
         "default": {
-          "const": true
+          "type": "boolean"
         },
         "cost": {
           "$ref": "http://maasglobal.com/core/components/cost.json"


### PR DESCRIPTION
9-series schema changes forced choice "default" property to be always set to true or validation would fail, in real life there should be only one of the choice elements having `"default": true` and rest should have it set to false.