### PR TITLE
Deploy docs to gh-pages branch when merged to master 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,17 @@ jobs:
         - yarn --cwd maas-schemas ci
         - yarn --cwd maas-schemas-ts ci
     - stage: deploy
-      script: skip
-      before_deploy:
+      script:
         - cd maas-schemas
+        - yarn build
+        - yarn docs
+        - echo Deploying docs to GitHub pages of ${TRAVIS_REPO_SLUG}
+        - git remote add origin-pages https://github:${GITHUB_API_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+        - yarn gh-pages -o origin-pages
       deploy:
         provider: npm
         email: tech@maas.global
         skip_cleanup: true
         api_key: $NPM_TOKEN
-      after_deploy: ./maas-schemas/scripts/tag.sh
+      after_deploy: ./scripts/tag.sh
+


### PR DESCRIPTION
Builds and deploys documentation, similar to available at https://huksley.github.io/maas-schemas/
uses GITHUB_API_TOKEN to push to remote branch
 