### PR TITLE
Add voucher property for car rentals

### DIFF
--- a/schemas/core/components/car-rental.json
+++ b/schemas/core/components/car-rental.json
@@ -21,6 +21,13 @@
     "image": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
     },
+    "vendor": {
+      "type": "object",
+      "description": "Some fields have a vendor specific format, but appear in all, or most TSPs",
+      "properties": {
+        "voucher": {}
+      }
+    },
     "terms": {},
     "car": {
       "type": "object",


### PR DESCRIPTION
## What has been implemented?

Car rentals often use a voucher that is vendor specific but nevertheless a standard property
