### PR TITLE
Support reasons as part of bookings webhooks update payload

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "13.2.1",
+  "version": "13.3.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
+++ b/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
@@ -11,6 +11,7 @@ import * as t from 'io-ts';
 import * as Booking_ from 'maas-schemas-ts/core/booking';
 import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
 import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
+import * as Errors_ from 'maas-schemas-ts/core/components/errors';
 
 type Defined =
   | Record<string, unknown>
@@ -42,6 +43,7 @@ export type RemoteRequest = t.Branded<
     meta?: BookingMeta_.BookingMeta;
     terms?: Booking_.Terms;
     token?: Booking_.Token;
+    reasons?: Array<Errors_.Reason>;
   } & {
     tspId: Defined;
     state: Defined;
@@ -65,6 +67,7 @@ export const RemoteRequest = t.brand(
       meta: BookingMeta_.BookingMeta,
       terms: Booking_.Terms,
       token: Booking_.Token,
+      reasons: t.array(Errors_.Reason),
     }),
     t.type({
       tspId: Defined,
@@ -88,6 +91,7 @@ export const RemoteRequest = t.brand(
       meta?: BookingMeta_.BookingMeta;
       terms?: Booking_.Terms;
       token?: Booking_.Token;
+      reasons?: Array<Errors_.Reason>;
     } & {
       tspId: Defined;
       state: Defined;

--- a/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
+++ b/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
@@ -43,7 +43,7 @@ export type RemoteRequest = t.Branded<
     meta?: BookingMeta_.BookingMeta;
     terms?: Booking_.Terms;
     token?: Booking_.Token;
-    reasons?: Array<Errors_.Reason>;
+    reason?: Errors_.Reason;
   } & {
     tspId: Defined;
     state: Defined;
@@ -67,7 +67,7 @@ export const RemoteRequest = t.brand(
       meta: BookingMeta_.BookingMeta,
       terms: Booking_.Terms,
       token: Booking_.Token,
-      reasons: t.array(Errors_.Reason),
+      reason: Errors_.Reason,
     }),
     t.type({
       tspId: Defined,
@@ -91,7 +91,7 @@ export const RemoteRequest = t.brand(
       meta?: BookingMeta_.BookingMeta;
       terms?: Booking_.Terms;
       token?: Booking_.Token;
-      reasons?: Array<Errors_.Reason>;
+      reason?: Errors_.Reason;
     } & {
       tspId: Defined;
       state: Defined;

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "13.2.1",
+  "version": "13.3.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/tsp/webhooks-bookings-update/remote-request.json
+++ b/maas-schemas/schemas/tsp/webhooks-bookings-update/remote-request.json
@@ -23,6 +23,12 @@
     },
     "token": {
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/token"
+    },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "$ref": "http://maasglobal.com/core/components/errors.json#/definitions/reason"
+      }
     }
   },
   "required": ["tspId", "state"],

--- a/maas-schemas/schemas/tsp/webhooks-bookings-update/remote-request.json
+++ b/maas-schemas/schemas/tsp/webhooks-bookings-update/remote-request.json
@@ -24,11 +24,8 @@
     "token": {
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/token"
     },
-    "reasons": {
-      "type": "array",
-      "items": {
-        "$ref": "http://maasglobal.com/core/components/errors.json#/definitions/reason"
-      }
+    "reason": {
+      "$ref": "http://maasglobal.com/core/components/errors.json#/definitions/reason"
     }
   },
   "required": ["tspId", "state"],


### PR DESCRIPTION
## What has been implemented?
Webhooks booking update now supports "reasons" object in the same way as routes query's response
