### PR TITLE
Remove duplicate description property from core/error.json

### DIFF
--- a/schemas/core/error.json
+++ b/schemas/core/error.json
@@ -1,8 +1,7 @@
 {
   "$id": "http://maasglobal.com/core/error.json",
-  "description": "MaaS event response error objects",
+  "description": "MaaS event response error object. An error that the service may send.",
   "type": "object",
-  "description": "An error that the service may send",
   "required": ["message", "code"],
   "properties": {
     "message": {


### PR DESCRIPTION
## What has been implemented?

I've checked schemas together with OpenAPI spec using `https://github.com/stoplightio/spectral/` and found this error when `error` definition have duplicated description.

Diff are pretty self explanatory.

### How I run the lint?

See my branch https://github.com/huksley/maas-tsp-api/tree/spec-schemas
Run `npm run lint`

Unfortunately spectral reports other/invalid errors 🤷‍♂ reported here https://github.com/stoplightio/spectral/issues/751

## Todos:

- [x] No tests needed

## Versioning:

- [x] Non-breaking change
