### PR TITLE
Fix definition extractor

### DIFF
--- a/maas-schemas/index.js
+++ b/maas-schemas/index.js
@@ -22,10 +22,9 @@ function definitions(schema) {
   return Object.fromEntries(
     Object.entries(schema.definitions).map(([name, def]) => [
       name,
-      {
+      Object.assign({}, def, {
         $id: `${schemaId}#/definitions/${name}`,
-        ...def,
-      },
+      }),
     ])
   );
 }

--- a/maas-schemas/index.js
+++ b/maas-schemas/index.js
@@ -17,11 +17,13 @@ if (typeof Object.fromEntries === 'undefined') {
 }
 
 function definitions(schema) {
+  // schema $id should not contain # but sometimes they do
+  const [schemaId] = schema.$id.split('#');
   return Object.fromEntries(
     Object.entries(schema.definitions).map(([name, def]) => [
       name,
       {
-        $id: `http://maasglobal.com/environments/environments.json#/definitions/${name}`,
+        $id: `${schemaId}#/definitions/${name}`,
         ...def,
       },
     ])

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "9.9.0",
+  "version": "9.9.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {


### PR DESCRIPTION
Environments id was accidentally hard coded in definition extractor. This PR should fix the problem.