### PR TITLE
Remove obsolete profile.balance property

### DIFF
--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -272,7 +272,6 @@ export const examplesCustomerJson: NonEmptyArray<unknown> = [
       modified: 0,
       currency: 'EUR',
     },
-    balance: 1234,
   },
 ];
 export const examplesCustomer = nonEmptyArray(Customer).decode(examplesCustomerJson);

--- a/maas-schemas-ts/src/core/profile.ts
+++ b/maas-schemas-ts/src/core/profile.ts
@@ -152,7 +152,6 @@ export type Profile = t.Branded<
     };
     subscription?: {};
     subscriptionInstance?: SubscriptionInstance;
-    balance?: number;
     balances?: Array<Fare_.Fare>;
     created?: Units_.Time;
     modified?: Units_.Time;
@@ -200,7 +199,6 @@ export const Profile = t.brand(
       ]),
       subscription: t.type({}),
       subscriptionInstance: SubscriptionInstance,
-      balance: t.number,
       balances: t.array(Fare_.Fare),
       created: Units_.Time,
       modified: Units_.Time,
@@ -243,7 +241,6 @@ export const Profile = t.brand(
       };
       subscription?: {};
       subscriptionInstance?: SubscriptionInstance;
-      balance?: number;
       balances?: Array<Fare_.Fare>;
       created?: Units_.Time;
       modified?: Units_.Time;

--- a/maas-schemas-ts/src/core/profile.ts
+++ b/maas-schemas-ts/src/core/profile.ts
@@ -160,7 +160,6 @@ export type Profile = t.Branded<
     identityId: Defined;
     phone: Defined;
     favoriteLocations: Defined;
-    balance: Defined;
     paymentMethod: Defined;
     subscriptionInstance: Defined;
     balances: Defined;
@@ -210,7 +209,6 @@ export const Profile = t.brand(
       identityId: Defined,
       phone: Defined,
       favoriteLocations: Defined,
-      balance: Defined,
       paymentMethod: Defined,
       subscriptionInstance: Defined,
       balances: Defined,
@@ -253,7 +251,6 @@ export const Profile = t.brand(
       identityId: Defined;
       phone: Defined;
       favoriteLocations: Defined;
-      balance: Defined;
       paymentMethod: Defined;
       subscriptionInstance: Defined;
       balances: Defined;

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -878,12 +878,6 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/profile.json
-INFO: primitive type "integer" used outside top-level definitions
-  in ./core/profile.json
-WARNING: minimum field not supported outside top-level definitions
-  in ./core/profile.json
-WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/profile.json
 INFO: missing description
   in ./core/profile.json
 INFO: primitive type "string" used outside top-level definitions

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/customer.json
+++ b/maas-schemas/schemas/core/customer.json
@@ -191,8 +191,7 @@
         "created": 1553687004207,
         "modified": 0,
         "currency": "EUR"
-      },
-      "balance": 1234
+      }
     }
   ]
 }

--- a/maas-schemas/schemas/core/profile.json
+++ b/maas-schemas/schemas/core/profile.json
@@ -106,15 +106,7 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "identityId",
-    "phone",
-    "favoriteLocations",
-    "balance",
-    "paymentMethod",
-    "subscriptionInstance",
-    "balances"
-  ],
+  "required": ["identityId", "phone", "favoriteLocations", "paymentMethod", "subscriptionInstance", "balances"],
   "definitions": {
     "subscriptionInstance": {
       "type": "object",

--- a/maas-schemas/schemas/core/profile.json
+++ b/maas-schemas/schemas/core/profile.json
@@ -87,11 +87,6 @@
     "subscriptionInstance": {
       "$ref": "#/definitions/subscriptionInstance"
     },
-    "balance": {
-      "type": "integer",
-      "minimum": 0,
-      "multipleOf": 1
-    },
     "balances": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Since this property has become unused on clients, removing it (it is only a polyfill for older clients. All clients now use `balances`)