### PR TITLE
Fix schema validation on each file not running

### DIFF
--- a/maas-schemas/test/feature-require-schemas.js
+++ b/maas-schemas/test/feature-require-schemas.js
@@ -7,34 +7,15 @@ const ajvFactory = require('ajv');
 
 const ajv = ajvFactory({ allErrors: true });
 
-function globPromise(pattern, options) {
-  return new Promise((resolve, reject) => {
-    glob(pattern, options || {}, (err, matches) => {
-      if (err) return reject(err);
-      return resolve(matches);
-    });
-  });
-}
-
 describe('Source schemas should be valid JSON Schemas', () => {
-  before(() => {
-    return globPromise('schemas/**/*.json').then(schemaPaths => {
-      describe(`Validate ${schemaPaths.length} schemas`, () => {
-        schemaPaths.forEach(schemaPath => {
-          it(`should be a able to require a valid schema ${schemaPath}`, () => {
-            const filePath = path.resolve(__dirname, '..', schemaPath);
-            // eslint-disable-next-line import/no-dynamic-require
-            const schema = require(filePath);
-            const valid = ajv.validateSchema(schema);
-            expect(ajv.errors || []).to.eql([]);
-            expect(valid).to.be.true;
-          });
-        });
-      });
+  glob.sync('schemas/**/*.json').forEach(schemaPath => {
+    it(`should be a valid schema ${schemaPath}`, () => {
+      const filePath = path.resolve(__dirname, '..', schemaPath);
+      // eslint-disable-next-line import/no-dynamic-require
+      const schema = require(filePath);
+      const valid = ajv.validateSchema(schema);
+      expect(ajv.errors || []).to.eql([]);
+      expect(valid).to.be.true;
     });
-  });
-
-  it('[placeholder to trigger before()]', () => {
-    return Promise.resolve();
   });
 });


### PR DESCRIPTION
Async test case generation was not working.

You can now see in the output:
```
 PASS  test/feature-require-schemas.js
  Source schemas should be valid JSON Schemas
    ✓ should be a valid schema schemas/core/booking-meta.json (8ms)
    ✓ should be a valid schema schemas/core/booking-option.json (2ms)
    ✓ should be a valid schema schemas/core/booking.json (1ms)
    ✓ should be a valid schema schemas/core/card.json (1ms)
...
```