### PR TITLE
Loosen tsp request schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/tsp/booking-read-by-id/request.json
+++ b/schemas/tsp/booking-read-by-id/request.json
@@ -5,6 +5,10 @@
   "properties": {
     "tspId": {
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
+    },
+    "query": {
+      "type": "object",
+      "description": "Debug info"
     }
   },
   "required": ["tspId"],


### PR DESCRIPTION
## What has been implemented?
Allow the `query` property for tsp requests to fetch a booking by id