### PR TITLE
Release/11

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "10.9.0",
+  "version": "11.0.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/core/components/errors.ts
+++ b/maas-schemas-ts/src/core/components/errors.ts
@@ -16,21 +16,21 @@ export const schemaId = 'http://maasglobal.com/core/components/errors.json';
 export type Reason = t.Branded<
   {
     text?: string;
-    errorCode?: string | number;
+    errorCode?: string;
   },
   ReasonBrand
 >;
 export const Reason = t.brand(
   t.partial({
     text: t.string,
-    errorCode: t.union([t.string, t.number]),
+    errorCode: t.string,
   }),
   (
     x,
   ): x is t.Branded<
     {
       text?: string;
-      errorCode?: string | number;
+      errorCode?: string;
     },
     ReasonBrand
   > => true,

--- a/maas-schemas-ts/src/core/components/state-log.ts
+++ b/maas-schemas-ts/src/core/components/state-log.ts
@@ -10,6 +10,7 @@ Set of booking state transitions
 import * as t from 'io-ts';
 import * as Units_ from 'maas-schemas-ts/core/components/units';
 import * as State_ from 'maas-schemas-ts/core/components/state';
+import * as Errors_ from 'maas-schemas-ts/core/components/errors';
 
 type Defined =
   | Record<string, unknown>
@@ -50,10 +51,7 @@ export type BookingStateTransition = t.Branded<
     oldState?: State_.BookingState;
     newState?: State_.BookingState;
     invalid?: boolean;
-    reason?: {
-      text?: string;
-      errorCode?: string | number;
-    };
+    reason?: Errors_.Reason;
   } & {
     newState: Defined;
     oldState: Defined;
@@ -68,10 +66,7 @@ export const BookingStateTransition = t.brand(
       oldState: State_.BookingState,
       newState: State_.BookingState,
       invalid: t.boolean,
-      reason: t.partial({
-        text: t.string,
-        errorCode: t.union([t.string, t.number]),
-      }),
+      reason: Errors_.Reason,
     }),
     t.type({
       newState: Defined,
@@ -87,10 +82,7 @@ export const BookingStateTransition = t.brand(
       oldState?: State_.BookingState;
       newState?: State_.BookingState;
       invalid?: boolean;
-      reason?: {
-        text?: string;
-        errorCode?: string | number;
-      };
+      reason?: Errors_.Reason;
     } & {
       newState: Defined;
       oldState: Defined;

--- a/maas-schemas-ts/src/maas-backend/booking-option-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/booking-option-create/request.ts
@@ -34,9 +34,9 @@ const Defined = t.union([
 export const schemaId =
   'http://maasglobal.com/maas-backend/booking-option-create/request.json';
 
-// Payload
+// Option
 // The purpose of this remains a mystery
-export type Payload = t.Branded<
+export type Option = t.Branded<
   {
     paymentSourceId?: Common_.PaymentSourceId;
     productId?: Product_.Id;
@@ -44,9 +44,9 @@ export type Payload = t.Branded<
     autoPurchaseId?: Units_.Uuid;
     agencyOptions?: AgencyOptions_.AgencyOptions;
   },
-  PayloadBrand
+  OptionBrand
 >;
-export const Payload = t.brand(
+export const Option = t.brand(
   t.partial({
     paymentSourceId: Common_.PaymentSourceId,
     productId: Product_.Id,
@@ -64,12 +64,12 @@ export const Payload = t.brand(
       autoPurchaseId?: Units_.Uuid;
       agencyOptions?: AgencyOptions_.AgencyOptions;
     },
-    PayloadBrand
+    OptionBrand
   > => true,
-  'Payload',
+  'Option',
 );
-export interface PayloadBrand {
-  readonly Payload: unique symbol;
+export interface OptionBrand {
+  readonly Option: unique symbol;
 }
 
 // Request
@@ -77,7 +77,7 @@ export interface PayloadBrand {
 export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
-    payload?: Payload;
+    payload?: Array<Option>;
     headers?: ApiCommon_.Headers;
   } & {
     identityId: Defined;
@@ -90,7 +90,7 @@ export const Request = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
-      payload: Payload,
+      payload: t.array(Option),
       headers: ApiCommon_.Headers,
     }),
     t.type({
@@ -104,7 +104,7 @@ export const Request = t.brand(
   ): x is t.Branded<
     {
       identityId?: Units_.IdentityId;
-      payload?: Payload;
+      payload?: Array<Option>;
       headers?: ApiCommon_.Headers;
     } & {
       identityId: Defined;

--- a/maas-schemas-ts/src/maas-backend/booking-option-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/booking-option-create/request.ts
@@ -43,6 +43,7 @@ export type Option = t.Branded<
     customerSelection?: CustomerSelection_.CustomerSelection;
     autoPurchaseId?: Units_.Uuid;
     agencyOptions?: AgencyOptions_.AgencyOptions;
+    rollbackOnFailure?: boolean;
   },
   OptionBrand
 >;
@@ -53,6 +54,7 @@ export const Option = t.brand(
     customerSelection: CustomerSelection_.CustomerSelection,
     autoPurchaseId: Units_.Uuid,
     agencyOptions: AgencyOptions_.AgencyOptions,
+    rollbackOnFailure: t.boolean,
   }),
   (
     x,
@@ -63,6 +65,7 @@ export const Option = t.brand(
       customerSelection?: CustomerSelection_.CustomerSelection;
       autoPurchaseId?: Units_.Uuid;
       agencyOptions?: AgencyOptions_.AgencyOptions;
+      rollbackOnFailure?: boolean;
     },
     OptionBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/booking-option-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/booking-option-create/response.ts
@@ -8,7 +8,6 @@ Response schema for booking-option-create
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
 
 type Defined =
   | Record<string, unknown>
@@ -32,55 +31,37 @@ export const schemaId =
 // Response
 // The default export. More information at the top.
 export type Response = t.Branded<
-  | ({
-      booking?: Booking_.Booking;
-    } & {
-      booking: Defined;
+  | (Array<unknown> & {
+      bookings: Defined;
     })
-  | ({
-      error?: {
-        message?: string;
-      };
-    } & {
-      error: Defined;
+  | (Array<unknown> & {
+      failures: Defined;
     }),
   ResponseBrand
 >;
 export const Response = t.brand(
   t.union([
     t.intersection([
-      t.partial({
-        booking: Booking_.Booking,
-      }),
+      t.UnknownArray,
       t.type({
-        booking: Defined,
+        bookings: Defined,
       }),
     ]),
     t.intersection([
-      t.partial({
-        error: t.partial({
-          message: t.string,
-        }),
-      }),
+      t.UnknownArray,
       t.type({
-        error: Defined,
+        failures: Defined,
       }),
     ]),
   ]),
   (
     x,
   ): x is t.Branded<
-    | ({
-        booking?: Booking_.Booking;
-      } & {
-        booking: Defined;
+    | (Array<unknown> & {
+        bookings: Defined;
       })
-    | ({
-        error?: {
-          message?: string;
-        };
-      } & {
-        error: Defined;
+    | (Array<unknown> & {
+        failures: Defined;
       }),
     ResponseBrand
   > => true,

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1021,12 +1021,6 @@ WARNING: default field not supported outside top-level definitions
 INFO: missing description
   in ./maas-backend/booking-option-create/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/booking-option-create/response.json
-WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/booking-option-create/response.json
-WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/booking-option-create/response.json
-INFO: primitive type "string" used outside top-level definitions
   in ./maas-backend/customers/customer.json
 WARNING: minLength field not supported outside top-level definitions
   in ./maas-backend/customers/customer.json

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -246,8 +246,6 @@ INFO: primitive type "string" used outside top-level definitions
   in ./core/components/errors.json
 INFO: primitive type "string" used outside top-level definitions
   in ./core/components/errors.json
-INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/errors.json
 WARNING: minimum field not supported outside top-level definitions
   in ./core/components/fare.json
 INFO: primitive type "string" used outside top-level definitions
@@ -418,12 +416,6 @@ WARNING: minLength field not supported outside top-level definitions
   in ./core/components/place.json
 WARNING: maxLength field not supported outside top-level definitions
   in ./core/components/place.json
-INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/state-log.json
-INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/state-log.json
-INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/state-log.json
 INFO: missing description
   in ./core/components/state-log.json
 INFO: missing description

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "10.9.0",
+  "version": "11.0.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/errors.json
+++ b/maas-schemas/schemas/core/components/errors.json
@@ -10,9 +10,7 @@
         "text": {
           "type": "string"
         },
-        "errorCode": {
-          "anyOf": [{ "type": "string" }, { "type": "number" }]
-        }
+        "errorCode": { "type": "string" }
       },
       "additionalProperties": false
     }

--- a/maas-schemas/schemas/core/components/state-log.json
+++ b/maas-schemas/schemas/core/components/state-log.json
@@ -33,16 +33,7 @@
           "type": "boolean"
         },
         "reason": {
-          "type": "object",
-          "properties": {
-            "text": {
-              "type": "string"
-            },
-            "errorCode": {
-              "anyOf": [{ "type": "string" }, { "type": "number" }]
-            }
-          },
-          "additionalProperties": true
+          "$ref": "http://maasglobal.com/core/components/errors.json#/definitions/reason"
         }
       },
       "required": ["newState", "oldState", "timestamp"],

--- a/maas-schemas/schemas/maas-backend/booking-option-create/request.json
+++ b/maas-schemas/schemas/maas-backend/booking-option-create/request.json
@@ -37,6 +37,10 @@
         },
         "agencyOptions": {
           "$ref": "http://maasglobal.com/core/components/agencyOptions.json"
+        },
+        "rollbackOnFailure": {
+          "type": "boolean",
+          "description": "If one of these is true, then all bookings will be cancelled"
         }
       }
     }

--- a/maas-schemas/schemas/maas-backend/booking-option-create/request.json
+++ b/maas-schemas/schemas/maas-backend/booking-option-create/request.json
@@ -9,14 +9,15 @@
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
     "payload": {
-      "$ref": "#/definitions/payload"
+      "type": "array",
+      "$ref": "#/definitions/option"
     },
     "headers": {
       "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"
     }
   },
   "definitions": {
-    "payload": {
+    "option": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/maas-schemas/schemas/maas-backend/booking-option-create/request.json
+++ b/maas-schemas/schemas/maas-backend/booking-option-create/request.json
@@ -10,7 +10,9 @@
     },
     "payload": {
       "type": "array",
-      "$ref": "#/definitions/option"
+      "items": {
+        "$ref": "#/definitions/option"
+      }
     },
     "headers": {
       "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"

--- a/maas-schemas/schemas/maas-backend/booking-option-create/response.json
+++ b/maas-schemas/schemas/maas-backend/booking-option-create/response.json
@@ -1,20 +1,22 @@
 {
   "$id": "http://maasglobal.com/maas-backend/booking-option-create/response.json",
   "description": "Response schema for booking-option-create",
-  "oneOf": [
+  "anyOf": [
     {
-      "type": "object",
+      "type": "array",
       "properties": {
-        "booking": {
-          "$ref": "http://maasglobal.com/core/booking.json"
+        "bookings": {
+          "items": {
+            "$ref": "http://maasglobal.com/core/booking.json"
+          }
         }
       },
-      "required": ["booking"]
+      "required": ["bookings"]
     },
     {
-      "type": "object",
+      "type": "array",
       "properties": {
-        "error": {
+        "failures": {
           "type": "object",
           "properties": {
             "message": {
@@ -22,11 +24,17 @@
               "description": "A human readable error message (preferably in English)",
               "minLength": 1,
               "maxLength": 255
+            },
+            "productId": {
+              "type": "string",
+              "description": "ProductId of failed booking",
+              "minLength": 1,
+              "maxLength": 255
             }
           }
         }
       },
-      "required": ["error"]
+      "required": ["failures"]
     }
   ]
 }


### PR DESCRIPTION
## What has been implemented?

Two changes:

* `maas-backend/booking-option-create/request.json` - changes the query from `object` to `array` of `objects` of the same type - the idea is to lower the amount of requests by sending a number of options at the same time - author: @BeyondCreative 
* 10.9.0 added `errors.json` schema that includes the definition of `reason` used in `tsp/options/response,json`, version 11 will change the type from `number|string` to `string` only. This is needed for the android clients - author @MichalCz 

## Versioning:

- [x] Breaking change
