### PR TITLE
Add tspFixedPrice property.

### DIFF
--- a/maas-schemas-ts/src/core/components/cost.ts
+++ b/maas-schemas-ts/src/core/components/cost.ts
@@ -36,6 +36,7 @@ export type Cost = t.Branded<
     originalAmount?: number | null;
     discount?: number;
     taxes?: number;
+    tspFixedPrice?: boolean;
     currency?: Units_.Currency | null;
   } & {
     amount: Defined;
@@ -50,6 +51,7 @@ export const Cost = t.brand(
       originalAmount: t.union([t.number, t.null]),
       discount: t.number,
       taxes: t.number,
+      tspFixedPrice: t.boolean,
       currency: t.union([Units_.Currency, t.null]),
     }),
     t.type({
@@ -65,6 +67,7 @@ export const Cost = t.brand(
       originalAmount?: number | null;
       discount?: number;
       taxes?: number;
+      tspFixedPrice?: boolean;
       currency?: Units_.Currency | null;
     } & {
       amount: Defined;

--- a/maas-schemas-ts/src/core/components/cost.ts
+++ b/maas-schemas-ts/src/core/components/cost.ts
@@ -36,7 +36,7 @@ export type Cost = t.Branded<
     originalAmount?: number | null;
     discount?: number;
     taxes?: number;
-    tspFixedPrice?: boolean;
+    isFixedPrice?: boolean;
     currency?: Units_.Currency | null;
   } & {
     amount: Defined;
@@ -51,7 +51,7 @@ export const Cost = t.brand(
       originalAmount: t.union([t.number, t.null]),
       discount: t.number,
       taxes: t.number,
-      tspFixedPrice: t.boolean,
+      isFixedPrice: t.boolean,
       currency: t.union([Units_.Currency, t.null]),
     }),
     t.type({
@@ -67,7 +67,7 @@ export const Cost = t.brand(
       originalAmount?: number | null;
       discount?: number;
       taxes?: number;
-      tspFixedPrice?: boolean;
+      isFixedPrice?: boolean;
       currency?: Units_.Currency | null;
     } & {
       amount: Defined;

--- a/maas-schemas/schemas/core/components/cost.json
+++ b/maas-schemas/schemas/core/components/cost.json
@@ -23,7 +23,7 @@
       "minimum": 0,
       "multipleOf": 0.01
     },
-    "tspFixedPrice": {
+    "isFixedPrice": {
       "type": "boolean",
       "description": "A flag indicating whether TSP price is fixed"
     },

--- a/maas-schemas/schemas/core/components/cost.json
+++ b/maas-schemas/schemas/core/components/cost.json
@@ -23,6 +23,10 @@
       "minimum": 0,
       "multipleOf": 0.01
     },
+    "tspFixedPrice": {
+      "type": "boolean",
+      "description": "A flag indicating whether TSP price is fixed"
+    },
     "currency": {
       "oneOf": [
         { "$ref": "http://maasglobal.com/core/components/units.json#/definitions/currency" },


### PR DESCRIPTION
Related Task WS-7146

## What has been implemented?
Add support for property that indicates whether tsp returns fixed price.
Based on this property we can ignore preAuth buffer and don't add extra cost to final fare in backend.