### PR TITLE
Non empty example arrays

### DIFF
--- a/maas-schemas-ts/converter.ts
+++ b/maas-schemas-ts/converter.ts
@@ -769,7 +769,8 @@ function constructDefs(defInputs: Array<DefInput>): Array<Def> {
       info('missing description');
     }
     if (examples.length > 0) {
-      imps.add("import * as t from 'io-ts';");
+      imps.add("import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';");
+      imps.add("import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';");
     }
     return {
       typeName,
@@ -845,8 +846,10 @@ for (const def of defs) {
   if (examples.length > 0) {
     const examplesName = `examples${typeName}`;
     const jsonName = `${examplesName}Json`;
-    log(`export const ${jsonName}: Array<unknown> = ${JSON.stringify(examples)};`);
-    log(`export const ${examplesName} = t.array(${typeName}).decode(${jsonName});`);
+    log(
+      `export const ${jsonName}: NonEmptyArray<unknown> = ${JSON.stringify(examples)};`,
+    );
+    log(`export const ${examplesName} = nonEmptyArray(${typeName}).decode(${jsonName});`);
   }
   if (typeof defaultValue !== 'undefined') {
     const defaultName = `default${typeName}`;

--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -54,7 +54,8 @@
   },
   "homepage": "https://github.com/maasglobal/maas-schemas-ts#readme",
   "peerDependencies": {
-    "io-ts": "^2.0.1"
+    "io-ts": "^2.0.1",
+    "io-ts-types": "^0.5.2"
   },
   "devDependencies": {
     "@types/json-schema": "^7.0.3",
@@ -72,6 +73,9 @@
     "fp-ts": "^2.0.5",
     "io-ts": "^2.0.1",
     "io-ts-codegen": "^0.4.2",
+    "io-ts-types": "^0.5.2",
+    "monocle-ts": "^2.0.0",
+    "newtype-ts": "^0.3.2",
     "prettier": "^1.18.2",
     "ts-node": "^8.4.1",
     "tslint": "^5.20.0",

--- a/maas-schemas-ts/src/core/booking.ts
+++ b/maas-schemas-ts/src/core/booking.ts
@@ -21,6 +21,8 @@ import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
 import * as Customer_ from 'maas-schemas-ts/core/customer';
 import * as Product_ from 'maas-schemas-ts/core/product';
 import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 type Defined =
   | Record<string, unknown>
@@ -307,7 +309,7 @@ export const Default = t.brand(
 export interface DefaultBrand {
   readonly Default: unique symbol;
 }
-export const examplesDefaultJson: Array<unknown> = [
+export const examplesDefaultJson: NonEmptyArray<unknown> = [
   {
     id: '12345678-ABCD-1234-ABCD-123456789ABC',
     state: 'EXPIRED',
@@ -429,7 +431,7 @@ export const examplesDefaultJson: Array<unknown> = [
     customer: { identityId: 'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958' },
   },
 ];
-export const examplesDefault = t.array(Default).decode(examplesDefaultJson);
+export const examplesDefault = nonEmptyArray(Default).decode(examplesDefaultJson);
 
 export default Default;
 

--- a/maas-schemas-ts/src/core/components/common.ts
+++ b/maas-schemas-ts/src/core/components/common.ts
@@ -8,6 +8,8 @@ MaaS common components that are used consistently within our own objects
 */
 
 import * as t from 'io-ts';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 export const schemaId = 'http://maasglobal.com/core/components/common.json';
 
@@ -103,8 +105,8 @@ export const Phone = t.brand(
 export interface PhoneBrand {
   readonly Phone: unique symbol;
 }
-export const examplesPhoneJson: Array<unknown> = ['+358401234567'];
-export const examplesPhone = t.array(Phone).decode(examplesPhoneJson);
+export const examplesPhoneJson: NonEmptyArray<unknown> = ['+358401234567'];
+export const examplesPhone = nonEmptyArray(Phone).decode(examplesPhoneJson);
 
 // RawPhone
 // Slightly looser definition of phone number
@@ -132,8 +134,8 @@ export const Email = t.brand(
 export interface EmailBrand {
   readonly Email: unique symbol;
 }
-export const examplesEmailJson: Array<unknown> = ['joe.customer@example.com'];
-export const examplesEmail = t.array(Email).decode(examplesEmailJson);
+export const examplesEmailJson: NonEmptyArray<unknown> = ['joe.customer@example.com'];
+export const examplesEmail = nonEmptyArray(Email).decode(examplesEmailJson);
 
 // PaymentSourceId
 // The purpose of this remains a mystery

--- a/maas-schemas-ts/src/core/components/units.ts
+++ b/maas-schemas-ts/src/core/components/units.ts
@@ -8,6 +8,8 @@ MaaS common units that are used consistently within our own objects
 */
 
 import * as t from 'io-ts';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 export const schemaId = 'http://maasglobal.com/core/components/units.json';
 
@@ -24,8 +26,10 @@ export const Uuid = t.brand(
 export interface UuidBrand {
   readonly Uuid: unique symbol;
 }
-export const examplesUuidJson: Array<unknown> = ['4828507e-683f-41bf-9d87-689808fbf958'];
-export const examplesUuid = t.array(Uuid).decode(examplesUuidJson);
+export const examplesUuidJson: NonEmptyArray<unknown> = [
+  '4828507e-683f-41bf-9d87-689808fbf958',
+];
+export const examplesUuid = nonEmptyArray(Uuid).decode(examplesUuidJson);
 
 // Url
 // Uniform resource locator, see https://en.wikipedia.org/wiki/Uniform_Resource_Locator and https://mathiasbynens.be/demo/url-regex
@@ -74,12 +78,12 @@ export const ObsoleteIdentityId = t.brand(
 export interface ObsoleteIdentityIdBrand {
   readonly ObsoleteIdentityId: unique symbol;
 }
-export const examplesObsoleteIdentityIdJson: Array<unknown> = [
+export const examplesObsoleteIdentityIdJson: NonEmptyArray<unknown> = [
   'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
 ];
-export const examplesObsoleteIdentityId = t
-  .array(ObsoleteIdentityId)
-  .decode(examplesObsoleteIdentityIdJson);
+export const examplesObsoleteIdentityId = nonEmptyArray(ObsoleteIdentityId).decode(
+  examplesObsoleteIdentityIdJson,
+);
 
 // IdentityId
 // The purpose of this remains a mystery
@@ -92,11 +96,13 @@ export const IdentityId = t.brand(
 export interface IdentityIdBrand {
   readonly IdentityId: unique symbol;
 }
-export const examplesIdentityIdJson: Array<unknown> = [
+export const examplesIdentityIdJson: NonEmptyArray<unknown> = [
   'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
   '4828507e-683f-41bf-9d87-689808fbf958',
 ];
-export const examplesIdentityId = t.array(IdentityId).decode(examplesIdentityIdJson);
+export const examplesIdentityId = nonEmptyArray(IdentityId).decode(
+  examplesIdentityIdJson,
+);
 
 // Currency
 // Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -13,6 +13,8 @@ import * as Common_ from 'maas-schemas-ts/core/components/common';
 import * as Address_ from 'maas-schemas-ts/core/components/address';
 import * as I18n_ from 'maas-schemas-ts/core/components/i18n';
 import * as Fare_ from 'maas-schemas-ts/core/components/fare';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 type Defined =
   | Record<string, unknown>
@@ -209,7 +211,7 @@ export const Default = t.brand(
 export interface DefaultBrand {
   readonly Default: unique symbol;
 }
-export const examplesDefaultJson: Array<unknown> = [
+export const examplesDefaultJson: NonEmptyArray<unknown> = [
   {
     identityId: 'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
     id: 1234,
@@ -272,7 +274,7 @@ export const examplesDefaultJson: Array<unknown> = [
     balance: 1234,
   },
 ];
-export const examplesDefault = t.array(Default).decode(examplesDefaultJson);
+export const examplesDefault = nonEmptyArray(Default).decode(examplesDefaultJson);
 
 export default Default;
 

--- a/maas-schemas-ts/src/environments/environments.ts
+++ b/maas-schemas-ts/src/environments/environments.ts
@@ -10,6 +10,8 @@ The base environments object with several environment groups and related meta da
 import * as t from 'io-ts';
 import * as Common_ from 'maas-schemas-ts/core/components/common';
 import * as Units_ from 'maas-schemas-ts/core/components/units';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 type Defined =
   | Record<string, unknown>
@@ -186,7 +188,7 @@ export const Environment = t.brand(
 export interface EnvironmentBrand {
   readonly Environment: unique symbol;
 }
-export const examplesEnvironmentJson: Array<unknown> = [
+export const examplesEnvironmentJson: NonEmptyArray<unknown> = [
   {
     id: 'production',
     api: 'https://production.example.com/api/',
@@ -195,7 +197,9 @@ export const examplesEnvironmentJson: Array<unknown> = [
     description: 'Production environment',
   },
 ];
-export const examplesEnvironment = t.array(Environment).decode(examplesEnvironmentJson);
+export const examplesEnvironment = nonEmptyArray(Environment).decode(
+  examplesEnvironmentJson,
+);
 
 // DevEnvironment
 // The purpose of this remains a mystery
@@ -236,7 +240,7 @@ export const DevEnvironment = t.brand(
 export interface DevEnvironmentBrand {
   readonly DevEnvironment: unique symbol;
 }
-export const examplesDevEnvironmentJson: Array<unknown> = [
+export const examplesDevEnvironmentJson: NonEmptyArray<unknown> = [
   {
     id: 'testing',
     api: 'https://testing.example.com/api/',
@@ -245,9 +249,9 @@ export const examplesDevEnvironmentJson: Array<unknown> = [
     description: 'Testing environment',
   },
 ];
-export const examplesDevEnvironment = t
-  .array(DevEnvironment)
-  .decode(examplesDevEnvironmentJson);
+export const examplesDevEnvironment = nonEmptyArray(DevEnvironment).decode(
+  examplesDevEnvironmentJson,
+);
 
 // EnvironmentGroupName
 // The purpose of this remains a mystery
@@ -354,7 +358,7 @@ export const Default = t.brand(
 export interface DefaultBrand {
   readonly Default: unique symbol;
 }
-export const examplesDefaultJson: Array<unknown> = [
+export const examplesDefaultJson: NonEmptyArray<unknown> = [
   {
     index: [
       {
@@ -392,7 +396,7 @@ export const examplesDefaultJson: Array<unknown> = [
     ],
   },
 ];
-export const examplesDefault = t.array(Default).decode(examplesDefaultJson);
+export const examplesDefault = nonEmptyArray(Default).decode(examplesDefaultJson);
 
 export default Default;
 

--- a/maas-schemas-ts/yarn.lock
+++ b/maas-schemas-ts/yarn.lock
@@ -743,6 +743,11 @@ io-ts-codegen@^0.4.2:
   resolved "https://registry.yarnpkg.com/io-ts-codegen/-/io-ts-codegen-0.4.2.tgz#b30513490587cd9d420c542c548d1083c3f5d74d"
   integrity sha512-UnTF3TfIFCPK2wlaZO0cNweeOIUjeCXzE3gfYOd7QY8W1xyQz1b69ggWIvqKuDx29SbSMjnvG3IR4MjmrWfIWg==
 
+io-ts-types@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/io-ts-types/-/io-ts-types-0.5.2.tgz#ff884926678a0418d36eb85045b0cf014698e554"
+  integrity sha512-ebIXH/Pf7IC/M4qa5wnQecJCs6MXZMZWaiZNWNzEP7tw+Hl8wapAI/tzBXn1LSGrpkVe0NIsFeL7yy6Byi3h+g==
+
 io-ts@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.0.1.tgz#1261c12f915c2f48d16393a36966636b48a45aa1"
@@ -917,6 +922,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+monocle-ts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.0.0.tgz#f695dbfb5b017846d95f0c377bd4c8acb10f7e02"
+  integrity sha512-vPM02WypUz0Xo2MtLUPgvdelCRn70VT05pdAB7qmHJSNY4CAoQt3ClpH77AG3yZk7PY8CA6++ezHcENUDOiuEA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -936,6 +946,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+newtype-ts@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/newtype-ts/-/newtype-ts-0.3.2.tgz#a25db880f9c601b4ea8fc61658ffa399d60f62e2"
+  integrity sha512-1F5ff8LdXtMgcuy+t2F0q6b8VCt26YiXCw/YCSLacBBGH5N+fkFzNoRzvvP6JAjmFCb1Zcfyn0ZyJOCJIpTkKQ==
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
This PR changes examples arrays type from `Array` to `NonEmptyArray`. This makes it unnecessary to perform separate checks to make sure they contain items when all you you want is one example.