### PR TITLE
Avoid examples decode

### DIFF
--- a/maas-schemas-ts/converter.ts
+++ b/maas-schemas-ts/converter.ts
@@ -909,20 +909,26 @@ for (const def of defs) {
   log(staticType);
   log(runtimeType);
   if (examples.length > 0) {
-    const examplesName = `examples${typeName}`;
-    const jsonName = `${examplesName}Json`;
-    log(`/** ${examplesName} // => { _tag: 'Right', right: ${jsonName} } */`);
+    const examplesName = 'examples'.concat(typeName);
     log(
-      `export const ${jsonName}: NonEmptyArray<unknown> = ${JSON.stringify(examples)};`,
+      `/** nonEmptyArray(${typeName}).decode(${examplesName}) // => { _tag: 'Right', right: ${examplesName} } */`,
     );
-    log(`export const ${examplesName} = nonEmptyArray(${typeName}).decode(${jsonName});`);
+    log(
+      `export const ${examplesName}: NonEmptyArray<${typeName}> = ${JSON.stringify(
+        examples,
+      )} as unknown as NonEmptyArray<${typeName}>;`,
+    );
   }
   if (typeof defaultValue !== 'undefined') {
-    const defaultName = `default${typeName}`;
-    const jsonName = `${defaultName}Json`;
-    log(`/** ${defaultName} // => { _tag: 'Right', right: ${jsonName} } */`);
-    log(`export const ${jsonName}: unknown = ${JSON.stringify(defaultValue)};`);
-    log(`export const ${defaultName} = ${typeName}.decode(${jsonName});`);
+    const defaultName = 'default'.concat(typeName);
+    log(
+      `/** ${typeName}.decode(${defaultName}) // => { _tag: 'Right', right: ${defaultName} } */`,
+    );
+    log(
+      `export const ${defaultName}: ${typeName} = ${JSON.stringify(
+        defaultValue,
+      )} as unknown as ${typeName};`,
+    );
   }
   log('');
 }

--- a/maas-schemas-ts/src/core/booking.ts
+++ b/maas-schemas-ts/src/core/booking.ts
@@ -309,8 +309,8 @@ export const Booking = t.brand(
 export interface BookingBrand {
   readonly Booking: unique symbol;
 }
-/** examplesBooking // => { _tag: 'Right', right: examplesBookingJson } */
-export const examplesBookingJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Booking).decode(examplesBooking) // => { _tag: 'Right', right: examplesBooking } */
+export const examplesBooking: NonEmptyArray<Booking> = ([
   {
     id: '12345678-ABCD-1234-ABCD-123456789ABC',
     state: 'EXPIRED',
@@ -431,8 +431,7 @@ export const examplesBookingJson: NonEmptyArray<unknown> = [
     cancelling: false,
     customer: { identityId: 'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958' },
   },
-];
-export const examplesBooking = nonEmptyArray(Booking).decode(examplesBookingJson);
+] as unknown) as NonEmptyArray<Booking>;
 
 export default Booking;
 

--- a/maas-schemas-ts/src/core/components/address.ts
+++ b/maas-schemas-ts/src/core/components/address.ts
@@ -32,8 +32,8 @@ export const ComponentAddress = t.brand(
 export interface ComponentAddressBrand {
   readonly ComponentAddress: unique symbol;
 }
-/** examplesComponentAddress // => { _tag: 'Right', right: examplesComponentAddressJson } */
-export const examplesComponentAddressJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(ComponentAddress).decode(examplesComponentAddress) // => { _tag: 'Right', right: examplesComponentAddress } */
+export const examplesComponentAddress: NonEmptyArray<ComponentAddress> = ([
   'state:Tōkyō-to|district:Kanda Nishikichō 3-chōme|streetNumber:4-パレステュディオ御茶ノ水駿河台参番館|zipCode:101-0054|city:Chiyoda-City|country:Japan',
   "streetName:Tarkk'ampujänkätu|city:Helsinki|country:Finland|state:Uusimaa|streetNumber:1|zipCode:00100|district:Tapiola",
   "streetName:Hämeentie Töölöntori Lähettilääntie Tarkk'ampujänkätu",
@@ -53,10 +53,7 @@ export const examplesComponentAddressJson: NonEmptyArray<unknown> = [
   'country:skandinavisk',
   'streetNumber:1-1',
   'streetNumber:1/2-d2',
-];
-export const examplesComponentAddress = nonEmptyArray(ComponentAddress).decode(
-  examplesComponentAddressJson,
-);
+] as unknown) as NonEmptyArray<ComponentAddress>;
 
 // PlaceName
 // Place name (given in autocomplete)

--- a/maas-schemas-ts/src/core/components/common.ts
+++ b/maas-schemas-ts/src/core/components/common.ts
@@ -105,9 +105,10 @@ export const Phone = t.brand(
 export interface PhoneBrand {
   readonly Phone: unique symbol;
 }
-/** examplesPhone // => { _tag: 'Right', right: examplesPhoneJson } */
-export const examplesPhoneJson: NonEmptyArray<unknown> = ['+358401234567'];
-export const examplesPhone = nonEmptyArray(Phone).decode(examplesPhoneJson);
+/** nonEmptyArray(Phone).decode(examplesPhone) // => { _tag: 'Right', right: examplesPhone } */
+export const examplesPhone: NonEmptyArray<Phone> = ([
+  '+358401234567',
+] as unknown) as NonEmptyArray<Phone>;
 
 // RawPhone
 // Slightly looser definition of phone number
@@ -135,9 +136,10 @@ export const Email = t.brand(
 export interface EmailBrand {
   readonly Email: unique symbol;
 }
-/** examplesEmail // => { _tag: 'Right', right: examplesEmailJson } */
-export const examplesEmailJson: NonEmptyArray<unknown> = ['joe.customer@example.com'];
-export const examplesEmail = nonEmptyArray(Email).decode(examplesEmailJson);
+/** nonEmptyArray(Email).decode(examplesEmail) // => { _tag: 'Right', right: examplesEmail } */
+export const examplesEmail: NonEmptyArray<Email> = ([
+  'joe.customer@example.com',
+] as unknown) as NonEmptyArray<Email>;
 
 // PaymentSourceId
 // The purpose of this remains a mystery

--- a/maas-schemas-ts/src/core/components/units.ts
+++ b/maas-schemas-ts/src/core/components/units.ts
@@ -26,11 +26,10 @@ export const Uuid = t.brand(
 export interface UuidBrand {
   readonly Uuid: unique symbol;
 }
-/** examplesUuid // => { _tag: 'Right', right: examplesUuidJson } */
-export const examplesUuidJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Uuid).decode(examplesUuid) // => { _tag: 'Right', right: examplesUuid } */
+export const examplesUuid: NonEmptyArray<Uuid> = ([
   '4828507e-683f-41bf-9d87-689808fbf958',
-];
-export const examplesUuid = nonEmptyArray(Uuid).decode(examplesUuidJson);
+] as unknown) as NonEmptyArray<Uuid>;
 
 // Url
 // Uniform resource locator, see https://en.wikipedia.org/wiki/Uniform_Resource_Locator and https://mathiasbynens.be/demo/url-regex
@@ -79,13 +78,10 @@ export const ObsoleteIdentityId = t.brand(
 export interface ObsoleteIdentityIdBrand {
   readonly ObsoleteIdentityId: unique symbol;
 }
-/** examplesObsoleteIdentityId // => { _tag: 'Right', right: examplesObsoleteIdentityIdJson } */
-export const examplesObsoleteIdentityIdJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(ObsoleteIdentityId).decode(examplesObsoleteIdentityId) // => { _tag: 'Right', right: examplesObsoleteIdentityId } */
+export const examplesObsoleteIdentityId: NonEmptyArray<ObsoleteIdentityId> = ([
   'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
-];
-export const examplesObsoleteIdentityId = nonEmptyArray(ObsoleteIdentityId).decode(
-  examplesObsoleteIdentityIdJson,
-);
+] as unknown) as NonEmptyArray<ObsoleteIdentityId>;
 
 // IdentityId
 // The purpose of this remains a mystery
@@ -98,14 +94,11 @@ export const IdentityId = t.brand(
 export interface IdentityIdBrand {
   readonly IdentityId: unique symbol;
 }
-/** examplesIdentityId // => { _tag: 'Right', right: examplesIdentityIdJson } */
-export const examplesIdentityIdJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(IdentityId).decode(examplesIdentityId) // => { _tag: 'Right', right: examplesIdentityId } */
+export const examplesIdentityId: NonEmptyArray<IdentityId> = ([
   'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
   '4828507e-683f-41bf-9d87-689808fbf958',
-];
-export const examplesIdentityId = nonEmptyArray(IdentityId).decode(
-  examplesIdentityIdJson,
-);
+] as unknown) as NonEmptyArray<IdentityId>;
 
 // Currency
 // Accepted monetary unit in ISO 4127 format, see https://en.wikipedia.org/wiki/ISO_4217#cite_note-1

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -226,8 +226,8 @@ export const Customer = t.brand(
 export interface CustomerBrand {
   readonly Customer: unique symbol;
 }
-/** examplesCustomer // => { _tag: 'Right', right: examplesCustomerJson } */
-export const examplesCustomerJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Customer).decode(examplesCustomer) // => { _tag: 'Right', right: examplesCustomer } */
+export const examplesCustomer: NonEmptyArray<Customer> = ([
   {
     identityId: 'eu-west-1:4828507e-683f-41bf-9d87-689808fbf958',
     id: 1234,
@@ -290,8 +290,7 @@ export const examplesCustomerJson: NonEmptyArray<unknown> = [
       currency: 'EUR',
     },
   },
-];
-export const examplesCustomer = nonEmptyArray(Customer).decode(examplesCustomerJson);
+] as unknown) as NonEmptyArray<Customer>;
 
 export default Customer;
 

--- a/maas-schemas-ts/src/environments/environments.ts
+++ b/maas-schemas-ts/src/environments/environments.ts
@@ -188,8 +188,8 @@ export const Environment = t.brand(
 export interface EnvironmentBrand {
   readonly Environment: unique symbol;
 }
-/** examplesEnvironment // => { _tag: 'Right', right: examplesEnvironmentJson } */
-export const examplesEnvironmentJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Environment).decode(examplesEnvironment) // => { _tag: 'Right', right: examplesEnvironment } */
+export const examplesEnvironment: NonEmptyArray<Environment> = ([
   {
     id: 'production',
     api: 'https://production.example.com/api/',
@@ -197,10 +197,7 @@ export const examplesEnvironmentJson: NonEmptyArray<unknown> = [
     contact: { name: 'Alisha Admin', email: 'admin@example.com' },
     description: 'Production environment',
   },
-];
-export const examplesEnvironment = nonEmptyArray(Environment).decode(
-  examplesEnvironmentJson,
-);
+] as unknown) as NonEmptyArray<Environment>;
 
 // DevEnvironment
 // The purpose of this remains a mystery
@@ -241,8 +238,8 @@ export const DevEnvironment = t.brand(
 export interface DevEnvironmentBrand {
   readonly DevEnvironment: unique symbol;
 }
-/** examplesDevEnvironment // => { _tag: 'Right', right: examplesDevEnvironmentJson } */
-export const examplesDevEnvironmentJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(DevEnvironment).decode(examplesDevEnvironment) // => { _tag: 'Right', right: examplesDevEnvironment } */
+export const examplesDevEnvironment: NonEmptyArray<DevEnvironment> = ([
   {
     id: 'testing',
     api: 'https://testing.example.com/api/',
@@ -250,10 +247,7 @@ export const examplesDevEnvironmentJson: NonEmptyArray<unknown> = [
     contact: { name: 'Alisha Admin' },
     description: 'Testing environment',
   },
-];
-export const examplesDevEnvironment = nonEmptyArray(DevEnvironment).decode(
-  examplesDevEnvironmentJson,
-);
+] as unknown) as NonEmptyArray<DevEnvironment>;
 
 // EnvironmentGroupName
 // The purpose of this remains a mystery
@@ -360,8 +354,8 @@ export const Environments = t.brand(
 export interface EnvironmentsBrand {
   readonly Environments: unique symbol;
 }
-/** examplesEnvironments // => { _tag: 'Right', right: examplesEnvironmentsJson } */
-export const examplesEnvironmentsJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Environments).decode(examplesEnvironments) // => { _tag: 'Right', right: examplesEnvironments } */
+export const examplesEnvironments: NonEmptyArray<Environments> = ([
   {
     index: [
       {
@@ -398,10 +392,7 @@ export const examplesEnvironmentsJson: NonEmptyArray<unknown> = [
       },
     ],
   },
-];
-export const examplesEnvironments = nonEmptyArray(Environments).decode(
-  examplesEnvironmentsJson,
-);
+] as unknown) as NonEmptyArray<Environments>;
 
 export default Environments;
 

--- a/maas-schemas-ts/src/tsp/booking-create/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-create/request.ts
@@ -99,8 +99,8 @@ export const Request = t.brand(
 export interface RequestBrand {
   readonly Request: unique symbol;
 }
-/** examplesRequest // => { _tag: 'Right', right: examplesRequestJson } */
-export const examplesRequestJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Request).decode(examplesRequest) // => { _tag: 'Right', right: examplesRequest } */
+export const examplesRequest: NonEmptyArray<Request> = ([
   {
     leg: {
       to: {
@@ -149,8 +149,7 @@ export const examplesRequestJson: NonEmptyArray<unknown> = [
     tspId: null,
     tspProduct: { id: 'testtaxi1-product1' },
   },
-];
-export const examplesRequest = nonEmptyArray(Request).decode(examplesRequestJson);
+] as unknown) as NonEmptyArray<Request>;
 
 export default Request;
 

--- a/maas-schemas-ts/src/tsp/booking-create/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-create/response.ts
@@ -114,8 +114,8 @@ export const Response = t.brand(
 export interface ResponseBrand {
   readonly Response: unique symbol;
 }
-/** examplesResponse // => { _tag: 'Right', right: examplesResponseJson } */
-export const examplesResponseJson: NonEmptyArray<unknown> = [
+/** nonEmptyArray(Response).decode(examplesResponse) // => { _tag: 'Right', right: examplesResponse } */
+export const examplesResponse: NonEmptyArray<Response> = ([
   {
     leg: {
       from: {
@@ -165,8 +165,7 @@ export const examplesResponseJson: NonEmptyArray<unknown> = [
     tspProductId: 'testtaxi1-product1',
     token: {},
   },
-];
-export const examplesResponse = nonEmptyArray(Response).decode(examplesResponseJson);
+] as unknown) as NonEmptyArray<Response>;
 
 export default Response;
 


### PR DESCRIPTION
This PR changes examples to use explicit type cast instead of io-ts decode.