### PR TITLE
Add examples support to converter

### DIFF
--- a/maas-schemas-ts/src/core/booking.ts
+++ b/maas-schemas-ts/src/core/booking.ts
@@ -298,6 +298,129 @@ export const Default = t.brand(
 export interface DefaultBrand {
   readonly Default: unique symbol;
 }
+export const examplesDefaultJson: Array<unknown> = [
+  {
+    id: '12345678-ABCD-1234-ABCD-123456789ABC',
+    state: 'EXPIRED',
+    leg: {
+      to: {
+        lat: 60.184333,
+        lon: 24.835972,
+        name: 'Otaranta 6, Espoo',
+        address:
+          'streetName:Otaranta|streetNumber:6|city:Espoo|zipCode:02150|country:Suomi',
+      },
+      from: {
+        lat: 60.168442,
+        lon: 24.932205,
+        name: 'Urho Kekkosen katu 1, Helsinki',
+        address:
+          'streetName:Urho Kekkosen katu|streetNumber:1|city:Helsinki|zipCode:00100|country:Suomi',
+      },
+      mode: 'TAXI',
+      endTime: 1553092978009,
+      agencyId: 'Valopilkku',
+      startTime: 1553092978009,
+      departureDelay: 123456,
+    },
+    token: { type: 'SECURITY_CODE', value: '12345' },
+    terms: {
+      reusable: false,
+      validity: { endTime: 1553092978009, startTime: 1553092978009 },
+      reconcilable: false,
+    },
+    meta: {
+      raw: {
+        data: { lat: 60.168442, lon: 24.932205, vehicle_id: '123' },
+        order_id: 12345,
+        timestamp: '2019-03-20T10:10:12+00:00',
+        localized_description: 'Tilaus on valmis.',
+      },
+      MODE_TAXI: {
+        vehicleId: '123',
+        taxiCenter: { name: 'Lähitaksi', phone: '+3581007300' },
+        vehicleType: 'any',
+        vehicleLocation: { lat: 60.245254, lon: 24.989604 },
+      },
+      timestamp: 1553092978009,
+      valopilkku: {
+        prepaid: true,
+        locations: [
+          {
+            type: 'pickup',
+            address: { city: 'Helsinki', street_address: 'Urho Kekkosen katu 1' },
+            contacts: [
+              { name: 'John Doe', passenger_count: 1, provider_order_id: 'MaaS-12345' },
+            ],
+            coordinate: { lat: 60.168442, lon: 24.932205 },
+            passenger_count: 1,
+          },
+          {
+            type: 'destination',
+            address: { city: 'Espoo', street_address: 'Otaranta 6' },
+            drop_off: ['MaaS-12345'],
+            coordinate: { lat: 60.184333, lon: 24.835972 },
+            passenger_count: 1,
+          },
+        ],
+        submitted: '2019-03-21T11:13:19.753Z',
+      },
+      description: 'Tilaus on valmis.',
+    },
+    created: '2019-03-20 10:10:12.123456',
+    modified: '2019-03-20 18:30:12.123456',
+    cost: { amount: 0, currency: 'EUR' },
+    stateLog: [
+      {
+        reason: {},
+        invalid: false,
+        newState: 'PENDING',
+        oldState: 'START',
+        timestamp: 1553092178009,
+      },
+      {
+        reason: {},
+        invalid: false,
+        newState: 'PAID',
+        oldState: 'PENDING',
+        timestamp: 1553092278009,
+      },
+      {
+        reason: {},
+        invalid: false,
+        newState: 'RESERVED',
+        oldState: 'PAID',
+        timestamp: 1553092378009,
+      },
+      {
+        reason: {},
+        invalid: false,
+        newState: 'CONFIRMED',
+        oldState: 'RESERVED',
+        timestamp: 1553092478009,
+      },
+      {
+        reason: {},
+        invalid: false,
+        newState: 'ACTIVATED',
+        oldState: 'CONFIRMED',
+        timestamp: 1553092578009,
+      },
+      {
+        reason: {},
+        invalid: false,
+        newState: 'EXPIRED',
+        oldState: 'ACTIVATED',
+        timestamp: 1553092678009,
+      },
+    ],
+    productId: 'valopilkku-any',
+    fares: [{ type: 'charge', amount: 1000, currency: 'WMP', productionAmount: 1234 }],
+    cancelling: false,
+    customer: { identityId: 'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958' },
+  },
+];
+export const examplesDefault = t.array(Default).decode(examplesDefaultJson);
 
 export default Default;
 

--- a/maas-schemas-ts/src/core/components/common.ts
+++ b/maas-schemas-ts/src/core/components/common.ts
@@ -95,6 +95,8 @@ export const Phone = t.brand(
 export interface PhoneBrand {
   readonly Phone: unique symbol;
 }
+export const examplesPhoneJson: Array<unknown> = ['+358401234567'];
+export const examplesPhone = t.array(Phone).decode(examplesPhoneJson);
 // RawPhone
 // Slightly looser definition of phone number
 export type RawPhone = t.Branded<string, RawPhoneBrand>;
@@ -120,6 +122,8 @@ export const Email = t.brand(
 export interface EmailBrand {
   readonly Email: unique symbol;
 }
+export const examplesEmailJson: Array<unknown> = ['joe.customer@example.com'];
+export const examplesEmail = t.array(Email).decode(examplesEmailJson);
 // PaymentSourceId
 // The purpose of this remains a mystery
 export type PaymentSourceId = t.Branded<string, PaymentSourceIdBrand>;

--- a/maas-schemas-ts/src/core/components/units.ts
+++ b/maas-schemas-ts/src/core/components/units.ts
@@ -23,6 +23,8 @@ export const Uuid = t.brand(
 export interface UuidBrand {
   readonly Uuid: unique symbol;
 }
+export const examplesUuidJson: Array<unknown> = ['4828507e-683f-41bf-9d87-689808fbf958'];
+export const examplesUuid = t.array(Uuid).decode(examplesUuidJson);
 // Url
 // Uniform resource locator, see https://en.wikipedia.org/wiki/Uniform_Resource_Locator and https://mathiasbynens.be/demo/url-regex
 export type Url = t.Branded<string, UrlBrand>;
@@ -68,6 +70,12 @@ export const ObsoleteIdentityId = t.brand(
 export interface ObsoleteIdentityIdBrand {
   readonly ObsoleteIdentityId: unique symbol;
 }
+export const examplesObsoleteIdentityIdJson: Array<unknown> = [
+  'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
+];
+export const examplesObsoleteIdentityId = t
+  .array(ObsoleteIdentityId)
+  .decode(examplesObsoleteIdentityIdJson);
 // IdentityId
 // The purpose of this remains a mystery
 export type IdentityId = t.Branded<ObsoleteIdentityId | Uuid, IdentityIdBrand>;
@@ -79,6 +87,11 @@ export const IdentityId = t.brand(
 export interface IdentityIdBrand {
   readonly IdentityId: unique symbol;
 }
+export const examplesIdentityIdJson: Array<unknown> = [
+  'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
+  '4828507e-683f-41bf-9d87-689808fbf958',
+];
+export const examplesIdentityId = t.array(IdentityId).decode(examplesIdentityIdJson);
 // Currency
 // Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1
 export type Currency = t.Branded<

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -208,6 +208,70 @@ export const Default = t.brand(
 export interface DefaultBrand {
   readonly Default: unique symbol;
 }
+export const examplesDefaultJson: Array<unknown> = [
+  {
+    identityId: 'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
+    id: 1234,
+    favoriteLocations: [],
+    phone: '+358407654321',
+    email: 'bob.customer@example.com',
+    firstName: 'Bob',
+    lastName: 'Customer',
+    created: 1553687004207,
+    modified: 1553688004207,
+    paymentMethod: { type: 'unknown', valid: false },
+    subscriptionInstance: {
+      id: 10,
+      name: 'Whim to Go',
+      plan: { id: 'fi-whim-payg_v2' },
+      addons: { '0': 'eur-whim-rollover-100_v1', '1': 'fi-whim-car' },
+      region: {
+        id: 'fi-helsinki',
+        name: 'Helsinki Region',
+        active: true,
+        hidden: false,
+        created: '2019-03-27T14:00:00.12345+00:00',
+        zipCode: '00100',
+        currency: 'EUR',
+        location: { lat: 60.1699, lon: 24.9384 },
+        geometryId: 2,
+        countryCode: 'FI',
+        countryDefault: true,
+      },
+      coupons: [],
+      topUpId: 'fi-whim-top-up',
+      wmpGrant: 0,
+      pointCost: 0.01,
+      description: 'Pay for each trip as you go',
+    },
+    balances: {
+      WMP: { currency: 'WMP', amount: 1234, type: 'charge' },
+      'cx-test-token_v2': {
+        currency: 'TOKEN',
+        tokenId: 'cx-test-token_v2',
+        amount: 1,
+        type: 'charge',
+      },
+    },
+    regionId: 'fi-helsinki',
+    region: {
+      id: 'fi-helsinki',
+      name: 'Helsinki Region',
+      countryCode: 'FI',
+      countryDefault: true,
+      zipCode: '00100',
+      location: { lat: 60.1699, lon: 24.9384 },
+      active: true,
+      hidden: false,
+      geometryId: 2,
+      created: 1553687004207,
+      modified: 0,
+      currency: 'EUR',
+    },
+    balance: 1234,
+  },
+];
+export const examplesDefault = t.array(Default).decode(examplesDefaultJson);
 
 export default Default;
 

--- a/maas-schemas-ts/src/environments/environments.ts
+++ b/maas-schemas-ts/src/environments/environments.ts
@@ -179,6 +179,16 @@ export const Environment = t.brand(
 export interface EnvironmentBrand {
   readonly Environment: unique symbol;
 }
+export const examplesEnvironmentJson: Array<unknown> = [
+  {
+    id: 'production',
+    api: 'https://production.example.com/api/',
+    live: true,
+    contact: { name: 'Alisha Admin', email: 'admin@example.com' },
+    description: 'Production environment',
+  },
+];
+export const examplesEnvironment = t.array(Environment).decode(examplesEnvironmentJson);
 // DevEnvironment
 // The purpose of this remains a mystery
 export type DevEnvironment = t.Branded<
@@ -218,6 +228,18 @@ export const DevEnvironment = t.brand(
 export interface DevEnvironmentBrand {
   readonly DevEnvironment: unique symbol;
 }
+export const examplesDevEnvironmentJson: Array<unknown> = [
+  {
+    id: 'testing',
+    api: 'https://testing.example.com/api/',
+    live: false,
+    contact: { name: 'Alisha Admin' },
+    description: 'Testing environment',
+  },
+];
+export const examplesDevEnvironment = t
+  .array(DevEnvironment)
+  .decode(examplesDevEnvironmentJson);
 // EnvironmentGroupName
 // The purpose of this remains a mystery
 export type EnvironmentGroupName = t.Branded<string, EnvironmentGroupNameBrand>;
@@ -320,6 +342,45 @@ export const Default = t.brand(
 export interface DefaultBrand {
   readonly Default: unique symbol;
 }
+export const examplesDefaultJson: Array<unknown> = [
+  {
+    index: [
+      {
+        name: 'Core Environments',
+        envs: [
+          {
+            id: 'production',
+            api: 'https://production.example.com/api/',
+            live: true,
+            contact: { name: 'Alisha Admin', email: 'admin@example.com' },
+            description: 'Production environment',
+          },
+          {
+            id: 'testing',
+            api: 'https://testing.example.com/api/',
+            live: false,
+            contact: { name: 'Alisha Admin' },
+            description: 'Testing environment',
+          },
+        ],
+      },
+      {
+        name: 'Development Environments',
+        envs: [
+          {
+            id: 'fantasyTopping',
+            api: 'https://fantasy.example.com/api/',
+            live: false,
+            contact: { name: 'Dennis Developer' },
+            name: 'Fantasy Topping',
+            description: 'Add support for pizza customization',
+          },
+        ],
+      },
+    ],
+  },
+];
+export const examplesDefault = t.array(Default).decode(examplesDefaultJson);
 
 export default Default;
 

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1,8 +1,48 @@
+INFO: fragment used as part of $id
+  in ./core/booking.json
+WARNING: skipping examples handling for $ref object
+  in ./core/booking.json
+WARNING: skipping default value handling for $ref object
+  in ./core/booking.json
+WARNING: skipping examples handling for $ref object
+  in ./core/booking.json
+WARNING: skipping default value handling for $ref object
+  in ./core/booking.json
+WARNING: skipping examples handling for $ref object
+  in ./core/booking.json
+WARNING: skipping default value handling for $ref object
+  in ./core/booking.json
+WARNING: skipping examples handling for $ref object
+  in ./core/booking.json
+WARNING: skipping default value handling for $ref object
+  in ./core/booking.json
+INFO: missing description
+  in ./core/booking.json
+INFO: missing description
+  in ./core/booking.json
+INFO: missing description
+  in ./core/booking.json
+INFO: missing description
+  in ./core/booking.json
+INFO: missing description
+  in ./core/booking.json
+INFO: missing description
+  in ./core/booking.json
+WARNING: skipping examples handling for $ref object
+  in ./core/booking-option.json
+WARNING: skipping default value handling for $ref object
+  in ./core/booking-option.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/booking-option.json
 WARNING: minLength field not supported outside top-level definitions
   in ./core/booking-option.json
 WARNING: maxLength field not supported outside top-level definitions
+  in ./core/booking-option.json
+INFO: missing description
+  in ./core/booking-option.json
+INFO: missing description
+  in ./core/booking-option.json
+INFO: missing description
   in ./core/booking-option.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/card.json
@@ -28,6 +68,34 @@ WARNING: maxLength field not supported outside top-level definitions
   in ./core/card.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/card.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/address.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/address.json
+INFO: missing description
+  in ./core/components/address.json
+INFO: missing description
+  in ./core/components/address.json
+INFO: missing description
+  in ./core/components/address.json
+INFO: missing description
+  in ./core/components/address.json
+INFO: missing description
+  in ./core/components/api-common.json
+INFO: missing description
+  in ./core/components/api-common.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/authorization.json
 INFO: primitive type "string" used outside top-level definitions
@@ -106,6 +174,12 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/components/car-rental.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/components/car-rental.json
+INFO: missing description
+  in ./core/components/common.json
+INFO: missing description
+  in ./core/components/common.json
+INFO: missing description
+  in ./core/components/common.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/configurator.json
 WARNING: minLength field not supported outside top-level definitions
@@ -178,6 +252,8 @@ WARNING: minimum field not supported outside top-level definitions
   in ./core/components/fare.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/fare.json
+INFO: missing description
+  in ./core/components/fare.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
@@ -220,6 +296,14 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/components/geolocation.json
+INFO: missing description
+  in ./core/components/geolocation.json
+INFO: missing description
+  in ./core/components/geolocation.json
+INFO: missing description
+  in ./core/components/geolocation.json
+INFO: missing description
+  in ./core/components/geolocation.json
 INFO: primitive type "number" used outside top-level definitions
   in ./core/components/geometry.json
 INFO: primitive type "number" used outside top-level definitions
@@ -228,6 +312,8 @@ WARNING: minItems field not supported outside top-level definitions
   in ./core/components/geometry.json
 WARNING: minItems field not supported outside top-level definitions
   in ./core/components/geometry.json
+INFO: missing description
+  in ./core/components/i18n.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/payment-parameters.json
 WARNING: minLength field not supported outside top-level definitions
@@ -291,6 +377,10 @@ INFO: primitive type "string" used outside top-level definitions
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
+  in ./core/components/payment-parameters.json
+INFO: missing description
+  in ./core/components/payment-parameters.json
+INFO: missing description
   in ./core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/personalDataAllowItem.json
@@ -326,6 +416,30 @@ INFO: primitive type "string" used outside top-level definitions
   in ./core/components/state-log.json
 INFO: primitive type "number" used outside top-level definitions
   in ./core/components/state-log.json
+INFO: missing description
+  in ./core/components/state-log.json
+INFO: missing description
+  in ./core/components/state-log.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping examples handling for $ref object
+  in ./core/components/station.json
+WARNING: skipping default value handling for $ref object
+  in ./core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
@@ -341,6 +455,22 @@ INFO: primitive type "string" used outside top-level definitions
 INFO: primitive type "number" used outside top-level definitions
   in ./core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
+  in ./core/components/station.json
+INFO: missing description
   in ./core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/subscriptionChangeState.json
@@ -376,6 +506,16 @@ WARNING: minimum field not supported outside top-level definitions
   in ./core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
   in ./core/components/terms.json
+INFO: missing description
+  in ./core/components/terms.json
+INFO: missing description
+  in ./core/components/terms.json
+INFO: missing description
+  in ./core/components/units.json
+INFO: missing description
+  in ./core/components/units.json
+INFO: missing description
+  in ./core/components/units.json
 INFO: primitive type "integer" used outside top-level definitions
   in ./core/customer.json
 WARNING: minimum field not supported outside top-level definitions
@@ -402,6 +542,10 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/error.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/error.json
+WARNING: skipping examples handling for $ref object
+  in ./core/itinerary.json
+WARNING: skipping default value handling for $ref object
+  in ./core/itinerary.json
 INFO: primitive type "number" used outside top-level definitions
   in ./core/itinerary.json
 WARNING: minimum field not supported outside top-level definitions
@@ -410,6 +554,86 @@ WARNING: minItems field not supported outside top-level definitions
   in ./core/itinerary.json
 WARNING: minItems field not supported outside top-level definitions
   in ./core/itinerary.json
+INFO: missing description
+  in ./core/itinerary.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+WARNING: skipping examples handling for $ref object
+  in ./core/leg.json
+WARNING: skipping default value handling for $ref object
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
+INFO: missing description
+  in ./core/leg.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
@@ -418,6 +642,10 @@ INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_BICYCLE.json
+WARNING: skipping examples handling for $ref object
+  in ./core/modes/MODE_CAR.json
+WARNING: skipping default value handling for $ref object
+  in ./core/modes/MODE_CAR.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_RAIL.json
 INFO: primitive type "string" used outside top-level definitions
@@ -432,6 +660,10 @@ INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_SHARED_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_SHARED_BICYCLE.json
+WARNING: skipping examples handling for $ref object
+  in ./core/modes/MODE_SHARED_CAR.json
+WARNING: skipping default value handling for $ref object
+  in ./core/modes/MODE_SHARED_CAR.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
@@ -502,6 +734,12 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/paymentSource.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/paymentSource.json
+INFO: missing description
+  in ./core/plan.json
+INFO: missing description
+  in ./core/plan.json
+INFO: missing description
+  in ./core/plan.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/product.json
 WARNING: minLength field not supported outside top-level definitions
@@ -529,6 +767,8 @@ INFO: primitive type "string" used outside top-level definitions
 WARNING: minLength field not supported outside top-level definitions
   in ./core/product.json
 WARNING: maxLength field not supported outside top-level definitions
+  in ./core/product.json
+INFO: missing description
   in ./core/product.json
 INFO: primitive type "integer" used outside top-level definitions
   in ./core/product-option.json
@@ -616,6 +856,8 @@ WARNING: minimum field not supported outside top-level definitions
   in ./core/profile.json
 WARNING: multipleOf field not supported outside top-level definitions
   in ./core/profile.json
+INFO: missing description
+  in ./core/profile.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/region.json
 WARNING: minLength field not supported outside top-level definitions
@@ -628,6 +870,26 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/region.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/region.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
+INFO: missing description
+  in ./environments/environments.json
 INFO: primitive type "number" used outside top-level definitions
   in ./geojson/geometry.json
 INFO: primitive type "number" used outside top-level definitions
@@ -650,12 +912,22 @@ WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/autocomplete/autocomplete-query/request.json
 WARNING: maximum field not supported outside top-level definitions
   in ./maas-backend/autocomplete/autocomplete-query/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/autocomplete/autocomplete-query/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/autocomplete/autocomplete-query/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/autocomplete/autocomplete-query/response.json
 WARNING: patternProperty support has limitations
   in ./maas-backend/bookings/bookings-agency-options/request.json
+INFO: missing description
+  in ./maas-backend/bookings/bookings-agency-options/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/bookings/bookings-agency-options/response.json
+INFO: missing description
+  in ./maas-backend/bookings/bookings-agency-options/response.json
+INFO: missing description
+  in ./maas-backend/bookings/bookings-agency-products/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/bookings/bookings-agency-products/response.json
 WARNING: minLength field not supported outside top-level definitions
@@ -685,6 +957,8 @@ INFO: primitive type "string" used outside top-level definitions
 WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/bookings/bookings-agency-products/response.json
 WARNING: maxLength field not supported outside top-level definitions
+  in ./maas-backend/bookings/bookings-agency-products/response.json
+INFO: missing description
   in ./maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/bookings/bookings-list/request.json
@@ -696,6 +970,10 @@ WARNING: pattern field not supported outside top-level definitions
   in ./maas-backend/bookings/bookings-list/request.json
 WARNING: minItems field not supported outside top-level definitions
   in ./maas-backend/bookings/bookings-list/response.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/bookings/bookings-retrieve/request.json
+INFO: missing description
+  in ./maas-backend/booking-option-create/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/booking-option-create/response.json
 WARNING: minLength field not supported outside top-level definitions
@@ -735,6 +1013,18 @@ WARNING: minLength field not supported outside top-level definitions
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/customers/payment-sources/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
+  in ./maas-backend/customers/payment-sources/paymentSource.json
+INFO: missing description
+  in ./maas-backend/customers/payment-sources/paymentSource.json
+INFO: missing description
+  in ./maas-backend/customers/payment-sources/paymentSource.json
+INFO: missing description
+  in ./maas-backend/customers/payment-sources/paymentSource.json
+INFO: missing description
+  in ./maas-backend/customers/payment-sources/paymentSource.json
+INFO: missing description
+  in ./maas-backend/customers/payment-sources/paymentSource.json
+INFO: missing description
   in ./maas-backend/customers/payment-sources/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/customers/payment-sources/setup-intent/response.json
@@ -800,6 +1090,8 @@ WARNING: minItems field not supported outside top-level definitions
   in ./maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/customers/verification/verification-object.json
+INFO: missing description
+  in ./maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/geocoding/geocoding-query/request.json
 WARNING: minLength field not supported outside top-level definitions
@@ -812,13 +1104,23 @@ WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/geocoding/geocoding-query/request.json
 WARNING: maximum field not supported outside top-level definitions
   in ./maas-backend/geocoding/geocoding-query/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/geocoding/geocoding-query/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/geocoding/geocoding-query/request.json
 INFO: primitive type "integer" used outside top-level definitions
   in ./maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: maximum field not supported outside top-level definitions
   in ./maas-backend/geocoding/geocoding-reverse/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/geocoding/geocoding-reverse/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: minLength field not supported outside top-level definitions
+  in ./maas-backend/invoices/invoice.json
+INFO: missing description
   in ./maas-backend/invoices/invoice.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/invoices/invoiceLineItem.json
@@ -840,6 +1142,14 @@ WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/invoices/invoiceLineItem.json
 WARNING: multipleOf field not supported outside top-level definitions
   in ./maas-backend/invoices/invoiceLineItem.json
+INFO: missing description
+  in ./maas-backend/invoices/invoiceUnits.json
+INFO: missing description
+  in ./maas-backend/invoices/invoiceUnits.json
+INFO: missing description
+  in ./maas-backend/itineraries/itinerary-create/request.json
+INFO: missing description
+  in ./maas-backend/itineraries/itinerary-create/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/itineraries/itinerary-list/request.json
 WARNING: pattern field not supported outside top-level definitions
@@ -850,6 +1160,10 @@ WARNING: minItems field not supported outside top-level definitions
   in ./maas-backend/itineraries/itinerary-list/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/itineraries/itinerary-retrieve/request.json
+INFO: missing description
+  in ./maas-backend/products/products-providers-options/request.json
+INFO: missing description
+  in ./maas-backend/products/products-providers-retrieve/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/products/provider.json
 WARNING: minLength field not supported outside top-level definitions
@@ -906,6 +1220,8 @@ WARNING: pattern field not supported outside top-level definitions
   in ./maas-backend/profile/profile-devices-put/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/profile/profile-devices-put/response.json
+INFO: missing description
+  in ./maas-backend/profile/profile-devices-put/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/profile/profile-favoriteLocations-delete/request.json
 WARNING: minLength field not supported outside top-level definitions
@@ -914,6 +1230,12 @@ WARNING: maxLength field not supported outside top-level definitions
   in ./maas-backend/profile/profile-favoriteLocations-delete/request.json
 WARNING: patternProperty support has limitations
   in ./maas-backend/provider/routes/request.json
+INFO: missing description
+  in ./maas-backend/provider/routes/response.json
+INFO: missing description
+  in ./maas-backend/provider/routes/response.json
+INFO: missing description
+  in ./maas-backend/provider/routes/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
@@ -956,6 +1278,8 @@ INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/routes/routes-query/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/routes/routes-query/request.json
+INFO: missing description
+  in ./maas-backend/routes/routes-query/request.json
 INFO: primitive type "integer" used outside top-level definitions
   in ./maas-backend/stations/stations-list/request.json
 WARNING: minimum field not supported outside top-level definitions
@@ -968,10 +1292,22 @@ INFO: primitive type "integer" used outside top-level definitions
   in ./maas-backend/stations/stations-list/request.json
 WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/stations/stations-list/request.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/stations/stations-list/response.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/stations/stations-list/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/stations/stations-retrieve/request.json
 WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/stations/stations-retrieve/request.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/stations/stations-retrieve/response.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/stations/stations-retrieve/response.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/subscriptions/contact.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
@@ -1004,6 +1340,18 @@ INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/contact.json
 WARNING: pattern field not supported outside top-level definitions
   in ./maas-backend/subscriptions/contact.json
+INFO: missing description
+  in ./maas-backend/subscriptions/contact.json
+INFO: missing description
+  in ./maas-backend/subscriptions/contact.json
+INFO: missing description
+  in ./maas-backend/subscriptions/contact.json
+INFO: missing description
+  in ./maas-backend/subscriptions/contact.json
+INFO: missing description
+  in ./maas-backend/subscriptions/contact.json
+INFO: missing description
+  in ./maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/pricing.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1018,10 +1366,24 @@ WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/subscriptions/pricing.json
 WARNING: maximum field not supported outside top-level definitions
   in ./maas-backend/subscriptions/pricing.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/subscriptions/pricing.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/pricing.json
 WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/subscriptions/pricing.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1058,13 +1420,35 @@ WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/subscriptions/subscription.json
 WARNING: maximum field not supported outside top-level definitions
   in ./maas-backend/subscriptions/subscription.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/subscriptions/subscription.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/subscriptions/subscription.json
+INFO: missing description
+  in ./maas-backend/subscriptions/subscription.json
+INFO: missing description
+  in ./maas-backend/subscriptions/subscription.json
+INFO: missing description
+  in ./maas-backend/subscriptions/subscription.json
+INFO: missing description
+  in ./maas-backend/subscriptions/subscription.json
+INFO: missing description
+  in ./maas-backend/subscriptions/subscription.json
+INFO: missing description
+  in ./maas-backend/subscriptions/subscriptionAddress.json
 WARNING: minItems field not supported outside top-level definitions
+  in ./maas-backend/subscriptions/subscriptionOption.json
+INFO: missing description
   in ./maas-backend/subscriptions/subscriptionOption.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/subscriptions/subscriptions-options/request.json
@@ -1072,6 +1456,8 @@ WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/subscriptions/subscriptions-options/request.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./maas-backend/subscriptions/subscriptions-options/request.json
+WARNING: default field not supported outside top-level definitions
+  in ./maas-backend/subscriptions/subscriptions-retrieve/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/vehicle/vehicle-alert/request.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1084,6 +1470,10 @@ WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/webhooks/webhooks-bookings-update/request.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./maas-backend/webhooks/webhooks-bookings-update/request.json
+WARNING: skipping examples handling for $ref object
+  in ./maas-backend/webhooks/webhooks-bookings-update/response.json
+WARNING: skipping default value handling for $ref object
+  in ./maas-backend/webhooks/webhooks-bookings-update/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1106,6 +1496,8 @@ INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+INFO: missing description
+  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1158,6 +1550,8 @@ WARNING: minimum field not supported outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+INFO: missing description
+  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1179,6 +1573,8 @@ INFO: primitive type "string" used outside top-level definitions
 WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
+  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+INFO: missing description
   in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/response.json
@@ -1197,6 +1593,8 @@ INFO: primitive type "integer" used outside top-level definitions
 INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/webhooks/webhooks-payments/response.json
 INFO: primitive type "string" used outside top-level definitions
+  in ./maas-backend/webhooks/webhooks-payments/response.json
+INFO: missing description
   in ./maas-backend/webhooks/webhooks-payments/response.json
 WARNING: minItems field not supported outside top-level definitions
   in ./maas-backend/webhooks/zendesk-push-notification/request.json
@@ -1300,6 +1698,10 @@ WARNING: patternProperty support has limitations
   in ./tsp/journey-planner/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ./tsp/journey-planner/request.json
+WARNING: skipping examples handling for $ref object
+  in ./tsp/journey-planner/response.json
+WARNING: skipping default value handling for $ref object
+  in ./tsp/journey-planner/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ./tsp/stations-list/request.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1314,3 +1716,5 @@ WARNING: minLength field not supported outside top-level definitions
   in ./tsp/vehicle-alert/request.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./tsp/vehicle-alert/request.json
+INFO: missing description
+  in ./tsp/webhooks-bookings-update/remote-response.json


### PR DESCRIPTION
This PR adds JSON Schema `examples` and `default` field support to converter.