### PR TITLE
Loosen address definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/schemas/core/components/address.json
+++ b/schemas/core/components/address.json
@@ -10,7 +10,7 @@
     "placeName": {
       "description": "Place name (given in autocomplete)",
       "type": "string",
-      "pattern": "^(?:\\p{L}|\\d)(?:\\p{L}|\\d|[!-/:-@[-`{-\\xA9\\xAB-\\xB4\\xB6-\\xB9\\xBB-\\xBF\\xD7\\xF7])*(?:\\s(?:\\p{L}|\\d|[!-/:-@[-`{-\\xA9\\xAB-\\xB4\\xB6-\\xB9\\xBB-\\xBF\\xD7\\xF7])+)*$",
+      "minLength": 1,
       "maxLength": 255
     },
     "firstName": {

--- a/schemas/core/components/address.json
+++ b/schemas/core/components/address.json
@@ -32,8 +32,7 @@
     "address": {
       "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",
       "type": "string",
-      "pattern": "^(?:(?:\\p{L}|\\d)+[`'´\\(\\)\\-/,\\.]?)+(\\s?(?:\\p{L}|[\\d`'´\\(\\)\\-/,\\.])?)*$",
-      "maxLength": 255
+      "pattern": "^(?:(?:\\p{L}|\\d)+[`'´\\(\\)\\-/,\\.]?)+(\\s?(?:\\p{L}|[\\d`'´\\(\\)\\-/,\\.])?)*$"
     },
     "zipCode": {
       "description": "Numeric zip code, see https://en.wikipedia.org/wiki/Postal_code",

--- a/schemas/core/components/address.json
+++ b/schemas/core/components/address.json
@@ -5,13 +5,12 @@
     "componentAddress": {
       "description": "Encoded address components in form country:Finland|state:Uusimaa|city:Helsinki|zipCode:00100|streetName:Ludviginkatu|streetNumber:6",
       "type": "string",
-      "pattern": "^(?:(?:(?:country:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:state:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:city:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:zipCode:(?:[a-zA-Z0-9 ]{3,10}|(?:\\p{L}|\\d){2,4}(\\s(?:\\p{L}|\\d){2,4})?))|(?:streetName:[^|]+)|(?:streetNumber:\\d+))\\|?){4,6}$"
+      "pattern": "^(?:(?:(?:country:(?:\\p{L}|\\s|')+)|(?:state:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:city:(?:\\p{L}|[,\\.:\\-`'´\\s])+)|(?:zipCode:(?:[a-zA-Z0-9 ]{3,10}|(?:\\p{L}|\\d){2,4}(\\s(?:\\p{L}|\\d){2,4})?))|(?:streetName:[^|]+)|(?:streetNumber:\\d+))\\|?){4,6}$"
     },
     "placeName": {
       "description": "Place name (given in autocomplete)",
       "type": "string",
-      "minLength": 1,
-      "maxLength": 255
+      "minLength": 1
     },
     "firstName": {
       "description": "First name of the customer (e.g. John)",
@@ -32,7 +31,7 @@
     "address": {
       "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",
       "type": "string",
-      "pattern": "^(?:(?:\\p{L}|\\d)+[`'´\\(\\)\\-/,\\.]?)+(\\s?(?:\\p{L}|[\\d`'´\\(\\)\\-/,\\.])?)*$"
+      "minLength": 2
     },
     "zipCode": {
       "description": "Numeric zip code, see https://en.wikipedia.org/wiki/Postal_code",
@@ -43,7 +42,7 @@
     "countryName": {
       "description": "Alphabetic country name",
       "type": "string",
-      "pattern": "^(?:\\p{L}|\\s)+$",
+      "pattern": "^(?:\\p{L}|\\s|')+$",
       "maxLength": 64
     },
     "country": {
@@ -54,8 +53,7 @@
     "city": {
       "description": "Alphabetic city name",
       "type": "string",
-      "pattern": "^(?:\\p{L}|[\\s`'´])+$",
-      "maxLength": 64
+      "minLength": 1
     }
   }
 }

--- a/test/schemas/core/address.js
+++ b/test/schemas/core/address.js
@@ -12,15 +12,10 @@ describe('address.placeName', () => {
     "28 St John's Wood Road, London",
     "Shakespeare's Globe",
     'Tarkk´ampujankatu', // Common known validation failure
+    '\'s-Gravesandestraat 55'
   ]);
 
   generateTestCases(schema.definitions.placeName, false, [
-    '💩',
-    // Double space, made inefficient regex lock the process
-    'ENTERPRISE RENT A CAR 9 10 SUFFOLK STREET  QUEENSWAY',
-    // Double space (2)
-    'Erenköy Mahallesi, Çoban Yıldızı Sk. No:4, 34738 Kadıköy/İstanbul,  Turkki',
-    // '00100', Does not work, but relaxed the schema
     '',
   ]);
 });

--- a/test/schemas/core/address.js
+++ b/test/schemas/core/address.js
@@ -28,8 +28,10 @@ describe('address.componentAddress', () => {
     'city:Helsinki|country:Finland|zipCode:00100|streetName:Ludviginkatu|streetNumber:6',
     // Spaces in-between
     'country:New Zealand|state:Bay of Plenty|city:White Pine Bush|zipCode:3191|streetName:White Pine Bush Road|streetNumber:479',
+    // Apostrophe
+    "country:Côte d'Ivoire|city:Abidjan|zipCode:01 BP2581|streetName:Cocody Quartier Ambassades Impasse du Belier|streetNumber:58",
     // Other interesting special characters
-    "country:Aäöم武кв.-`''´`|state:Aäöم武кв.-`''´`|city:Aäöم武кв.-`''´`|zipCode:3191|streetName:Aäöم武кв.-`''´`|streetNumber:479",
+    "country:Aäöم武кв'|state:Aäöم武кв.-`''´`|city:Aäöم武кв.-`''´`|zipCode:3191|streetName:Aäöم武кв.-`''´`|streetNumber:479",
     // King's Cross, UK, London
     'city:Lontoo|streetNumber:2|streetName:Charrington Street|zipCode:NW1|country:Yhdistynyt kuningaskunta',
     "country:UK|city:London|zipCode:NW8 7HA|streetName:St John's Wood Road|streetNumber:28",
@@ -41,7 +43,6 @@ describe('address.componentAddress', () => {
     // TODO The parser does not yet support limiting to one occurrence of each field
     //'country:Finland|country:Finland|country:Finland|country:Finland|country:Finland|
     //   country:Finland',
-    '',
   ]);
 });
 
@@ -54,11 +55,7 @@ describe('address.address', () => {
     'Красная Площадь', // Cyrillic - Red square
   ]);
 
-  generateTestCases(schema.definitions.address, false, [
-    '💩',
-    // '00100', Does not work, but relaxed the schema
-    '',
-  ]);
+  generateTestCases(schema.definitions.address, false, ['💩']);
 });
 
 describe('address.zipCode', () => {
@@ -94,12 +91,5 @@ describe('address.city', () => {
     'Москва', // Cyrillic: Moscow
   ]);
 
-  generateTestCases(schema.definitions.city, false, [
-    '💩',
-    '',
-    // Too long
-    'LRuwGi4XRMVgImvVm7OEsw58YBDsUsApuKGXrjAcQi9QDEWwFYUp2yrzspe2WHu5rGuFoSU6TKeFIf73QjEnzv5Lq6' +
-      'Wu1YTJAbN2bZws8SfwhEoDInr6K3zTgmFQEQnzaDheGZtO4IMzAGoDSUx2zw1Lv4inpE4uq6NBYELaSusrlxGM0p' +
-      'JEiUrYZwIlzGAS4MgRrOKfZIyuZLH9gARtzyKvstQZw9bMmnRE8yWPTNGKlWmYBHLjMTluZp5AcpbU',
-  ]);
+  generateTestCases(schema.definitions.city, false, ['']);
 });

--- a/test/schemas/core/address.js
+++ b/test/schemas/core/address.js
@@ -12,12 +12,10 @@ describe('address.placeName', () => {
     "28 St John's Wood Road, London",
     "Shakespeare's Globe",
     'Tarkk´ampujankatu', // Common known validation failure
-    '\'s-Gravesandestraat 55'
+    "'s-Gravesandestraat 55",
   ]);
 
-  generateTestCases(schema.definitions.placeName, false, [
-    '',
-  ]);
+  generateTestCases(schema.definitions.placeName, false, ['']);
 });
 
 describe('address.componentAddress', () => {


### PR DESCRIPTION
## What has been implemented?

Instead of enforcing a pattern on `placeName`, which currently allows `¶` but does not allow `-`, just expect a non-empty string.