### PR TITLE
WS-6269 Add preAuthBuffer to product schema

### DIFF
--- a/maas-schemas-ts/src/core/product.ts
+++ b/maas-schemas-ts/src/core/product.ts
@@ -42,26 +42,27 @@ export const Id = t.brand(
 export interface IdBrand {
   readonly Id: unique symbol;
 }
+
 // PreAuthBuffer
 // The purpose of this remains a mystery
 export type PreAuthBuffer = t.Branded<
   {
     percentageExtra?: number;
-    minimumExtra?: Fare_.Default;
+    minimumExtra?: Fare_.Fare;
   },
   PreAuthBufferBrand
 >;
 export const PreAuthBuffer = t.brand(
   t.partial({
     percentageExtra: t.number,
-    minimumExtra: Fare_.Default,
+    minimumExtra: Fare_.Fare,
   }),
   (
     x,
   ): x is t.Branded<
     {
       percentageExtra?: number;
-      minimumExtra?: Fare_.Default;
+      minimumExtra?: Fare_.Fare;
     },
     PreAuthBufferBrand
   > => true,
@@ -70,7 +71,8 @@ export const PreAuthBuffer = t.brand(
 export interface PreAuthBufferBrand {
   readonly PreAuthBuffer: unique symbol;
 }
-// Default
+
+// Product
 // The default export. More information at the top.
 export type Product = t.Branded<
   {

--- a/maas-schemas-ts/src/core/product.ts
+++ b/maas-schemas-ts/src/core/product.ts
@@ -41,8 +41,19 @@ export const Id = t.brand(
 export interface IdBrand {
   readonly Id: unique symbol;
 }
-
-// Product
+// PreAuthBufferPercentage
+// Percentage of the fare which is added as a safety margin when pre-authorizing; e.g. if 20% is added as a safety margin, this value would be 0.2
+export type PreAuthBufferPercentage = t.Branded<number, PreAuthBufferPercentageBrand>;
+export const PreAuthBufferPercentage = t.brand(
+  t.number,
+  (x): x is t.Branded<number, PreAuthBufferPercentageBrand> =>
+    typeof x !== 'number' || x % 0.01 === 0,
+  'PreAuthBufferPercentage',
+);
+export interface PreAuthBufferPercentageBrand {
+  readonly PreAuthBufferPercentage: unique symbol;
+}
+// Default
 // The default export. More information at the top.
 export type Product = t.Branded<
   {
@@ -54,6 +65,7 @@ export type Product = t.Branded<
     agencyId?: Common_.AgencyId;
     tspProductId?: string;
     allowFinishTrip?: boolean;
+    preAuthBufferPercentage?: PreAuthBufferPercentage;
   } & {
     id: Defined;
     tspProductId: Defined;
@@ -72,6 +84,7 @@ export const Product = t.brand(
       agencyId: Common_.AgencyId,
       tspProductId: t.string,
       allowFinishTrip: t.boolean,
+      preAuthBufferPercentage: PreAuthBufferPercentage,
     }),
     t.type({
       id: Defined,
@@ -91,6 +104,7 @@ export const Product = t.brand(
       agencyId?: Common_.AgencyId;
       tspProductId?: string;
       allowFinishTrip?: boolean;
+      preAuthBufferPercentage?: PreAuthBufferPercentage;
     } & {
       id: Defined;
       tspProductId: Defined;

--- a/maas-schemas-ts/src/core/product.ts
+++ b/maas-schemas-ts/src/core/product.ts
@@ -8,6 +8,7 @@ Product in core which encapsulates at least an id, name and a tspProductId
 */
 
 import * as t from 'io-ts';
+import * as Fare_ from 'maas-schemas-ts/core/components/fare';
 import * as Common_ from 'maas-schemas-ts/core/components/common';
 
 type Defined =
@@ -41,17 +42,33 @@ export const Id = t.brand(
 export interface IdBrand {
   readonly Id: unique symbol;
 }
-// PreAuthBufferPercentage
-// Percentage of the fare which is added as a safety margin when pre-authorizing; e.g. if 20% is added as a safety margin, this value would be 0.2
-export type PreAuthBufferPercentage = t.Branded<number, PreAuthBufferPercentageBrand>;
-export const PreAuthBufferPercentage = t.brand(
-  t.number,
-  (x): x is t.Branded<number, PreAuthBufferPercentageBrand> =>
-    typeof x !== 'number' || x % 0.01 === 0,
-  'PreAuthBufferPercentage',
+// PreAuthBuffer
+// The purpose of this remains a mystery
+export type PreAuthBuffer = t.Branded<
+  {
+    percentageExtra?: number;
+    minimumExtra?: Fare_.Default;
+  },
+  PreAuthBufferBrand
+>;
+export const PreAuthBuffer = t.brand(
+  t.partial({
+    percentageExtra: t.number,
+    minimumExtra: Fare_.Default,
+  }),
+  (
+    x,
+  ): x is t.Branded<
+    {
+      percentageExtra?: number;
+      minimumExtra?: Fare_.Default;
+    },
+    PreAuthBufferBrand
+  > => true,
+  'PreAuthBuffer',
 );
-export interface PreAuthBufferPercentageBrand {
-  readonly PreAuthBufferPercentage: unique symbol;
+export interface PreAuthBufferBrand {
+  readonly PreAuthBuffer: unique symbol;
 }
 // Default
 // The default export. More information at the top.
@@ -65,7 +82,7 @@ export type Product = t.Branded<
     agencyId?: Common_.AgencyId;
     tspProductId?: string;
     allowFinishTrip?: boolean;
-    preAuthBufferPercentage?: PreAuthBufferPercentage;
+    preAuthBuffer?: PreAuthBuffer;
   } & {
     id: Defined;
     tspProductId: Defined;
@@ -84,7 +101,7 @@ export const Product = t.brand(
       agencyId: Common_.AgencyId,
       tspProductId: t.string,
       allowFinishTrip: t.boolean,
-      preAuthBufferPercentage: PreAuthBufferPercentage,
+      preAuthBuffer: PreAuthBuffer,
     }),
     t.type({
       id: Defined,
@@ -104,7 +121,7 @@ export const Product = t.brand(
       agencyId?: Common_.AgencyId;
       tspProductId?: string;
       allowFinishTrip?: boolean;
-      preAuthBufferPercentage?: PreAuthBufferPercentage;
+      preAuthBuffer?: PreAuthBuffer;
     } & {
       id: Defined;
       tspProductId: Defined;

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -760,6 +760,12 @@ INFO: missing description
   in ./core/plan.json
 INFO: missing description
   in ./core/plan.json
+INFO: primitive type "number" used outside top-level definitions
+  in ./core/product.json
+WARNING: minimum field not supported outside top-level definitions
+  in ./core/product.json
+WARNING: multipleOf field not supported outside top-level definitions
+  in ./core/product.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/product.json
 WARNING: minLength field not supported outside top-level definitions
@@ -787,6 +793,8 @@ INFO: primitive type "string" used outside top-level definitions
 WARNING: minLength field not supported outside top-level definitions
   in ./core/product.json
 WARNING: maxLength field not supported outside top-level definitions
+  in ./core/product.json
+INFO: missing description
   in ./core/product.json
 INFO: missing description
   in ./core/product.json

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/product.json
+++ b/maas-schemas/schemas/core/product.json
@@ -35,6 +35,9 @@
     },
     "allowFinishTrip": {
       "type": "boolean"
+    },
+    "preAuthBufferPercentage": {
+      "$ref": "#/definitions/preAuthBufferPercentage"
     }
   },
   "definitions": {
@@ -42,6 +45,12 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 255
+    },
+    "preAuthBufferPercentage": {
+      "description": "Percentage of the fare which is added as a safety margin when pre-authorizing; e.g. if 20% is added as a safety margin, this value would be 0.2",
+      "type": "number",
+      "minimum": 0,
+      "multipleOf": 0.01
     }
   },
   "required": ["id", "tspProductId", "name"]

--- a/maas-schemas/schemas/core/product.json
+++ b/maas-schemas/schemas/core/product.json
@@ -36,8 +36,8 @@
     "allowFinishTrip": {
       "type": "boolean"
     },
-    "preAuthBufferPercentage": {
-      "$ref": "#/definitions/preAuthBufferPercentage"
+    "preAuthBuffer": {
+      "$ref": "#/definitions/preAuthBuffer"
     }
   },
   "definitions": {
@@ -46,11 +46,21 @@
       "minLength": 1,
       "maxLength": 255
     },
-    "preAuthBufferPercentage": {
-      "description": "Percentage of the fare which is added as a safety margin when pre-authorizing; e.g. if 20% is added as a safety margin, this value would be 0.2",
-      "type": "number",
-      "minimum": 0,
-      "multipleOf": 0.01
+    "preAuthBuffer": {
+      "type": "object",
+      "properties": {
+        "percentageExtra": {
+          "description": "Percentage of the fare which is added as a safety margin when pre-authorizing; e.g. if 20% is added as a safety margin, this value would be 0.2",
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 0.01
+        },
+        "minimumExtra": {
+          "description": "Minimum amount, expressed as a fare, that will be added as a safety margin to the estimated fare",
+          "$ref": "http://maasglobal.com/core/components/fare.json"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": ["id", "tspProductId", "name"]


### PR DESCRIPTION
## What has been implemented?
Add a `preAuthBufferPercentage` property to the product schema.
This is so that this can be exposed via the API to clients, so that they can inform users that the
pre-authorization on their credit card will be more than the estimated fare.