### PR TITLE
Fix Travis CI DPL issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+version: 1.0
 node_js: "12"
 cache:
   directories:
@@ -28,6 +29,7 @@ jobs:
         - cd maas-schemas
       deploy:
         provider: npm
+        edge: true
         email: tech@maas.global
         skip_cleanup: true
         api_key: $NPM_TOKEN


### PR DESCRIPTION
After me adding script with publishing a documentation, 
somehow cannot deploy NPM package now
https://travis-ci.org/maasglobal/maas-schemas/builds/644362775?utm_medium=notification&utm_source=github_status

```
Installing deploy dependencies
Preparing deploy
missing api_key
```

Found this discussion and applying fixes there now
https://stackoverflow.com/questions/59169352/travis-ci-npm-release-error-missing-api-key