### PR TITLE
ValidationError by default should be 400

### DIFF
--- a/lib/ValidationError.js
+++ b/lib/ValidationError.js
@@ -27,6 +27,7 @@ class ValidationError extends Error {
     this.object = object;
     this.errors = errors;
     this.name = 'ValidationError';
+    this.statusCode = 400;
   }
   /**
    * Factory to instantiate a ValidationError from AJV validation error array

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/test/feature-validate.js
+++ b/test/feature-validate.js
@@ -37,6 +37,7 @@ describe('Schema validation', () => {
         expect(utils.validate(schema, invalidBookingResponse)).to.not.exist;
       } catch (e) {
         expect(e.name).to.equal('ValidationError');
+        expect(e.statusCode).to.equal(400);
         expect(e).to.exist;
       }
     });


### PR DESCRIPTION
## What has been implemented?

Added `statusCode` `400` (Bad Request) to ValidationError.

This way in TSP we won't need to do:
```
    if (error instanceof ValidationError) {
      throw new HttpError(400, `Input validation error: ${error.message}`);
    }
```

`ValidationError` by default should be `400`