### PR TITLE
Adds a pickupIdenitification 

### DIFF
--- a/maas-schemas-ts/src/core/modes/MODE_TAXI.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_TAXI.ts
@@ -29,6 +29,7 @@ export type MODE_TAXI = t.Branded<
       image?: Units_.Url;
       rating?: number;
     };
+    pickupIdentificationCode?: string;
     dispatchOrderId?: string;
     eta?: Units_.Time;
     taxiCenter?: {
@@ -52,6 +53,7 @@ export const MODE_TAXI = t.brand(
       image: Units_.Url,
       rating: t.number,
     }),
+    pickupIdentificationCode: t.string,
     dispatchOrderId: t.string,
     eta: Units_.Time,
     taxiCenter: t.partial({
@@ -75,6 +77,7 @@ export const MODE_TAXI = t.brand(
         image?: Units_.Url;
         rating?: number;
       };
+      pickupIdentificationCode?: string;
       dispatchOrderId?: string;
       eta?: Units_.Time;
       taxiCenter?: {

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -724,6 +724,12 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/modes/MODE_TAXI.json
+INFO: primitive type "string" used outside top-level definitions
+  in ./core/modes/MODE_TAXI.json
+WARNING: minLength field not supported outside top-level definitions
+  in ./core/modes/MODE_TAXI.json
+WARNING: maxLength field not supported outside top-level definitions
+  in ./core/modes/MODE_TAXI.json
 INFO: primitive type "number" used outside top-level definitions
   in ./core/partialFavoriteLocation.json
 INFO: primitive type "string" used outside top-level definitions

--- a/maas-schemas/schemas/core/modes/MODE_TAXI.json
+++ b/maas-schemas/schemas/core/modes/MODE_TAXI.json
@@ -45,7 +45,14 @@
         }
       }
     },
+    "pickupIdentificationCode": {
+      "description": "Any code that the user can show/tell to the driver to confirm legitimacy of the ride (name, letters, numbers - depends on the service provider)",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8
+    },
     "dispatchOrderId": {
+      "description": "An internal use only number identifying the dispatch id for inspection",
       "type": "string",
       "minLength": 1,
       "maxLength": 128


### PR DESCRIPTION
## What has been implemented?

Adds a `pickupIdenitificationCode` property in MODE_TAXI as something show to the taxi driver confirming legitimacy of the user.

The user would show or tell the code to the taxi driver to confirm that he's a legitimate taxi user, which is needed in one of the taxi integrations.

## Todos:

- [ ] Write tests

## Versioning:

- [ ] Breaking change
