### PR TITLE
Add customer reference types

### DIFF
--- a/maas-schemas-ts/src/core/components/common.ts
+++ b/maas-schemas-ts/src/core/components/common.ts
@@ -8,6 +8,7 @@ MaaS common components that are used consistently within our own objects
 */
 
 import * as t from 'io-ts';
+import * as Units_ from 'maas-schemas-ts/core/components/units';
 
 export const schemaId = 'http://maasglobal.com/core/components/common.json';
 // AgencyId
@@ -119,6 +120,34 @@ export const Email = t.brand(
 );
 export interface EmailBrand {
   readonly Email: unique symbol;
+}
+// CustomerReference
+// Any unique way to refer a customer
+export type CustomerReference = t.Branded<
+  Units_.IdentityId | Phone,
+  CustomerReferenceBrand
+>;
+export const CustomerReference = t.brand(
+  t.union([Units_.IdentityId, Phone]),
+  (x): x is t.Branded<Units_.IdentityId | Phone, CustomerReferenceBrand> => true,
+  'CustomerReference',
+);
+export interface CustomerReferenceBrand {
+  readonly CustomerReference: unique symbol;
+}
+// LooseCustomerReference
+// Any unique way to refer a customer, plus some opportunistic ways
+export type LooseCustomerReference = t.Branded<
+  CustomerReference | Email,
+  LooseCustomerReferenceBrand
+>;
+export const LooseCustomerReference = t.brand(
+  t.union([CustomerReference, Email]),
+  (x): x is t.Branded<CustomerReference | Email, LooseCustomerReferenceBrand> => true,
+  'LooseCustomerReference',
+);
+export interface LooseCustomerReferenceBrand {
+  readonly LooseCustomerReference: unique symbol;
 }
 // PaymentSourceId
 // The purpose of this remains a mystery

--- a/maas-schemas/schemas/core/components/common.json
+++ b/maas-schemas/schemas/core/components/common.json
@@ -50,6 +50,19 @@
       "maxLength": 64,
       "examples": ["joe.customer@example.com"]
     },
+    "customerReference": {
+      "description": "Any unique way to refer a customer",
+      "oneOf": [
+        { "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId" },
+        { "$ref": "#/definitions/phone" }
+      ],
+      "examples": ["4828507e-683f-41bf-9d87-689808fbf958", "+358401234567"]
+    },
+    "looseCustomerReference": {
+      "description": "Any unique way to refer a customer, plus some opportunistic ways",
+      "oneOf": [{ "$ref": "#/definitions/customerReference" }, { "$ref": "#/definitions/email" }],
+      "examples": ["4828507e-683f-41bf-9d87-689808fbf958", "+358401234567", "joe.customer@example.com"]
+    },
     "paymentSourceId": {
       "type": "string",
       "minLength": 3,

--- a/maas-schemas/test/feature-validate.js
+++ b/maas-schemas/test/feature-validate.js
@@ -100,7 +100,7 @@ describe('Schema validation', () => {
 
   describe('common schema', () => {
     const schema = require('../schemas/core/components/common.json');
-    const { phone, email } = utils.definitions(schema);
+    const { phone, email, customerReference, looseCustomerReference } = utils.definitions(schema);
     describe('phone schema', () => {
       it('should accept valid examples', () => {
         phone.examples.map(example => expect(utils.validate(phone, example)).to.exist);
@@ -109,6 +109,18 @@ describe('Schema validation', () => {
     describe('email schema', () => {
       it('should accept valid examples', () => {
         email.examples.map(example => expect(utils.validate(email, example)).to.exist);
+      });
+    });
+    describe('customerReference schema', () => {
+      it('should accept valid examples', () => {
+        customerReference.examples.map(example => expect(utils.validate(customerReference, example)).to.exist);
+      });
+    });
+    describe('looseCustomerReference schema', () => {
+      it('should accept valid examples', () => {
+        looseCustomerReference.examples.map(
+          example => expect(utils.validate(looseCustomerReference, example)).to.exist
+        );
       });
     });
   });


### PR DESCRIPTION
This PR adds two new data type CustomerReference ( IdentityId + phone ) and LooseCustomerReference ( IdentityId + phone + email ). The plan is to use these data types for selecting a customer in Maui. The loose version allows duplicates while the strict version should always identify a single customer.