### PR TITLE
WS-7267  Add regionDefault property to SubscriptionOption 

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "12.0.1",
+  "version": "13.0.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionOption.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionOption.ts
@@ -36,6 +36,7 @@ export type SubscriptionAdditions = t.Branded<
   {
     discounts?: Array<unknown>;
     requiredAuthorizations?: Array<Common_.AgencyId>;
+    regionDefault?: boolean;
   } & {
     plan: Defined;
     wmpGrant: Defined;
@@ -43,6 +44,7 @@ export type SubscriptionAdditions = t.Branded<
     addons: Defined;
     coupons: Defined;
     requiredAuthorizations: Defined;
+    regionDefault: Defined;
   },
   SubscriptionAdditionsBrand
 >;
@@ -51,6 +53,7 @@ export const SubscriptionAdditions = t.brand(
     t.partial({
       discounts: t.UnknownArray,
       requiredAuthorizations: t.array(Common_.AgencyId),
+      regionDefault: t.boolean,
     }),
     t.type({
       plan: Defined,
@@ -59,6 +62,7 @@ export const SubscriptionAdditions = t.brand(
       addons: Defined,
       coupons: Defined,
       requiredAuthorizations: Defined,
+      regionDefault: Defined,
     }),
   ]),
   (
@@ -67,6 +71,7 @@ export const SubscriptionAdditions = t.brand(
     {
       discounts?: Array<unknown>;
       requiredAuthorizations?: Array<Common_.AgencyId>;
+      regionDefault?: boolean;
     } & {
       plan: Defined;
       wmpGrant: Defined;
@@ -74,6 +79,7 @@ export const SubscriptionAdditions = t.brand(
       addons: Defined;
       coupons: Defined;
       requiredAuthorizations: Defined;
+      regionDefault: Defined;
     },
     SubscriptionAdditionsBrand
   > => true,

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "12.0.1",
+  "version": "13.0.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/maas-backend/subscriptions/subscriptionOption.json
+++ b/maas-schemas/schemas/maas-backend/subscriptions/subscriptionOption.json
@@ -19,9 +19,13 @@
             "$ref": "http://maasglobal.com/core/components/common.json#/definitions/agencyId"
           },
           "minItems": 0
+        },
+        "regionDefault": {
+          "description": "Is this subscription option the default one for the region",
+          "type": "boolean"
         }
       },
-      "required": ["plan", "wmpGrant", "pointCost", "addons", "coupons", "requiredAuthorizations"],
+      "required": ["plan", "wmpGrant", "pointCost", "addons", "coupons", "requiredAuthorizations", "regionDefault"],
       "additionalProperties": true
     }
   }


### PR DESCRIPTION
## What has been implemented?
Add a required `regionDefault` flag to `SubscriptionOption`.
Currently, clients are using a variety of ways to determine which plan is the default one for a given region. This adds an explicit flag so that the data can be provided by the backend.

## Versioning:

- [x] Breaking change
