### PR TITLE
Bug/booking option create schema default validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,10 @@ function init() {
     inlineRefs: false,
     meta: true,
     multipleOfPrecision: 6,
+    removeAdditional: true,
     sanitize: false,
     sourceCode: false,
+    useDefaults: true,
     validateSchema: false,
     verbose: true,
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.3.6",
+  "version": "9.3.7",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/configurator.json
+++ b/schemas/core/components/configurator.json
@@ -49,8 +49,7 @@
           "description": "Set of choices for one customization",
           "items": {
             "$ref": "#/definitions/choice"
-          },
-          "contains": { "properties": { "default": { "const": true } } }
+          }
         }
       },
       "required": ["type", "name", "choices"]


### PR DESCRIPTION
## What has been implemented?
- Remove the assumption that booking configurator will have at least one default true choice, specific to the case of booking options create ..response
- Bump version to 937. Put back sanitization of defaults to provide "some" failsafe for transport booking, which also needs this change
- Actually bump to 941 because of previously merged PRs