### PR TITLE
Use relative paths for imports

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -17,9 +17,9 @@
     "lint": "yarn eslint",
     "clean-src": "rm -rf src",
     "clean": "rm -rf lib",
-    "build-converter": "tsc converter.ts -outdir tmp",
-    "run-converter": "(cd ../maas-schemas/schemas/; find . -name '*.json' -print0|sort -V -z|xargs -0 -I {} node ../../maas-schemas-ts/tmp/converter.js {} ../../maas-schemas-ts/src http://maasglobal.com/ \\;)",
-    "build-package": "ttsc",
+    "build-converter": "tsc --lib es2019 converter.ts -outdir tmp",
+    "run-converter": "find ../maas-schemas/schemas -name '*.json' -print0|sort -V -z|xargs -0 -I {} node ./tmp/converter.js --inputFile {} --outputDir ./src --base http://maasglobal.com/",
+    "build-package": "tsc",
     "build": "yarn clean && yarn build-package",
     "typecheck": "tsc --noEmit",
     "ci": "yarn verify-conversion && yarn lint && yarn test && yarn build",
@@ -67,7 +67,6 @@
     "@typescript-eslint/eslint-plugin": "^2.1.0",
     "@typescript-eslint/eslint-plugin-tslint": "^2.3.2",
     "@typescript-eslint/parser": "^2.1.0",
-    "@zerollup/ts-transform-paths": "^1.7.3",
     "doctest-ts": "^0.5.0",
     "eslint": "^6.3.0",
     "eslint-config-prettier": "^6.2.0",
@@ -88,7 +87,6 @@
     "ts-node": "^8.4.1",
     "tslint": "^5.20.0",
     "tslint-no-circular-imports": "^0.7.0",
-    "ttypescript": "^1.5.7",
-    "typescript": "^3.5.3"
+    "typescript": "^3.9.2"
   }
 }

--- a/maas-schemas-ts/src/core/booking-meta.ts
+++ b/maas-schemas-ts/src/core/booking-meta.ts
@@ -8,26 +8,26 @@ TSP/mode-specific additional information. The TSP adapter should set MODE_{mode}
 */
 
 import * as t from 'io-ts';
-import * as MODE_WALK_ from 'maas-schemas-ts/core/modes/MODE_WALK';
-import * as MODE_BICYCLE_ from 'maas-schemas-ts/core/modes/MODE_BICYCLE';
-import * as MODE_CAR_ from 'maas-schemas-ts/core/modes/MODE_CAR';
-import * as MODE_TRAM_ from 'maas-schemas-ts/core/modes/MODE_TRAM';
-import * as MODE_SUBWAY_ from 'maas-schemas-ts/core/modes/MODE_SUBWAY';
-import * as MODE_RAIL_ from 'maas-schemas-ts/core/modes/MODE_RAIL';
-import * as MODE_BUS_ from 'maas-schemas-ts/core/modes/MODE_BUS';
-import * as MODE_FERRY_ from 'maas-schemas-ts/core/modes/MODE_FERRY';
-import * as MODE_CABLE_CAR_ from 'maas-schemas-ts/core/modes/MODE_CABLE_CAR';
-import * as MODE_GONDOLA_ from 'maas-schemas-ts/core/modes/MODE_GONDOLA';
-import * as MODE_FUNICULAR_ from 'maas-schemas-ts/core/modes/MODE_FUNICULAR';
-import * as MODE_SHARED_BICYCLE_ from 'maas-schemas-ts/core/modes/MODE_SHARED_BICYCLE';
-import * as MODE_SHARED_E_BICYCLE_ from 'maas-schemas-ts/core/modes/MODE_SHARED_E_BICYCLE';
-import * as MODE_SHARED_CAR_ from 'maas-schemas-ts/core/modes/MODE_SHARED_CAR';
-import * as MODE_TRANSIT_ from 'maas-schemas-ts/core/modes/MODE_TRANSIT';
-import * as MODE_TRAIN_ from 'maas-schemas-ts/core/modes/MODE_TRAIN';
-import * as MODE_TRAINISH_ from 'maas-schemas-ts/core/modes/MODE_TRAINISH';
-import * as MODE_BUSISH_ from 'maas-schemas-ts/core/modes/MODE_BUSISH';
-import * as MODE_TAXI_ from 'maas-schemas-ts/core/modes/MODE_TAXI';
-import * as MODE_SCOOTER_ from 'maas-schemas-ts/core/modes/MODE_SCOOTER';
+import * as MODE_WALK_ from './modes/MODE_WALK';
+import * as MODE_BICYCLE_ from './modes/MODE_BICYCLE';
+import * as MODE_CAR_ from './modes/MODE_CAR';
+import * as MODE_TRAM_ from './modes/MODE_TRAM';
+import * as MODE_SUBWAY_ from './modes/MODE_SUBWAY';
+import * as MODE_RAIL_ from './modes/MODE_RAIL';
+import * as MODE_BUS_ from './modes/MODE_BUS';
+import * as MODE_FERRY_ from './modes/MODE_FERRY';
+import * as MODE_CABLE_CAR_ from './modes/MODE_CABLE_CAR';
+import * as MODE_GONDOLA_ from './modes/MODE_GONDOLA';
+import * as MODE_FUNICULAR_ from './modes/MODE_FUNICULAR';
+import * as MODE_SHARED_BICYCLE_ from './modes/MODE_SHARED_BICYCLE';
+import * as MODE_SHARED_E_BICYCLE_ from './modes/MODE_SHARED_E_BICYCLE';
+import * as MODE_SHARED_CAR_ from './modes/MODE_SHARED_CAR';
+import * as MODE_TRANSIT_ from './modes/MODE_TRANSIT';
+import * as MODE_TRAIN_ from './modes/MODE_TRAIN';
+import * as MODE_TRAINISH_ from './modes/MODE_TRAINISH';
+import * as MODE_BUSISH_ from './modes/MODE_BUSISH';
+import * as MODE_TAXI_ from './modes/MODE_TAXI';
+import * as MODE_SCOOTER_ from './modes/MODE_SCOOTER';
 
 export const schemaId = 'http://maasglobal.com/core/booking-meta.json';
 

--- a/maas-schemas-ts/src/core/booking-option.ts
+++ b/maas-schemas-ts/src/core/booking-option.ts
@@ -8,15 +8,15 @@ MaaS single TSP adapter option
 */
 
 import * as t from 'io-ts';
-import * as Terms_ from 'maas-schemas-ts/core/components/terms';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
-import * as Configurator_ from 'maas-schemas-ts/core/components/configurator';
-import * as Customer_ from 'maas-schemas-ts/core/customer';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Terms_ from './components/terms';
+import * as BookingMeta_ from './booking-meta';
+import * as Cost_ from './components/cost';
+import * as Configurator_ from './components/configurator';
+import * as Customer_ from './customer';
+import * as TravelMode_ from './components/travel-mode';
+import * as Units_ from './components/units';
+import * as Place_ from './components/place';
+import * as Common_ from './components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/booking.ts
+++ b/maas-schemas-ts/src/core/booking.ts
@@ -7,20 +7,20 @@ The base booking object with all fields, to be inherited
 
 */
 
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from './components/units';
 import * as t from 'io-ts';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
-import * as Configurator_ from 'maas-schemas-ts/core/components/configurator';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Leg_ from 'maas-schemas-ts/core/leg';
-import * as Terms_ from 'maas-schemas-ts/core/components/terms';
-import * as State_ from 'maas-schemas-ts/core/components/state';
-import * as StateLog_ from 'maas-schemas-ts/core/components/state-log';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as Customer_ from 'maas-schemas-ts/core/customer';
-import * as Product_ from 'maas-schemas-ts/core/product';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import * as Fare_ from './components/fare';
+import * as Cost_ from './components/cost';
+import * as Configurator_ from './components/configurator';
+import * as Common_ from './components/common';
+import * as Leg_ from './leg';
+import * as Terms_ from './components/terms';
+import * as State_ from './components/state';
+import * as StateLog_ from './components/state-log';
+import * as BookingMeta_ from './booking-meta';
+import * as Customer_ from './customer';
+import * as Product_ from './product';
+import * as CustomerSelection_ from './components/customerSelection';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/core/card.ts
+++ b/maas-schemas-ts/src/core/card.ts
@@ -8,7 +8,7 @@ MaaS region schema
 */
 
 import * as t from 'io-ts';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
+import * as Address_ from './components/address';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/address.ts
+++ b/maas-schemas-ts/src/core/components/address.ts
@@ -8,7 +8,7 @@ MaaS schema for address related information
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Common_ from './common';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/core/components/agencyOptions.ts
+++ b/maas-schemas-ts/src/core/components/agencyOptions.ts
@@ -8,11 +8,11 @@ Options that can be used for available booking options
 */
 
 import * as t from 'io-ts';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
+import * as TravelMode_ from './travel-mode';
+import * as Common_ from './common';
+import * as Units_ from './units';
+import * as UnitsGeo_ from './units-geo';
+import * as Address_ from './address';
 
 export const schemaId = 'http://maasglobal.com/core/components/agencyOptions.json';
 

--- a/maas-schemas-ts/src/core/components/authorization.ts
+++ b/maas-schemas-ts/src/core/components/authorization.ts
@@ -8,8 +8,8 @@ MaaS information about an authorization required to use a particular TSP
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Common_ from './common';
+import * as Units_ from './units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/bike-station.ts
+++ b/maas-schemas-ts/src/core/components/bike-station.ts
@@ -8,7 +8,7 @@ MaaS bike station schema
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
+import * as UnitsGeo_ from './units-geo';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/car-rental.ts
+++ b/maas-schemas-ts/src/core/components/car-rental.ts
@@ -8,10 +8,10 @@ Base schema for MODE_CAR* metas
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ACRISS_ from 'maas-schemas-ts/core/components/ACRISS';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Units_ from './units';
+import * as ACRISS_ from './ACRISS';
+import * as UnitsGeo_ from './units-geo';
+import * as Common_ from './common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/configurator.ts
+++ b/maas-schemas-ts/src/core/components/configurator.ts
@@ -8,9 +8,9 @@ Configurator schema to customize a booking option
 */
 
 import * as t from 'io-ts';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Terms_ from 'maas-schemas-ts/core/components/terms';
+import * as Cost_ from './cost';
+import * as Fare_ from './fare';
+import * as Terms_ from './terms';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/cost.ts
+++ b/maas-schemas-ts/src/core/components/cost.ts
@@ -8,7 +8,7 @@ MaaS common units that are used consistently within our own objects
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from './units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/geolocation.ts
+++ b/maas-schemas-ts/src/core/components/geolocation.ts
@@ -8,8 +8,8 @@ Partial (Points only) GeoJSON Schema
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
+import * as UnitsGeo_ from './units-geo';
+import * as Address_ from './address';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/payment-parameters.ts
+++ b/maas-schemas-ts/src/core/components/payment-parameters.ts
@@ -8,7 +8,7 @@ MaaS payment parameters for completing booking payment
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from './units';
 
 export const schemaId = 'http://maasglobal.com/core/components/payment-parameters.json';
 

--- a/maas-schemas-ts/src/core/components/place.ts
+++ b/maas-schemas-ts/src/core/components/place.ts
@@ -8,9 +8,9 @@ A place, as a location-name pair with name and address
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
+import * as UnitsGeo_ from './units-geo';
+import * as Address_ from './address';
+import * as Station_ from './station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/state-log.ts
+++ b/maas-schemas-ts/src/core/components/state-log.ts
@@ -8,9 +8,9 @@ Set of booking state transitions
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as State_ from 'maas-schemas-ts/core/components/state';
-import * as Errors_ from 'maas-schemas-ts/core/components/errors';
+import * as Units_ from './units';
+import * as State_ from './state';
+import * as Errors_ from './errors';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/station.ts
+++ b/maas-schemas-ts/src/core/components/station.ts
@@ -8,11 +8,11 @@ MaaS station schemas
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as UnitsGeo_ from './units-geo';
+import * as Address_ from './address';
+import * as Common_ from './common';
+import * as TravelMode_ from './travel-mode';
+import * as Units_ from './units';
 
 export const schemaId = 'http://maasglobal.com/core/components/station.json';
 

--- a/maas-schemas-ts/src/core/components/subscriptionChangeState.ts
+++ b/maas-schemas-ts/src/core/components/subscriptionChangeState.ts
@@ -8,7 +8,7 @@ MaaS state schemas
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from './units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/components/terms.ts
+++ b/maas-schemas-ts/src/core/components/terms.ts
@@ -8,9 +8,9 @@ MaaS booking terms and condition for its business engine
 */
 
 import * as t from 'io-ts';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Cost_ from './cost';
+import * as Fare_ from './fare';
+import * as Units_ from './units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -8,12 +8,12 @@ MaaS customer schema
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as I18n_ from 'maas-schemas-ts/core/components/i18n';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
+import * as Units_ from './components/units';
+import * as Common_ from './components/common';
+import * as Address_ from './components/address';
+import * as I18n_ from './components/i18n';
+import * as PersonalDocument_ from './personal-document';
+import * as Fare_ from './components/fare';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/core/iot-thing-shadow.ts
+++ b/maas-schemas-ts/src/core/iot-thing-shadow.ts
@@ -8,9 +8,9 @@ Schema for MaaS thing shadow
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as State_ from 'maas-schemas-ts/core/components/state';
+import * as UnitsGeo_ from './components/units-geo';
+import * as Units_ from './components/units';
+import * as State_ from './components/state';
 
 export const schemaId = 'http://maasglobal.com/core/iot-thing-shadow.json';
 

--- a/maas-schemas-ts/src/core/itinerary.ts
+++ b/maas-schemas-ts/src/core/itinerary.ts
@@ -7,14 +7,14 @@ OpenTripPlanner itinerary, augmented with leg bookings per leg
 
 */
 
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from './components/units';
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as State_ from 'maas-schemas-ts/core/components/state';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Leg_ from 'maas-schemas-ts/core/leg';
-import * as ProductOption_ from 'maas-schemas-ts/core/product-option';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Common_ from './components/common';
+import * as State_ from './components/state';
+import * as Fare_ from './components/fare';
+import * as Leg_ from './leg';
+import * as ProductOption_ from './product-option';
+import * as Booking_ from './booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/kyc-service.ts
+++ b/maas-schemas-ts/src/core/kyc-service.ts
@@ -8,7 +8,7 @@ KycService object
 */
 
 import * as t from 'io-ts';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
+import * as PersonalDocument_ from './personal-document';
 
 export const schemaId = 'http://maasglobal.com/core/kyc-service.json';
 

--- a/maas-schemas-ts/src/core/leg.ts
+++ b/maas-schemas-ts/src/core/leg.ts
@@ -7,15 +7,15 @@ The base leg object with all fields, to be inherited
 
 */
 
-import * as State_ from 'maas-schemas-ts/core/components/state';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as State_ from './components/state';
+import * as Place_ from './components/place';
+import * as Units_ from './components/units';
 import * as t from 'io-ts';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
-import * as Stop_ from 'maas-schemas-ts/core/stop';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
+import * as TravelMode_ from './components/travel-mode';
+import * as Stop_ from './stop';
+import * as UnitsGeo_ from './components/units-geo';
+import * as Common_ from './components/common';
+import * as BookingOption_ from './booking-option';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/modes/MODE_BICYCLE.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_BICYCLE.ts
@@ -8,7 +8,7 @@ undefined
 */
 
 import * as t from 'io-ts';
-import * as BikeStation_ from 'maas-schemas-ts/core/components/bike-station';
+import * as BikeStation_ from '../components/bike-station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/modes/MODE_CAR.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_CAR.ts
@@ -7,7 +7,7 @@ Schemas for MODE_CAR meta field
 
 */
 
-import * as CarRental_ from 'maas-schemas-ts/core/components/car-rental';
+import * as CarRental_ from '../components/car-rental';
 
 export const schemaId = 'http://maasglobal.com/core/modes/MODE_CAR.json';
 

--- a/maas-schemas-ts/src/core/modes/MODE_RAIL.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_RAIL.ts
@@ -8,8 +8,8 @@ Schema for MODE_RAIL meta field
 */
 
 import * as t from 'io-ts';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
+import * as Place_ from '../components/place';
+import * as Station_ from '../components/station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/modes/MODE_SHARED_CAR.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_SHARED_CAR.ts
@@ -7,7 +7,7 @@ Schemas for MODE_SHARED_CAR meta field
 
 */
 
-import * as CarRental_ from 'maas-schemas-ts/core/components/car-rental';
+import * as CarRental_ from '../components/car-rental';
 
 export const schemaId = 'http://maasglobal.com/core/modes/MODE_SHARED_CAR.json';
 

--- a/maas-schemas-ts/src/core/modes/MODE_TAXI.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_TAXI.ts
@@ -8,9 +8,9 @@ Schema for MODE_TAXI meta field
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as UnitsGeo_ from '../components/units-geo';
+import * as Units_ from '../components/units';
+import * as Common_ from '../components/common';
 
 export const schemaId = 'http://maasglobal.com/core/modes/MODE_TAXI.json';
 

--- a/maas-schemas-ts/src/core/partialFavoriteLocation.ts
+++ b/maas-schemas-ts/src/core/partialFavoriteLocation.ts
@@ -8,11 +8,11 @@ Customer's favorite location
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
+import * as Units_ from './components/units';
+import * as UnitsGeo_ from './components/units-geo';
+import * as Address_ from './components/address';
+import * as Common_ from './components/common';
+import * as Station_ from './components/station';
 
 export const schemaId = 'http://maasglobal.com/core/partialFavoriteLocation.json';
 

--- a/maas-schemas-ts/src/core/paymentSource.ts
+++ b/maas-schemas-ts/src/core/paymentSource.ts
@@ -8,8 +8,8 @@ MaaS region schema
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Card_ from 'maas-schemas-ts/core/card';
+import * as Units_ from './components/units';
+import * as Card_ from './card';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/personal-document.ts
+++ b/maas-schemas-ts/src/core/personal-document.ts
@@ -8,7 +8,7 @@ Personal document object
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from './components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/plan.ts
+++ b/maas-schemas-ts/src/core/plan.ts
@@ -8,9 +8,9 @@ OpenTripPlanner compatible format for plans, extended with id for legs and itine
 */
 
 import * as t from 'io-ts';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
+import * as Place_ from './components/place';
+import * as Units_ from './components/units';
+import * as Itinerary_ from './itinerary';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/product-option.ts
+++ b/maas-schemas-ts/src/core/product-option.ts
@@ -8,14 +8,14 @@ Product option for an itinerary, is either an existing booking pointer or a new 
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Product_ from 'maas-schemas-ts/core/product';
-import * as Terms_ from 'maas-schemas-ts/core/components/terms';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as Configurator_ from 'maas-schemas-ts/core/components/configurator';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
+import * as Units_ from './components/units';
+import * as Product_ from './product';
+import * as Terms_ from './components/terms';
+import * as BookingMeta_ from './booking-meta';
+import * as Configurator_ from './components/configurator';
+import * as BookingOption_ from './booking-option';
+import * as Fare_ from './components/fare';
+import * as Cost_ from './components/cost';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/product.ts
+++ b/maas-schemas-ts/src/core/product.ts
@@ -8,8 +8,8 @@ Product in core which encapsulates at least an id, name and a tspProductId
 */
 
 import * as t from 'io-ts';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Fare_ from './components/fare';
+import * as Common_ from './components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/profile.ts
+++ b/maas-schemas-ts/src/core/profile.ts
@@ -8,13 +8,13 @@ MaaS user profiles as returned by our API
 */
 
 import * as t from 'io-ts';
-import * as PointCost_ from 'maas-schemas-ts/core/components/point-cost';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Region_ from 'maas-schemas-ts/core/region';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
+import * as PointCost_ from './components/point-cost';
+import * as Units_ from './components/units';
+import * as Common_ from './components/common';
+import * as Address_ from './components/address';
+import * as Region_ from './region';
+import * as Place_ from './components/place';
+import * as Fare_ from './components/fare';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/region.ts
+++ b/maas-schemas-ts/src/core/region.ts
@@ -8,7 +8,7 @@ MaaS region schema
 */
 
 import * as t from 'io-ts';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
+import * as Address_ from './components/address';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/core/stop.ts
+++ b/maas-schemas-ts/src/core/stop.ts
@@ -8,8 +8,8 @@ undefined
 */
 
 import * as t from 'io-ts';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Place_ from './components/place';
+import * as Units_ from './components/units';
 
 export const schemaId = 'http://maasglobal.com/core/stop.json';
 

--- a/maas-schemas-ts/src/environments/environments.ts
+++ b/maas-schemas-ts/src/environments/environments.ts
@@ -8,8 +8,8 @@ The base environments object with several environment groups and related meta da
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Common_ from '../core/components/common';
+import * as Units_ from '../core/components/units';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/maas-backend/auth/auth-sms-login/request.ts
+++ b/maas-schemas-ts/src/maas-backend/auth/auth-sms-login/request.ts
@@ -8,8 +8,8 @@ Request schema for auth-sms-login
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/auth/auth-sms-request-code/request.ts
+++ b/maas-schemas-ts/src/maas-backend/auth/auth-sms-request-code/request.ts
@@ -8,8 +8,8 @@ Request schema for auth-sms-request-code
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/autocomplete/autocomplete-query/request.ts
+++ b/maas-schemas-ts/src/maas-backend/autocomplete/autocomplete-query/request.ts
@@ -8,10 +8,10 @@ Request schema for autocomplete
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Address_ from '../../../core/components/address';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/booking-option-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/booking-option-create/request.ts
@@ -8,12 +8,12 @@ Request schema for booking-option-create
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Product_ from 'maas-schemas-ts/core/product';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as AgencyOptions_ from 'maas-schemas-ts/core/components/agencyOptions';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Common_ from '../../core/components/common';
+import * as Product_ from '../../core/product';
+import * as CustomerSelection_ from '../../core/components/customerSelection';
+import * as Units_ from '../../core/components/units';
+import * as AgencyOptions_ from '../../core/components/agencyOptions';
+import * as ApiCommon_ from '../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-options/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-options/request.ts
@@ -8,12 +8,12 @@ Request schema for bookings-agency-options
 */
 
 import * as t from 'io-ts';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as TravelMode_ from '../../../core/components/travel-mode';
+import * as Common_ from '../../../core/components/common';
+import * as Units_ from '../../../core/components/units';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as Address_ from '../../../core/components/address';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-options/response.ts
@@ -8,9 +8,9 @@ Response schema for bookings-agency-options
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as BikeStation_ from 'maas-schemas-ts/core/components/bike-station';
+import * as Booking_ from '../../../core/booking';
+import * as BookingMeta_ from '../../../core/booking-meta';
+import * as BikeStation_ from '../../../core/components/bike-station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-products/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-products/request.ts
@@ -8,9 +8,9 @@ Request schema for bookings-agency-products
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-products/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-products/response.ts
@@ -8,9 +8,9 @@ Response schema for bookings-agency-products
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Units_ from '../../../core/components/units';
+import * as Fare_ from '../../../core/components/fare';
+import * as Common_ from '../../../core/components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-cancel/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-cancel/request.ts
@@ -8,8 +8,8 @@ Request schema for bookings-cancel
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/bookings/bookings-cancel/request.json';

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-create/request.ts
@@ -8,10 +8,10 @@ Request schema for bookings-create
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Response_ from 'maas-schemas-ts/maas-backend/bookings/bookings-agency-options/response';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Response_ from '../bookings-agency-options/response';
+import * as CustomerSelection_ from '../../../core/components/customerSelection';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-create/response.ts
@@ -8,7 +8,7 @@ Response schema for bookings-create
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-list/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-list/request.ts
@@ -8,8 +8,8 @@ Request schema for bookings-list
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-list/response.ts
@@ -8,7 +8,7 @@ Response schema for bookings-list
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-retrieve/request.ts
@@ -8,8 +8,8 @@ Request schema for bookings-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-retrieve/response.ts
@@ -8,7 +8,7 @@ Response schema for bookings-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-update/request.ts
@@ -8,9 +8,9 @@ Request schema for bookings-update
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Booking_ from '../../../core/booking';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-update/response.ts
@@ -8,7 +8,7 @@ Response schema for bookings-update
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/v2/bookings-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/v2/bookings-create/request.ts
@@ -8,11 +8,11 @@ Request schema for bookings-create v2
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Response_ from 'maas-schemas-ts/maas-backend/bookings/bookings-agency-options/response';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as Common_ from '../../../../core/components/common';
+import * as Response_ from '../../bookings-agency-options/response';
+import * as CustomerSelection_ from '../../../../core/components/customerSelection';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/bookings/v2/bookings-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/v2/bookings-create/response.ts
@@ -8,8 +8,8 @@ Response schema for bookings-create v2
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as PaymentParameters_ from 'maas-schemas-ts/core/components/payment-parameters';
+import * as Booking_ from '../../../../core/booking';
+import * as PaymentParameters_ from '../../../../core/components/payment-parameters';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/coupons/coupons-validate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/coupons/coupons-validate/request.ts
@@ -8,9 +8,9 @@ MaaS coupon validation
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Code_ from 'maas-schemas-ts/maas-backend/coupons/code';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Code_ from '../code';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/coupons/coupons-validate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/coupons/coupons-validate/response.ts
@@ -8,7 +8,7 @@ MaaS coupon validation
 */
 
 import * as t from 'io-ts';
-import * as Code_ from 'maas-schemas-ts/maas-backend/coupons/code';
+import * as Code_ from '../code';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/coupons/v2/coupons-redeem/request.ts
+++ b/maas-schemas-ts/src/maas-backend/coupons/v2/coupons-redeem/request.ts
@@ -8,9 +8,9 @@ MaaS coupon redeem
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Code_ from 'maas-schemas-ts/maas-backend/coupons/code';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as Code_ from '../../code';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/coupons/v2/coupons-redeem/response.ts
+++ b/maas-schemas-ts/src/maas-backend/coupons/v2/coupons-redeem/response.ts
@@ -8,8 +8,8 @@ MaaS coupon redeem
 */
 
 import * as t from 'io-ts';
-import * as Code_ from 'maas-schemas-ts/maas-backend/coupons/code';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
+import * as Code_ from '../../code';
+import * as Subscription_ from '../../../subscriptions/subscription';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/customer.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/customer.ts
@@ -8,15 +8,15 @@ MaaS customer schema
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalData_ from 'maas-schemas-ts/maas-backend/customers/personalData';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
-import * as Region_ from 'maas-schemas-ts/core/region';
-import * as Authorization_ from 'maas-schemas-ts/core/components/authorization';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as VirtualCard_ from 'maas-schemas-ts/maas-backend/customers/virtual-cards/virtualCard';
+import * as Units_ from '../../core/components/units';
+import * as PersonalData_ from './personalData';
+import * as PaymentSource_ from './payment-sources/paymentSource';
+import * as Fare_ from '../../core/components/fare';
+import * as Region_ from '../../core/region';
+import * as Authorization_ from '../../core/components/authorization';
+import * as PersonalDocument_ from '../../core/personal-document';
+import * as Common_ from '../../core/components/common';
+import * as VirtualCard_ from './virtual-cards/virtualCard';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/request.ts
@@ -8,9 +8,9 @@ MaaS customer favorite locations adding
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PartialFavoriteLocation_ from 'maas-schemas-ts/core/partialFavoriteLocation';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PartialFavoriteLocation_ from '../../../../core/partialFavoriteLocation';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/response.ts
@@ -8,7 +8,7 @@ MaaS customer favorite location adding response
 */
 
 import * as t from 'io-ts';
-import * as PartialFavoriteLocation_ from 'maas-schemas-ts/core/partialFavoriteLocation';
+import * as PartialFavoriteLocation_ from '../../../../core/partialFavoriteLocation';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/customers/favorite-locations/add/response.json';

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/delete/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/delete/request.ts
@@ -8,8 +8,8 @@ MaaS customer favorite locations deletion
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/list/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/list/request.ts
@@ -8,8 +8,8 @@ MaaS customer favorite locations listing
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/list/response.ts
@@ -8,7 +8,7 @@ MaaS customer favorite location listing response
 */
 
 import * as t from 'io-ts';
-import * as PartialFavoriteLocation_ from 'maas-schemas-ts/core/partialFavoriteLocation';
+import * as PartialFavoriteLocation_ from '../../../../core/partialFavoriteLocation';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/update/request.ts
@@ -8,9 +8,9 @@ MaaS customer favorite locations updating
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PartialFavoriteLocation_ from 'maas-schemas-ts/core/partialFavoriteLocation';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PartialFavoriteLocation_ from '../../../../core/partialFavoriteLocation';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/update/response.ts
@@ -8,7 +8,7 @@ MaaS customer favorite location updating response
 */
 
 import * as t from 'io-ts';
-import * as PartialFavoriteLocation_ from 'maas-schemas-ts/core/partialFavoriteLocation';
+import * as PartialFavoriteLocation_ from '../../../../core/partialFavoriteLocation';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/create/request.ts
@@ -8,9 +8,9 @@ MaaS customer payment sources create
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PaymentSource_ from '../paymentSource';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/delete/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/delete/request.ts
@@ -8,9 +8,9 @@ MaaS customer retrieve
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PaymentSource_ from '../paymentSource';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/paymentSource.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/paymentSource.ts
@@ -8,8 +8,8 @@ MaaS payment source schema
 */
 
 import * as t from 'io-ts';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
+import * as Station_ from '../../../core/components/station';
+import * as Address_ from '../../../core/components/address';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/setup-intent/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/setup-intent/request.ts
@@ -8,10 +8,10 @@ MaaS customer payment sources setup intent create
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as Common_ from '../../../../core/components/common';
+import * as PaymentSource_ from '../paymentSource';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/setup-intent/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/setup-intent/response.ts
@@ -8,8 +8,8 @@ MaaS customer payment sources setup intent create response
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
+import * as Common_ from '../../../../core/components/common';
+import * as PaymentSource_ from '../paymentSource';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/update/request.ts
@@ -8,9 +8,9 @@ MaaS customer payment sources update
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PaymentSource_ from '../paymentSource';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/payment-sources/update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/payment-sources/update/response.ts
@@ -8,7 +8,7 @@ MaaS customer payment sources update response
 */
 
 import * as t from 'io-ts';
-import * as PaymentSource_ from 'maas-schemas-ts/maas-backend/customers/payment-sources/paymentSource';
+import * as PaymentSource_ from '../paymentSource';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-data-delete/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-data-delete/request.ts
@@ -8,8 +8,8 @@ MaaS customer personal data delete item
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/request.ts
@@ -8,10 +8,10 @@ Save user consent to send all TSP required personal documents to TSP
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PersonalDocument_ from '../../../../core/personal-document';
+import * as Common_ from '../../../../core/components/common';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/response.ts
@@ -8,8 +8,8 @@ Save user consent to send all TSP required personal documents to TSP
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
+import * as Units_ from '../../../../core/components/units';
+import * as PersonalDocument_ from '../../../../core/personal-document';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/create/request.ts
@@ -8,9 +8,9 @@ Insert a pending verification personal document object
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PersonalDocument_ from '../../../../core/personal-document';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/create/response.ts
@@ -8,7 +8,7 @@ Insert a pending verification personal document object
 */
 
 import * as t from 'io-ts';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
+import * as PersonalDocument_ from '../../../../core/personal-document';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/request.ts
@@ -8,10 +8,10 @@ Initiate customer KYC process
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PersonalDocument_ from '../../../../core/personal-document';
+import * as UnitsGeo_ from '../../../../core/components/units-geo';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/response.ts
@@ -7,7 +7,7 @@ Initiate customer KYC process
 
 */
 
-import * as KycService_ from 'maas-schemas-ts/core/kyc-service';
+import * as KycService_ from '../../../../core/kyc-service';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/customers/personal-documents/initiate/response.json';

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/remove/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/remove/request.ts
@@ -8,9 +8,9 @@ Remove customer personal document by id
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalDocument_ from 'maas-schemas-ts/core/personal-document';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as PersonalDocument_ from '../../../../core/personal-document';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/revoke-consent/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/revoke-consent/request.ts
@@ -8,9 +8,9 @@ Revoke user consent to send all TSP required personal documents to TSP
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as Common_ from '../../../../core/components/common';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/personalData.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personalData.ts
@@ -8,9 +8,9 @@ MaaS customer personal data schema
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Common_ from '../../core/components/common';
+import * as Address_ from '../../core/components/address';
+import * as Units_ from '../../core/components/units';
 
 export const schemaId = 'http://maasglobal.com/maas-backend/customers/personalData.json';
 

--- a/maas-schemas-ts/src/maas-backend/customers/retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/retrieve/request.ts
@@ -8,8 +8,8 @@ MaaS customer retrieve
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/retrieve/response.ts
@@ -8,7 +8,7 @@ MaaS customer retrieve
 */
 
 import * as t from 'io-ts';
-import * as Customer_ from 'maas-schemas-ts/maas-backend/customers/customer';
+import * as Customer_ from '../customer';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/stats/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/stats/request.ts
@@ -8,8 +8,8 @@ MaaS customer stats. Give lifetime stats of customer e.g total number of booking
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/stats/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/stats/response.ts
@@ -8,7 +8,7 @@ MaaS customer stats. Give lifetime stats of customer e.g total number of booking
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/update/request.ts
@@ -8,9 +8,9 @@ MaaS customer update
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalData_ from 'maas-schemas-ts/maas-backend/customers/personalData';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as PersonalData_ from '../personalData';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/update/response.ts
@@ -8,7 +8,7 @@ MaaS customer update
 */
 
 import * as t from 'io-ts';
-import * as Customer_ from 'maas-schemas-ts/maas-backend/customers/customer';
+import * as Customer_ from '../customer';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/initiate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/initiate/request.ts
@@ -8,8 +8,8 @@ MaaS customer verification initiate
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/initiate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/initiate/response.ts
@@ -8,7 +8,7 @@ MaaS customer verification initiate
 */
 
 import * as t from 'io-ts';
-import * as VerificationObject_ from 'maas-schemas-ts/maas-backend/customers/verification/verification-object';
+import * as VerificationObject_ from '../verification-object';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/media/get/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/media/get/request.ts
@@ -8,7 +8,7 @@ MaaS customer verification media get
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../../../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/media/list/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/media/list/request.ts
@@ -8,7 +8,7 @@ MaaS customer verification media list
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../../../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/register/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/register/request.ts
@@ -8,9 +8,9 @@ MaaS customer verification TSP registration
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
+import * as Common_ from '../../../../core/components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/register/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/register/response.ts
@@ -8,7 +8,7 @@ Response schema for customers verification register
 */
 
 import * as t from 'io-ts';
-import * as Customer_ from 'maas-schemas-ts/maas-backend/customers/customer';
+import * as Customer_ from '../../customer';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/status/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/status/response.ts
@@ -8,7 +8,7 @@ MaaS customer verification status
 */
 
 import * as t from 'io-ts';
-import * as VerificationObject_ from 'maas-schemas-ts/maas-backend/customers/verification/verification-object';
+import * as VerificationObject_ from '../verification-object';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/verification/verification-object.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/verification-object.ts
@@ -8,8 +8,8 @@ MaaS verification schema
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Units_ from '../../../core/components/units';
+import * as Common_ from '../../../core/components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/add-token-reference/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/add-token-reference/request.ts
@@ -8,8 +8,8 @@ MaaS customer virtual cards get token reference request
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/add-token-reference/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/add-token-reference/response.ts
@@ -8,7 +8,7 @@ MaaS customer virtual cards add token reference response
 */
 
 import * as t from 'io-ts';
-import * as VirtualCard_ from 'maas-schemas-ts/maas-backend/customers/virtual-cards/virtualCard';
+import * as VirtualCard_ from '../virtualCard';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/get-token-reference/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/get-token-reference/request.ts
@@ -8,8 +8,8 @@ MaaS customer virtual cards get token reference request
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/get-token-reference/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/get-token-reference/response.ts
@@ -8,7 +8,7 @@ MaaS customer virtual cards get token reference response
 */
 
 import * as t from 'io-ts';
-import * as VirtualCardTokenReference_ from 'maas-schemas-ts/maas-backend/customers/virtual-cards/virtualCardTokenReference';
+import * as VirtualCardTokenReference_ from '../virtualCardTokenReference';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/request.ts
@@ -8,8 +8,8 @@ MaaS customer virtual cards provision request
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../../core/components/units';
+import * as ApiCommon_ from '../../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/response.ts
@@ -8,7 +8,7 @@ MaaS customer virtual cards provision response
 */
 
 import * as t from 'io-ts';
-import * as VirtualCard_ from 'maas-schemas-ts/maas-backend/customers/virtual-cards/virtualCard';
+import * as VirtualCard_ from '../virtualCard';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/virtualCard.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/virtualCard.ts
@@ -8,7 +8,7 @@ MaaS virtual card schema
 */
 
 import * as t from 'io-ts';
-import * as VirtualCardTokenReference_ from 'maas-schemas-ts/maas-backend/customers/virtual-cards/virtualCardTokenReference';
+import * as VirtualCardTokenReference_ from './virtualCardTokenReference';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/virtualCardTokenReference.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/virtualCardTokenReference.ts
@@ -8,8 +8,8 @@ MaaS virtual card schema
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Common_ from '../../../core/components/common';
+import * as Units_ from '../../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/request.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/request.ts
@@ -8,10 +8,10 @@ MaaS geocoding query request schema.
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as I18n_ from 'maas-schemas-ts/core/components/i18n';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as I18n_ from '../../../core/components/i18n';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/response.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/response.ts
@@ -8,7 +8,7 @@ MaaS.fi geocoding (GeoJSON) response schema
 */
 
 import * as t from 'io-ts';
-import * as Geolocation_ from 'maas-schemas-ts/core/components/geolocation';
+import * as Geolocation_ from '../../../core/components/geolocation';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/request.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/request.ts
@@ -8,10 +8,10 @@ MaaS geocoding query request schema.
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as I18n_ from 'maas-schemas-ts/core/components/i18n';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as I18n_ from '../../../core/components/i18n';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/response.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/response.ts
@@ -8,7 +8,7 @@ MaaS.fi geocoding (GeoJSON) response schema
 */
 
 import * as t from 'io-ts';
-import * as Geolocation_ from 'maas-schemas-ts/core/components/geolocation';
+import * as Geolocation_ from '../../../core/components/geolocation';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/invoices/invoice.ts
+++ b/maas-schemas-ts/src/maas-backend/invoices/invoice.ts
@@ -8,9 +8,9 @@ MaaS Invoice schema
 */
 
 import * as t from 'io-ts';
-import * as InvoiceUnits_ from 'maas-schemas-ts/maas-backend/invoices/invoiceUnits';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as InvoiceLineItem_ from 'maas-schemas-ts/maas-backend/invoices/invoiceLineItem';
+import * as InvoiceUnits_ from './invoiceUnits';
+import * as Units_ from '../../core/components/units';
+import * as InvoiceLineItem_ from './invoiceLineItem';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/invoices/invoiceLineItem.ts
+++ b/maas-schemas-ts/src/maas-backend/invoices/invoiceLineItem.ts
@@ -8,9 +8,9 @@ MaaS InvoiceLineItem schema
 */
 
 import * as t from 'io-ts';
-import * as InvoiceUnits_ from 'maas-schemas-ts/maas-backend/invoices/invoiceUnits';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Fare_ from 'maas-schemas-ts/core/components/fare';
+import * as InvoiceUnits_ from './invoiceUnits';
+import * as Units_ from '../../core/components/units';
+import * as Fare_ from '../../core/components/fare';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-cancel/request.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-cancel/request.ts
@@ -8,8 +8,8 @@ Request schema for itinerary-cancel
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-create/request.ts
@@ -8,13 +8,13 @@ Request schema for itineraries-create
 */
 
 import * as t from 'io-ts';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
-import * as ProductOption_ from 'maas-schemas-ts/core/product-option';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Message_ from 'maas-schemas-ts/core/components/message';
+import * as Itinerary_ from '../../../core/itinerary';
+import * as ProductOption_ from '../../../core/product-option';
+import * as CustomerSelection_ from '../../../core/components/customerSelection';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as Message_ from '../../../core/components/message';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/itineraries/itinerary-create/request.json';

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-create/response.ts
@@ -8,8 +8,8 @@ Response schema for itineraries-create
 */
 
 import * as t from 'io-ts';
-import * as PaymentParameters_ from 'maas-schemas-ts/core/components/payment-parameters';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
+import * as PaymentParameters_ from '../../../core/components/payment-parameters';
+import * as Itinerary_ from '../../../core/itinerary';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-list/request.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-list/request.ts
@@ -8,9 +8,9 @@ Request schema for itinerary-list
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Booking_ from '../../../core/booking';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-list/response.ts
@@ -8,7 +8,7 @@ Response schema for itineraries-list
 */
 
 import * as t from 'io-ts';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
+import * as Itinerary_ from '../../../core/itinerary';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-retrieve/request.ts
@@ -8,8 +8,8 @@ Request schema for itinerary-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-retrieve/response.ts
@@ -8,7 +8,7 @@ Response schema for itinerary-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
+import * as Itinerary_ from '../../../core/itinerary';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-update/request.ts
@@ -8,12 +8,12 @@ Maas Itinerary update request
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ProductOption_ from 'maas-schemas-ts/core/product-option';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import * as Units_ from '../../../core/components/units';
+import * as Itinerary_ from '../../../core/itinerary';
+import * as ApiCommon_ from '../../../core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as ProductOption_ from '../../../core/product-option';
+import * as CustomerSelection_ from '../../../core/components/customerSelection';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-update/response.ts
@@ -8,7 +8,7 @@ Maas Itinerary update request
 */
 
 import * as t from 'io-ts';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
+import * as Itinerary_ from '../../../core/itinerary';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/products/products-providers-options/request.ts
+++ b/maas-schemas-ts/src/maas-backend/products/products-providers-options/request.ts
@@ -8,9 +8,9 @@ Request schema for products-providers-options
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/products/products-providers-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/products/products-providers-options/response.ts
@@ -8,7 +8,7 @@ Response schema for products-providers-options
 */
 
 import * as t from 'io-ts';
-import * as Provider_ from 'maas-schemas-ts/maas-backend/products/provider';
+import * as Provider_ from '../provider';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/products/products-providers-retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/products/products-providers-retrieve/request.ts
@@ -8,9 +8,9 @@ Request schema for products-providers-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/products/products-providers-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/products/products-providers-retrieve/response.ts
@@ -8,7 +8,7 @@ Response schema for products-providers-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Provider_ from 'maas-schemas-ts/maas-backend/products/provider';
+import * as Provider_ from '../provider';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/products/provider.ts
+++ b/maas-schemas-ts/src/maas-backend/products/provider.ts
@@ -8,10 +8,10 @@ MaaS product provider schema
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as PersonalDataAllowItem_ from 'maas-schemas-ts/core/components/personalDataAllowItem';
-import * as PersonalDocumentRequiredItem_ from 'maas-schemas-ts/core/components/personalDocumentRequiredItem';
+import * as Common_ from '../../core/components/common';
+import * as Units_ from '../../core/components/units';
+import * as PersonalDataAllowItem_ from '../../core/components/personalDataAllowItem';
+import * as PersonalDocumentRequiredItem_ from '../../core/components/personalDocumentRequiredItem';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/profile/profile-devices-put/request.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-devices-put/request.ts
@@ -8,8 +8,8 @@ Request schema for profile-active-plan-put
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/profile/profile-devices-put/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-devices-put/response.ts
@@ -8,7 +8,7 @@ Response schema for profile-devices-put
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/profile/profile-edit/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-edit/response.ts
@@ -8,7 +8,7 @@ Response schema for profile-edit
 */
 
 import * as t from 'io-ts';
-import * as Profile_ from 'maas-schemas-ts/core/profile';
+import * as Profile_ from '../../../core/profile';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/profile/profile-edit/response.json';

--- a/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-add/request.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-add/request.ts
@@ -8,9 +8,9 @@ Request schema for profile-favoriteLocations-add
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Place_ from '../../../core/components/place';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/profile/profile-favoriteLocations-add/request.json';

--- a/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-add/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-add/response.ts
@@ -8,7 +8,7 @@ Response schema for profile-favoriteLocations-add
 */
 
 import * as t from 'io-ts';
-import * as Profile_ from 'maas-schemas-ts/core/profile';
+import * as Profile_ from '../../../core/profile';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/profile/profile-favoriteLocations-add/response.json';

--- a/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-delete/request.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-delete/request.ts
@@ -8,8 +8,8 @@ Request schema for profile-favoriteLocations-delete
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-delete/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-delete/response.ts
@@ -8,7 +8,7 @@ Response schema for profile-favoriteLocations-delete
 */
 
 import * as t from 'io-ts';
-import * as Profile_ from 'maas-schemas-ts/core/profile';
+import * as Profile_ from '../../../core/profile';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/profile/profile-favoriteLocations-delete/response.json';

--- a/maas-schemas-ts/src/maas-backend/profile/profile-webhook/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-webhook/response.ts
@@ -8,7 +8,7 @@ Response schema for profile-webhook
 */
 
 import * as t from 'io-ts';
-import * as Profile_ from 'maas-schemas-ts/core/profile';
+import * as Profile_ from '../../../core/profile';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/profile/profile-webhook/response.json';

--- a/maas-schemas-ts/src/maas-backend/provider/routes/request.ts
+++ b/maas-schemas-ts/src/maas-backend/provider/routes/request.ts
@@ -8,11 +8,11 @@ Request schema for routes providers
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
+import * as Units_ from '../../../core/components/units';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as Address_ from '../../../core/components/address';
+import * as Station_ from '../../../core/components/station';
+import * as TravelMode_ from '../../../core/components/travel-mode';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/provider/routes/response.ts
+++ b/maas-schemas-ts/src/maas-backend/provider/routes/response.ts
@@ -8,8 +8,8 @@ Response schema for routes providers, subset of routes-query response schema
 */
 
 import * as t from 'io-ts';
-import * as Place_ from 'maas-schemas-ts/core/components/place';
-import * as Itinerary_ from 'maas-schemas-ts/core/itinerary';
+import * as Place_ from '../../../core/components/place';
+import * as Itinerary_ from '../../../core/itinerary';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/push-notification/request.ts
+++ b/maas-schemas-ts/src/maas-backend/push-notification/request.ts
@@ -8,7 +8,7 @@ MaaS push notification request schema.
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/push-notification/response.ts
+++ b/maas-schemas-ts/src/maas-backend/push-notification/response.ts
@@ -8,7 +8,7 @@ MaaS push notification response schema.
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/regions/regions-options/request.ts
+++ b/maas-schemas-ts/src/maas-backend/regions/regions-options/request.ts
@@ -8,8 +8,8 @@ Request schema for regions-options
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/regions/regions-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/regions/regions-options/response.ts
@@ -8,7 +8,7 @@ Response schema for regions-options
 */
 
 import * as t from 'io-ts';
-import * as Region_ from 'maas-schemas-ts/core/region';
+import * as Region_ from '../../../core/region';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/routes/routes-query/request.ts
+++ b/maas-schemas-ts/src/maas-backend/routes/routes-query/request.ts
@@ -8,11 +8,11 @@ Request schema for routes query
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as Address_ from '../../../core/components/address';
+import * as Station_ from '../../../core/components/station';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/stations/stations-list/request.ts
+++ b/maas-schemas-ts/src/maas-backend/stations/stations-list/request.ts
@@ -8,10 +8,10 @@ Request schema for stations list
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Common_ from '../../../core/components/common';
+import * as UnitsGeo_ from '../../../core/components/units-geo';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/stations/stations-list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/stations/stations-list/response.ts
@@ -7,7 +7,7 @@ undefined
 
 */
 
-import * as Response_ from 'maas-schemas-ts/tsp/stations-list/response';
+import * as Response_ from '../../../tsp/stations-list/response';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/stations/stations-list/response.json';

--- a/maas-schemas-ts/src/maas-backend/stations/stations-retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/stations/stations-retrieve/request.ts
@@ -8,9 +8,9 @@ Request schema for regions-options
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Common_ from '../../../core/components/common';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/stations/stations-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/stations/stations-retrieve/response.ts
@@ -7,7 +7,7 @@ undefined
 
 */
 
-import * as Response_ from 'maas-schemas-ts/tsp/stations-retrieve/response';
+import * as Response_ from '../../../tsp/stations-retrieve/response';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/stations/stations-retrieve/response.json';

--- a/maas-schemas-ts/src/maas-backend/subscriptions/contact.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/contact.ts
@@ -8,9 +8,9 @@ MaaS contact (customer and user) schema
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Common_ from '../../core/components/common';
+import * as Address_ from '../../core/components/address';
+import * as Units_ from '../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/pricing.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/pricing.ts
@@ -8,9 +8,9 @@ MaaS pricing schema
 */
 
 import * as t from 'io-ts';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Subscription_ from './subscription';
+import * as Cost_ from '../../core/components/cost';
+import * as Units_ from '../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscription.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscription.ts
@@ -8,13 +8,13 @@ MaaS subscription schema
 */
 
 import * as t from 'io-ts';
-import * as Contact_ from 'maas-schemas-ts/maas-backend/subscriptions/contact';
-import * as PointCost_ from 'maas-schemas-ts/core/components/point-cost';
-import * as Region_ from 'maas-schemas-ts/core/region';
-import * as SubscriptionAddress_ from 'maas-schemas-ts/maas-backend/subscriptions/subscriptionAddress';
-import * as SubscriptionChangeState_ from 'maas-schemas-ts/core/components/subscriptionChangeState';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Cost_ from 'maas-schemas-ts/core/components/cost';
+import * as Contact_ from './contact';
+import * as PointCost_ from '../../core/components/point-cost';
+import * as Region_ from '../../core/region';
+import * as SubscriptionAddress_ from './subscriptionAddress';
+import * as SubscriptionChangeState_ from '../../core/components/subscriptionChangeState';
+import * as Units_ from '../../core/components/units';
+import * as Cost_ from '../../core/components/cost';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionAddress.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionAddress.ts
@@ -8,7 +8,7 @@ MaaS subscription address schema
 */
 
 import * as t from 'io-ts';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
+import * as Address_ from '../../core/components/address';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionOption.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionOption.ts
@@ -8,8 +8,8 @@ MaaS subscription option schema
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
+import * as Common_ from '../../core/components/common';
+import * as Subscription_ from './subscription';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-change-state/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-change-state/request.ts
@@ -8,8 +8,8 @@ Request schema for subscriptions-change-state
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-change-state/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-change-state/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-change-state
 */
 
 import * as t from 'io-ts';
-import * as SubscriptionChangeState_ from 'maas-schemas-ts/core/components/subscriptionChangeState';
+import * as SubscriptionChangeState_ from '../../../core/components/subscriptionChangeState';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-create/request.ts
@@ -8,9 +8,9 @@ Request schema for subscriptions-create
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Subscription_ from '../subscription';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-create/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-create
 */
 
 import * as t from 'io-ts';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
+import * as Subscription_ from '../subscription';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-estimate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-estimate/request.ts
@@ -8,9 +8,9 @@ Request schema for subscriptions-estimate
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Subscription_ from '../subscription';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-estimate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-estimate/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-estimate
 */
 
 import * as t from 'io-ts';
-import * as Pricing_ from 'maas-schemas-ts/maas-backend/subscriptions/pricing';
+import * as Pricing_ from '../pricing';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-options/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-options/request.ts
@@ -8,8 +8,8 @@ Request schema for subscriptions-options
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-options/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-options
 */
 
 import * as t from 'io-ts';
-import * as SubscriptionOption_ from 'maas-schemas-ts/maas-backend/subscriptions/subscriptionOption';
+import * as SubscriptionOption_ from '../subscriptionOption';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/request.ts
@@ -8,8 +8,8 @@ Request schema for subscriptions-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-retrieve
 */
 
 import * as t from 'io-ts';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
+import * as Subscription_ from '../subscription';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-scheduled-change-delete/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-scheduled-change-delete/request.ts
@@ -8,8 +8,8 @@ Request schema for subscriptions-scheduled-change-delete
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-scheduled-change-delete/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-scheduled-change-delete/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-scheduled-change-delete
 */
 
 import * as t from 'io-ts';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
+import * as Subscription_ from '../subscription';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-update/request.ts
@@ -8,9 +8,9 @@ Request schema for subscriptions-update
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Subscription_ from '../subscription';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-update/response.ts
@@ -8,7 +8,7 @@ Response schema for subscriptions-update
 */
 
 import * as t from 'io-ts';
-import * as Subscription_ from 'maas-schemas-ts/maas-backend/subscriptions/subscription';
+import * as Subscription_ from '../subscription';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/init/request.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/init/request.ts
@@ -8,9 +8,9 @@ Request schema for tsp-auth init
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as Common_ from '../../../core/components/common';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/init/response.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/init/response.ts
@@ -8,7 +8,7 @@ Response schema for tsp-auth init
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/validate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/validate/request.ts
@@ -8,7 +8,7 @@ Request schema for tsp-auth validate. Leaving as much flexibility as possible to
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Common_ from '../../../core/components/common';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/tsp-auth/validate/request.json';

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/validate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/validate/response.ts
@@ -8,7 +8,7 @@ Response schema for tsp-auth validate
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Common_ from '../../../core/components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/verify/definitions.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/verify/definitions.ts
@@ -8,8 +8,8 @@ Response schema for tsp-auth verify -> verification failure keys
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import * as Booking_ from '../../../core/booking';
+import * as CustomerSelection_ from '../../../core/components/customerSelection';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/tsp-auth/verify/definitions.json';

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/verify/request.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/verify/request.ts
@@ -8,10 +8,10 @@ Request schema for tsp-auth verify
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Definitions_ from 'maas-schemas-ts/maas-backend/tsp-auth/verify/definitions';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Common_ from '../../../core/components/common';
+import * as Units_ from '../../../core/components/units';
+import * as Definitions_ from './definitions';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/verify/response.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/verify/response.ts
@@ -8,7 +8,7 @@ Response schema for tsp-auth verify
 */
 
 import * as t from 'io-ts';
-import * as Definitions_ from 'maas-schemas-ts/maas-backend/tsp-auth/verify/definitions';
+import * as Definitions_ from './definitions';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/vehicle/vehicle-alert/request.ts
+++ b/maas-schemas-ts/src/maas-backend/vehicle/vehicle-alert/request.ts
@@ -8,7 +8,7 @@ Request to vehicle
 */
 
 import * as t from 'io-ts';
-import * as Product_ from 'maas-schemas-ts/core/product';
+import * as Product_ from '../../../core/product';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/vehicle/vehicle-alert/request.json';

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-create/request.ts
@@ -8,12 +8,12 @@ Request schema for webhooks-bookings-create
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as I18n_ from 'maas-schemas-ts/core/components/i18n';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
-import * as ApiCommon_ from 'maas-schemas-ts/core/components/api-common';
+import * as Units_ from '../../../core/components/units';
+import * as I18n_ from '../../../core/components/i18n';
+import * as Booking_ from '../../../core/booking';
+import * as BookingMeta_ from '../../../core/booking-meta';
+import * as CustomerSelection_ from '../../../core/components/customerSelection';
+import * as ApiCommon_ from '../../../core/components/api-common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-create/response.ts
@@ -8,7 +8,7 @@ Response schema for webhooks-bookings-create
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-update/request.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-update/request.ts
@@ -8,7 +8,7 @@ MaaS webhook to update bookings for tsp adapter callback request schema.
 */
 
 import * as t from 'io-ts';
-import * as RemoteRequest_ from 'maas-schemas-ts/tsp/webhooks-bookings-update/remote-request';
+import * as RemoteRequest_ from '../../../tsp/webhooks-bookings-update/remote-request';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-update/response.ts
@@ -7,7 +7,7 @@ MaaS webhook to update bookings for tsp adapter callback response schema.
 
 */
 
-import * as RemoteResponse_ from 'maas-schemas-ts/tsp/webhooks-bookings-update/remote-response';
+import * as RemoteResponse_ from '../../../tsp/webhooks-bookings-update/remote-response';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/webhooks/webhooks-bookings-update/response.json';

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/request.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/request.ts
@@ -8,9 +8,9 @@ MaaS webhook to receive payment status updates from payment gateways.
 */
 
 import * as t from 'io-ts';
-import * as Avainpay_ from 'maas-schemas-ts/maas-backend/webhooks/webhooks-payments/gateway/avainpay';
-import * as Stripe_ from 'maas-schemas-ts/maas-backend/webhooks/webhooks-payments/gateway/stripe';
-import * as Yaband_ from 'maas-schemas-ts/maas-backend/webhooks/webhooks-payments/gateway/yaband';
+import * as Avainpay_ from './gateway/avainpay';
+import * as Stripe_ from './gateway/stripe';
+import * as Yaband_ from './gateway/yaband';
 
 export const schemaId =
   'http://maasglobal.com/maas-backend/webhooks/webhooks-payments/request.json';

--- a/maas-schemas-ts/src/tsp/booking-cancel/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-cancel/request.ts
@@ -8,7 +8,7 @@ Request schema for cancelling a booking through a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-cancel/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-cancel/response.ts
@@ -8,9 +8,9 @@ Response schema for canceling a booking through a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
+import * as Booking_ from '../../core/booking';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-create/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-create/request.ts
@@ -8,12 +8,12 @@ Request schema for creating a booking through a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as Customer_ from 'maas-schemas-ts/core/customer';
-import * as Configurator_ from 'maas-schemas-ts/core/components/configurator';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
+import * as Booking_ from '../../core/booking';
+import * as Customer_ from '../../core/customer';
+import * as Configurator_ from '../../core/components/configurator';
+import * as CustomerSelection_ from '../../core/components/customerSelection';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/tsp/booking-create/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-create/response.ts
@@ -8,12 +8,12 @@ Response schema for creating a booking through a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as State_ from 'maas-schemas-ts/core/components/state';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as Configurator_ from 'maas-schemas-ts/core/components/configurator';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import * as Booking_ from '../../core/booking';
+import * as State_ from '../../core/components/state';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
+import * as Configurator_ from '../../core/components/configurator';
+import * as CustomerSelection_ from '../../core/components/customerSelection';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/tsp/booking-options-list/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-options-list/request.ts
@@ -8,12 +8,12 @@ Request schema for getting options from a TSP adapter.
 */
 
 import * as t from 'io-ts';
-import * as TravelMode_ from 'maas-schemas-ts/core/components/travel-mode';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as TravelMode_ from '../../core/components/travel-mode';
+import * as Units_ from '../../core/components/units';
+import * as UnitsGeo_ from '../../core/components/units-geo';
+import * as Address_ from '../../core/components/address';
+import * as Booking_ from '../../core/booking';
+import * as Common_ from '../../core/components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-options-list/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-options-list/response.ts
@@ -8,8 +8,8 @@ Response schema for getting options from a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BikeStation_ from 'maas-schemas-ts/core/components/bike-station';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BikeStation_ from '../../core/components/bike-station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-read-by-id/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-read-by-id/request.ts
@@ -8,7 +8,7 @@ Request schema for getting a specific booking with a TSP ID from a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-receipt/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-receipt/request.ts
@@ -8,7 +8,7 @@ Request schema for getting a receipt for a specific booking
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-ticket/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-ticket/request.ts
@@ -8,7 +8,7 @@ Request schema for retrieving a ticket from booking through a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
+import * as Booking_ from '../../core/booking';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-ticket/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-ticket/response.ts
@@ -8,7 +8,7 @@ Response schema for retrieving a ticket from booking through a TSP adapter
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-update/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-update/request.ts
@@ -8,10 +8,10 @@ Request schema for update a state of a specific booking with a TSP ID from a TSP
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as Configurator_ from 'maas-schemas-ts/core/components/configurator';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as CustomerSelection_ from 'maas-schemas-ts/core/components/customerSelection';
+import * as Booking_ from '../../core/booking';
+import * as Configurator_ from '../../core/components/configurator';
+import * as BookingMeta_ from '../../core/booking-meta';
+import * as CustomerSelection_ from '../../core/components/customerSelection';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/booking-update/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-update/response.ts
@@ -8,10 +8,10 @@ Response schema for updating state of a specific booking with a TSP ID from a TS
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as State_ from 'maas-schemas-ts/core/components/state';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
+import * as Booking_ from '../../core/booking';
+import * as State_ from '../../core/components/state';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/customer-auth-validate/request.ts
+++ b/maas-schemas-ts/src/tsp/customer-auth-validate/request.ts
@@ -8,7 +8,7 @@ Request schema for completing customer authorization for TSP
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
+import * as Common_ from '../../core/components/common';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/customer-auth-validate/response.ts
+++ b/maas-schemas-ts/src/tsp/customer-auth-validate/response.ts
@@ -8,9 +8,9 @@ Response schema for completing customer authorization for TSP
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Error_ from 'maas-schemas-ts/core/error';
+import * as Common_ from '../../core/components/common';
+import * as Units_ from '../../core/components/units';
+import * as Error_ from '../../core/error';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/customer-auth/request.ts
+++ b/maas-schemas-ts/src/tsp/customer-auth/request.ts
@@ -8,9 +8,9 @@ Request schema for initiating customer authorization for TSP
 */
 
 import * as t from 'io-ts';
-import * as Common_ from 'maas-schemas-ts/core/components/common';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as I18n_ from 'maas-schemas-ts/core/components/i18n';
+import * as Common_ from '../../core/components/common';
+import * as Units_ from '../../core/components/units';
+import * as I18n_ from '../../core/components/i18n';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/customer-auth/response.ts
+++ b/maas-schemas-ts/src/tsp/customer-auth/response.ts
@@ -8,7 +8,7 @@ Response schema for initiating customer authorization for TSP
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as Units_ from '../../core/components/units';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/customer-registration/request.ts
+++ b/maas-schemas-ts/src/tsp/customer-registration/request.ts
@@ -8,7 +8,7 @@ Request schema for customer registration
 */
 
 import * as t from 'io-ts';
-import * as Customer_ from 'maas-schemas-ts/core/customer';
+import * as Customer_ from '../../core/customer';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/journey-planner/request.ts
+++ b/maas-schemas-ts/src/tsp/journey-planner/request.ts
@@ -8,10 +8,10 @@ Request schema for getting journey options from a TSP adapter.
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
-import * as Address_ from 'maas-schemas-ts/core/components/address';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
+import * as UnitsGeo_ from '../../core/components/units-geo';
+import * as Address_ from '../../core/components/address';
+import * as Station_ from '../../core/components/station';
+import * as Units_ from '../../core/components/units';
 
 export const schemaId = 'http://maasglobal.com/tsp/journey-planner/request.json';
 

--- a/maas-schemas-ts/src/tsp/journey-planner/response.ts
+++ b/maas-schemas-ts/src/tsp/journey-planner/response.ts
@@ -7,7 +7,7 @@ Response schema for getting journey options from a TSP adapter.
 
 */
 
-import * as Response_ from 'maas-schemas-ts/maas-backend/provider/routes/response';
+import * as Response_ from '../../maas-backend/provider/routes/response';
 
 export const schemaId = 'http://maasglobal.com/tsp/journey-planner/response.json';
 

--- a/maas-schemas-ts/src/tsp/post-kyc-verification-update/request.ts
+++ b/maas-schemas-ts/src/tsp/post-kyc-verification-update/request.ts
@@ -8,7 +8,7 @@ Request post KYC verification update
 */
 
 import * as t from 'io-ts';
-import * as Customer_ from 'maas-schemas-ts/core/customer';
+import * as Customer_ from '../../core/customer';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 

--- a/maas-schemas-ts/src/tsp/stations-list/request.ts
+++ b/maas-schemas-ts/src/tsp/stations-list/request.ts
@@ -8,7 +8,7 @@ MaaS stations query request schema
 */
 
 import * as t from 'io-ts';
-import * as UnitsGeo_ from 'maas-schemas-ts/core/components/units-geo';
+import * as UnitsGeo_ from '../../core/components/units-geo';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/stations-list/response.ts
+++ b/maas-schemas-ts/src/tsp/stations-list/response.ts
@@ -8,7 +8,7 @@ MaaS stations query response schema
 */
 
 import * as t from 'io-ts';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
+import * as Station_ from '../../core/components/station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/stations-retrieve/request.ts
+++ b/maas-schemas-ts/src/tsp/stations-retrieve/request.ts
@@ -8,7 +8,7 @@ MaaS stations retrieve request schema
 */
 
 import * as t from 'io-ts';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
+import * as Station_ from '../../core/components/station';
 
 export const schemaId = 'http://maasglobal.com/tsp/stations-retrieve/request.json';
 

--- a/maas-schemas-ts/src/tsp/stations-retrieve/response.ts
+++ b/maas-schemas-ts/src/tsp/stations-retrieve/response.ts
@@ -8,7 +8,7 @@ MaaS stations query response schema
 */
 
 import * as t from 'io-ts';
-import * as Station_ from 'maas-schemas-ts/core/components/station';
+import * as Station_ from '../../core/components/station';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
+++ b/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
@@ -8,10 +8,10 @@ Remote request schema, e.g. how TSP should call MaaS-backend
 */
 
 import * as t from 'io-ts';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
-import * as Errors_ from 'maas-schemas-ts/core/components/errors';
+import * as Booking_ from '../../core/booking';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
+import * as Errors_ from '../../core/components/errors';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-response.ts
+++ b/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-response.ts
@@ -8,10 +8,10 @@ Remote response schema, e.g. how MaaS-backend responds back to TSP
 */
 
 import * as t from 'io-ts';
-import * as Units_ from 'maas-schemas-ts/core/components/units';
-import * as Booking_ from 'maas-schemas-ts/core/booking';
-import * as BookingOption_ from 'maas-schemas-ts/core/booking-option';
-import * as BookingMeta_ from 'maas-schemas-ts/core/booking-meta';
+import * as Units_ from '../../core/components/units';
+import * as Booking_ from '../../core/booking';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
 
 type Defined =
   | Record<string, unknown>

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1,1926 +1,1926 @@
 WARNING: skipping examples handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping default value handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping examples handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping default value handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping examples handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping default value handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping examples handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping default value handling for $ref object
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
-  in ./core/booking.json
+  in ../maas-schemas/schemas/core/booking.json
 WARNING: skipping examples handling for $ref object
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 WARNING: skipping default value handling for $ref object
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 INFO: missing description
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 INFO: missing description
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 INFO: missing description
-  in ./core/booking-option.json
+  in ../maas-schemas/schemas/core/booking-option.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/card.json
+  in ../maas-schemas/schemas/core/card.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 INFO: missing description
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 INFO: missing description
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 INFO: missing description
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 INFO: missing description
-  in ./core/components/address.json
+  in ../maas-schemas/schemas/core/components/address.json
 INFO: missing description
-  in ./core/components/api-common.json
+  in ../maas-schemas/schemas/core/components/api-common.json
 INFO: missing description
-  in ./core/components/api-common.json
+  in ../maas-schemas/schemas/core/components/api-common.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/authorization.json
+  in ../maas-schemas/schemas/core/components/authorization.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/bike-station.json
+  in ../maas-schemas/schemas/core/components/bike-station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxItems field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxItems field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: regexp field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: missing description
-  in ./core/components/car-rental.json
+  in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: missing description
-  in ./core/components/common.json
+  in ../maas-schemas/schemas/core/components/common.json
 INFO: missing description
-  in ./core/components/common.json
+  in ../maas-schemas/schemas/core/components/common.json
 INFO: missing description
-  in ./core/components/common.json
+  in ../maas-schemas/schemas/core/components/common.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: uniqueItems field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/configurator.json
+  in ../maas-schemas/schemas/core/components/configurator.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/cost.json
+  in ../maas-schemas/schemas/core/components/cost.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/customerSelection.json
+  in ../maas-schemas/schemas/core/components/customerSelection.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/customerSelection.json
+  in ../maas-schemas/schemas/core/components/customerSelection.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/customerSelection.json
+  in ../maas-schemas/schemas/core/components/customerSelection.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/errors.json
+  in ../maas-schemas/schemas/core/components/errors.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/errors.json
+  in ../maas-schemas/schemas/core/components/errors.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/fare.json
+  in ../maas-schemas/schemas/core/components/fare.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/fare.json
+  in ../maas-schemas/schemas/core/components/fare.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/fare.json
+  in ../maas-schemas/schemas/core/components/fare.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/fare.json
+  in ../maas-schemas/schemas/core/components/fare.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/fare.json
+  in ../maas-schemas/schemas/core/components/fare.json
 INFO: missing description
-  in ./core/components/fare.json
+  in ../maas-schemas/schemas/core/components/fare.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: missing description
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: missing description
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: missing description
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: missing description
-  in ./core/components/geolocation.json
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/geometry.json
+  in ../maas-schemas/schemas/core/components/geometry.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/geometry.json
+  in ../maas-schemas/schemas/core/components/geometry.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./core/components/geometry.json
+  in ../maas-schemas/schemas/core/components/geometry.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./core/components/geometry.json
+  in ../maas-schemas/schemas/core/components/geometry.json
 INFO: missing description
-  in ./core/components/i18n.json
+  in ../maas-schemas/schemas/core/components/i18n.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/message.json
+  in ../maas-schemas/schemas/core/components/message.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/message.json
+  in ../maas-schemas/schemas/core/components/message.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/message.json
+  in ../maas-schemas/schemas/core/components/message.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/message.json
+  in ../maas-schemas/schemas/core/components/message.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: missing description
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: missing description
-  in ./core/components/payment-parameters.json
+  in ../maas-schemas/schemas/core/components/payment-parameters.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/personalDataAllowItem.json
+  in ../maas-schemas/schemas/core/components/personalDataAllowItem.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/personalDataAllowItem.json
+  in ../maas-schemas/schemas/core/components/personalDataAllowItem.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/personalDocumentRequiredItem.json
+  in ../maas-schemas/schemas/core/components/personalDocumentRequiredItem.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/personalDocumentRequiredItem.json
+  in ../maas-schemas/schemas/core/components/personalDocumentRequiredItem.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/place.json
+  in ../maas-schemas/schemas/core/components/place.json
 INFO: missing description
-  in ./core/components/state-log.json
+  in ../maas-schemas/schemas/core/components/state-log.json
 INFO: missing description
-  in ./core/components/state-log.json
+  in ../maas-schemas/schemas/core/components/state-log.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping examples handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 WARNING: skipping default value handling for $ref object
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: missing description
-  in ./core/components/station.json
+  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/subscriptionChangeState.json
+  in ../maas-schemas/schemas/core/components/subscriptionChangeState.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/subscriptionChangeState.json
+  in ../maas-schemas/schemas/core/components/subscriptionChangeState.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: missing description
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: missing description
-  in ./core/components/terms.json
+  in ../maas-schemas/schemas/core/components/terms.json
 INFO: missing description
-  in ./core/components/units.json
+  in ../maas-schemas/schemas/core/components/units.json
 INFO: missing description
-  in ./core/components/units.json
+  in ../maas-schemas/schemas/core/components/units.json
 INFO: missing description
-  in ./core/components/units.json
+  in ../maas-schemas/schemas/core/components/units.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 WARNING: patternProperty support has limitations
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/customer.json
+  in ../maas-schemas/schemas/core/customer.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/error.json
+  in ../maas-schemas/schemas/core/error.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/error.json
+  in ../maas-schemas/schemas/core/error.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/error.json
+  in ../maas-schemas/schemas/core/error.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/error.json
+  in ../maas-schemas/schemas/core/error.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/error.json
+  in ../maas-schemas/schemas/core/error.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/error.json
+  in ../maas-schemas/schemas/core/error.json
 WARNING: skipping examples handling for $ref object
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 WARNING: skipping default value handling for $ref object
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 INFO: missing description
-  in ./core/itinerary.json
+  in ../maas-schemas/schemas/core/itinerary.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/kyc-service.json
+  in ../maas-schemas/schemas/core/kyc-service.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping examples handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 WARNING: skipping default value handling for $ref object
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
-  in ./core/leg.json
+  in ../maas-schemas/schemas/core/leg.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_BICYCLE.json
 WARNING: skipping examples handling for $ref object
-  in ./core/modes/MODE_CAR.json
+  in ../maas-schemas/schemas/core/modes/MODE_CAR.json
 WARNING: skipping default value handling for $ref object
-  in ./core/modes/MODE_CAR.json
+  in ../maas-schemas/schemas/core/modes/MODE_CAR.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_RAIL.json
+  in ../maas-schemas/schemas/core/modes/MODE_RAIL.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_RAIL.json
+  in ../maas-schemas/schemas/core/modes/MODE_RAIL.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_RAIL.json
+  in ../maas-schemas/schemas/core/modes/MODE_RAIL.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_RAIL.json
+  in ../maas-schemas/schemas/core/modes/MODE_RAIL.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_SCOOTER.json
+  in ../maas-schemas/schemas/core/modes/MODE_SCOOTER.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_SHARED_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_SHARED_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_SHARED_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_SHARED_BICYCLE.json
 WARNING: skipping examples handling for $ref object
-  in ./core/modes/MODE_SHARED_CAR.json
+  in ../maas-schemas/schemas/core/modes/MODE_SHARED_CAR.json
 WARNING: skipping default value handling for $ref object
-  in ./core/modes/MODE_SHARED_CAR.json
+  in ../maas-schemas/schemas/core/modes/MODE_SHARED_CAR.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_SHARED_E_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_SHARED_E_BICYCLE.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/modes/MODE_SHARED_E_BICYCLE.json
+  in ../maas-schemas/schemas/core/modes/MODE_SHARED_E_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/modes/MODE_TAXI.json
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/partialFavoriteLocation.json
+  in ../maas-schemas/schemas/core/partialFavoriteLocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/partialFavoriteLocation.json
+  in ../maas-schemas/schemas/core/partialFavoriteLocation.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/partialFavoriteLocation.json
+  in ../maas-schemas/schemas/core/partialFavoriteLocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/partialFavoriteLocation.json
+  in ../maas-schemas/schemas/core/partialFavoriteLocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/partialFavoriteLocation.json
+  in ../maas-schemas/schemas/core/partialFavoriteLocation.json
 INFO: missing description
-  in ./core/partialFavoriteLocation.json
+  in ../maas-schemas/schemas/core/partialFavoriteLocation.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/paymentSource.json
+  in ../maas-schemas/schemas/core/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: missing description
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: missing description
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: missing description
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: missing description
-  in ./core/personal-document.json
+  in ../maas-schemas/schemas/core/personal-document.json
 INFO: missing description
-  in ./core/plan.json
+  in ../maas-schemas/schemas/core/plan.json
 INFO: missing description
-  in ./core/plan.json
+  in ../maas-schemas/schemas/core/plan.json
 INFO: missing description
-  in ./core/plan.json
+  in ../maas-schemas/schemas/core/plan.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: missing description
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: missing description
-  in ./core/product.json
+  in ../maas-schemas/schemas/core/product.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/product-option.json
+  in ../maas-schemas/schemas/core/product-option.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/product-option.json
+  in ../maas-schemas/schemas/core/product-option.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/product-option.json
+  in ../maas-schemas/schemas/core/product-option.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/product-option.json
+  in ../maas-schemas/schemas/core/product-option.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: missing description
-  in ./core/profile.json
+  in ../maas-schemas/schemas/core/profile.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/region.json
+  in ../maas-schemas/schemas/core/region.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/region.json
+  in ../maas-schemas/schemas/core/region.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/region.json
+  in ../maas-schemas/schemas/core/region.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./core/region.json
+  in ../maas-schemas/schemas/core/region.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./core/region.json
+  in ../maas-schemas/schemas/core/region.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./core/region.json
+  in ../maas-schemas/schemas/core/region.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description
-  in ./environments/environments.json
+  in ../maas-schemas/schemas/environments/environments.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./geojson/geometry.json
+  in ../maas-schemas/schemas/geojson/geometry.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./geojson/geometry.json
+  in ../maas-schemas/schemas/geojson/geometry.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./geojson/geometry.json
+  in ../maas-schemas/schemas/geojson/geometry.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./geojson/geometry.json
+  in ../maas-schemas/schemas/geojson/geometry.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/auth/auth-sms-login/request.json
+  in ../maas-schemas/schemas/maas-backend/auth/auth-sms-login/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/auth/auth-sms-login/request.json
+  in ../maas-schemas/schemas/maas-backend/auth/auth-sms-login/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/auth/auth-sms-login/request.json
+  in ../maas-schemas/schemas/maas-backend/auth/auth-sms-login/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/auth/auth-sms-login/request.json
+  in ../maas-schemas/schemas/maas-backend/auth/auth-sms-login/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/autocomplete/autocomplete-query/request.json
+  in ../maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/autocomplete/autocomplete-query/request.json
+  in ../maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/autocomplete/autocomplete-query/request.json
+  in ../maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/autocomplete/autocomplete-query/request.json
+  in ../maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/autocomplete/autocomplete-query/request.json
+  in ../maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/autocomplete/autocomplete-query/response.json
+  in ../maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/response.json
 WARNING: patternProperty support has limitations
-  in ./maas-backend/bookings/bookings-agency-options/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/request.json
 INFO: missing description
-  in ./maas-backend/bookings/bookings-agency-options/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-options/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/response.json
 INFO: missing description
-  in ./maas-backend/bookings/bookings-agency-options/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/response.json
 INFO: missing description
-  in ./maas-backend/bookings/bookings-agency-products/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: missing description
-  in ./maas-backend/bookings/bookings-agency-products/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-list/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-list/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/bookings/bookings-list/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-list/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/request.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-list/response.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/response.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/bookings/bookings-retrieve/request.json
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-retrieve/request.json
 INFO: missing description
-  in ./maas-backend/booking-option-create/request.json
+  in ../maas-schemas/schemas/maas-backend/booking-option-create/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/customer.json
+  in ../maas-schemas/schemas/maas-backend/customers/customer.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/customer.json
+  in ../maas-schemas/schemas/maas-backend/customers/customer.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/customer.json
+  in ../maas-schemas/schemas/maas-backend/customers/customer.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/favorite-locations/delete/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/favorite-locations/delete/request.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/favorite-locations/update/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/favorite-locations/update/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/payment-sources/create/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/create/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/create/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/create/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/create/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/create/request.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
-  in ./maas-backend/customers/payment-sources/paymentSource.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/payment-sources/setup-intent/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/setup-intent/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/setup-intent/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/setup-intent/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/payment-sources/setup-intent/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/payment-sources/setup-intent/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/personalData.json
+  in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/personalData.json
+  in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/personalData.json
+  in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/personalData.json
+  in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/personalData.json
+  in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/personalData.json
+  in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/personal-data-delete/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/personal-data-delete/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/personal-data-delete/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/personal-data-delete/request.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/customers/personal-documents/initiate/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/response.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/customers/personal-documents/initiate/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/response.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/customers/stats/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/stats/response.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/stats/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/stats/response.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/customers/stats/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/stats/response.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/stats/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/stats/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/initiate/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/initiate/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/initiate/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/initiate/request.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/initiate/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/initiate/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/media/get/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/media/get/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/media/get/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/media/get/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/media/get/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/media/get/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/media/get/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/media/get/request.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/status/response.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/status/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: missing description
-  in ./maas-backend/customers/verification/verification-object.json
+  in ../maas-schemas/schemas/maas-backend/customers/verification/verification-object.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/add-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/add-token-reference/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/get-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/get-token-reference/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/get-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/get-token-reference/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/get-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/get-token-reference/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/get-token-reference/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/get-token-reference/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/provision/request.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/provision/request.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCard.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCard.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/customers/virtual-cards/virtualCardTokenReference.json
+  in ../maas-schemas/schemas/maas-backend/customers/virtual-cards/virtualCardTokenReference.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-query/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-reverse/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-reverse/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-reverse/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-reverse/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/geocoding/geocoding-reverse/request.json
+  in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/invoices/invoice.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoice.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/invoices/invoiceLineItem.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 INFO: missing description
-  in ./maas-backend/invoices/invoiceUnits.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceUnits.json
 INFO: missing description
-  in ./maas-backend/invoices/invoiceUnits.json
+  in ../maas-schemas/schemas/maas-backend/invoices/invoiceUnits.json
 INFO: missing description
-  in ./maas-backend/itineraries/itinerary-create/request.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-create/request.json
 INFO: missing description
-  in ./maas-backend/itineraries/itinerary-create/response.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-create/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/itineraries/itinerary-list/request.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-list/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/itineraries/itinerary-list/request.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/itineraries/itinerary-list/request.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-list/request.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/itineraries/itinerary-list/response.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-list/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/itineraries/itinerary-retrieve/request.json
+  in ../maas-schemas/schemas/maas-backend/itineraries/itinerary-retrieve/request.json
 INFO: missing description
-  in ./maas-backend/products/products-providers-options/request.json
+  in ../maas-schemas/schemas/maas-backend/products/products-providers-options/request.json
 INFO: missing description
-  in ./maas-backend/products/products-providers-retrieve/request.json
+  in ../maas-schemas/schemas/maas-backend/products/products-providers-retrieve/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: multipleOf field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/products/provider.json
+  in ../maas-schemas/schemas/maas-backend/products/provider.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/profile/profile-devices-put/request.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/profile/profile-devices-put/request.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/profile/profile-devices-put/request.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/profile/profile-devices-put/response.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/response.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/profile/profile-devices-put/response.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/profile/profile-devices-put/response.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/response.json
 INFO: missing description
-  in ./maas-backend/profile/profile-devices-put/response.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-devices-put/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/profile/profile-favoriteLocations-delete/request.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-favoriteLocations-delete/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/profile/profile-favoriteLocations-delete/request.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-favoriteLocations-delete/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/profile/profile-favoriteLocations-delete/request.json
+  in ../maas-schemas/schemas/maas-backend/profile/profile-favoriteLocations-delete/request.json
 WARNING: patternProperty support has limitations
-  in ./maas-backend/provider/routes/request.json
+  in ../maas-schemas/schemas/maas-backend/provider/routes/request.json
 INFO: missing description
-  in ./maas-backend/provider/routes/response.json
+  in ../maas-schemas/schemas/maas-backend/provider/routes/response.json
 INFO: missing description
-  in ./maas-backend/provider/routes/response.json
+  in ../maas-schemas/schemas/maas-backend/provider/routes/response.json
 INFO: missing description
-  in ./maas-backend/provider/routes/response.json
+  in ../maas-schemas/schemas/maas-backend/provider/routes/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maxItems field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maxItems field not supported outside top-level definitions
-  in ./maas-backend/push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/routes/routes-query/request.json
+  in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/routes/routes-query/request.json
+  in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 WARNING: patternProperty support has limitations
-  in ./maas-backend/routes/routes-query/request.json
+  in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/routes/routes-query/request.json
+  in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/routes/routes-query/request.json
+  in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 INFO: missing description
-  in ./maas-backend/routes/routes-query/request.json
+  in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/stations/stations-list/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/stations/stations-list/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/stations/stations-list/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/stations/stations-list/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/stations/stations-list/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/stations/stations-list/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/stations/stations-list/response.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/response.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/stations/stations-list/response.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-list/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/stations/stations-retrieve/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/stations/stations-retrieve/request.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/request.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/stations/stations-retrieve/response.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/response.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/stations/stations-retrieve/response.json
+  in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/response.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: missing description
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: missing description
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: missing description
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: missing description
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: missing description
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: missing description
-  in ./maas-backend/subscriptions/contact.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/pricing.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/pricing.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: maximum field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: missing description
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: missing description
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: missing description
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: missing description
-  in ./maas-backend/subscriptions/subscription.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscriptionOption.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptionOption.json
 INFO: missing description
-  in ./maas-backend/subscriptions/subscriptionOption.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptionOption.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/subscriptions/subscriptions-options/request.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptions-options/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscriptions-options/request.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptions-options/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscriptions-options/request.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptions-options/request.json
 WARNING: default field not supported outside top-level definitions
-  in ./maas-backend/subscriptions/subscriptions-retrieve/request.json
+  in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptions-retrieve/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/vehicle/vehicle-alert/request.json
+  in ../maas-schemas/schemas/maas-backend/vehicle/vehicle-alert/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/vehicle/vehicle-alert/request.json
+  in ../maas-schemas/schemas/maas-backend/vehicle/vehicle-alert/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/vehicle/vehicle-alert/request.json
+  in ../maas-schemas/schemas/maas-backend/vehicle/vehicle-alert/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-bookings-create/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-create/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-bookings-update/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-bookings-update/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-bookings-update/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/request.json
 WARNING: skipping examples handling for $ref object
-  in ./maas-backend/webhooks/webhooks-bookings-update/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/response.json
 WARNING: skipping default value handling for $ref object
-  in ./maas-backend/webhooks/webhooks-bookings-update/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: missing description
-  in ./maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: missing description
-  in ./maas-backend/webhooks/webhooks-payments/gateway/stripe.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/stripe.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: missing description
-  in ./maas-backend/webhooks/webhooks-payments/gateway/yaband.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/yaband.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 INFO: missing description
-  in ./maas-backend/webhooks/webhooks-payments/response.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/response.json
 WARNING: minItems field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: maxItems field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./maas-backend/webhooks/zendesk-push-notification/request.json
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: patternProperty support has limitations
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./tsp/booking-options-list/request.json
+  in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-ticket/request.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./tsp/booking-ticket/request.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-ticket/request.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/request.json
 WARNING: pattern field not supported outside top-level definitions
-  in ./tsp/booking-ticket/request.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./tsp/booking-ticket/request.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-ticket/response.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-ticket/response.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/booking-ticket/response.json
+  in ../maas-schemas/schemas/tsp/booking-ticket/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/journey-planner/request.json
+  in ../maas-schemas/schemas/tsp/journey-planner/request.json
 WARNING: patternProperty support has limitations
-  in ./tsp/journey-planner/request.json
+  in ../maas-schemas/schemas/tsp/journey-planner/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/journey-planner/request.json
+  in ../maas-schemas/schemas/tsp/journey-planner/request.json
 WARNING: skipping examples handling for $ref object
-  in ./tsp/journey-planner/response.json
+  in ../maas-schemas/schemas/tsp/journey-planner/response.json
 WARNING: skipping default value handling for $ref object
-  in ./tsp/journey-planner/response.json
+  in ../maas-schemas/schemas/tsp/journey-planner/response.json
 INFO: primitive type "number" used outside top-level definitions
-  in ./tsp/post-kyc-verification-update/response.json
+  in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/post-kyc-verification-update/response.json
+  in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/stations-list/request.json
+  in ../maas-schemas/schemas/tsp/stations-list/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./tsp/stations-list/request.json
+  in ../maas-schemas/schemas/tsp/stations-list/request.json
 INFO: primitive type "integer" used outside top-level definitions
-  in ./tsp/stations-list/request.json
+  in ../maas-schemas/schemas/tsp/stations-list/request.json
 WARNING: minimum field not supported outside top-level definitions
-  in ./tsp/stations-list/request.json
+  in ../maas-schemas/schemas/tsp/stations-list/request.json
 INFO: primitive type "string" used outside top-level definitions
-  in ./tsp/vehicle-alert/request.json
+  in ../maas-schemas/schemas/tsp/vehicle-alert/request.json
 WARNING: minLength field not supported outside top-level definitions
-  in ./tsp/vehicle-alert/request.json
+  in ../maas-schemas/schemas/tsp/vehicle-alert/request.json
 WARNING: maxLength field not supported outside top-level definitions
-  in ./tsp/vehicle-alert/request.json
+  in ../maas-schemas/schemas/tsp/vehicle-alert/request.json
 INFO: missing description
-  in ./tsp/webhooks-bookings-update/remote-response.json
+  in ../maas-schemas/schemas/tsp/webhooks-bookings-update/remote-response.json

--- a/maas-schemas-ts/tsconfig.json
+++ b/maas-schemas-ts/tsconfig.json
@@ -14,16 +14,7 @@
     "downlevelIteration": true,
     "declaration": true,
     "baseUrl": ".",
-    "outDir": "./lib",
-    "paths": {
-      "maas-schemas-ts/*": ["src/*"]
-    },
-    "plugins": [
-      {
-        "transform": "@zerollup/ts-transform-paths",
-        "exclude": ["*"]
-      }
-    ]
+    "outDir": "./lib"
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"]

--- a/maas-schemas-ts/yarn.lock
+++ b/maas-schemas-ts/yarn.lock
@@ -493,20 +493,6 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@zerollup/ts-helpers@^1.7.13":
-  version "1.7.13"
-  resolved "https://registry.yarnpkg.com/@zerollup/ts-helpers/-/ts-helpers-1.7.13.tgz#e0089b8809ba637acb6d89730f3107c87d89b7ec"
-  integrity sha512-2Sb0BUTGvv07/TR0Rf2HzpUPhBzVDdQjIVUfbw73JRpnjcR/rrwOoSrJsIAPTw322+rrwkfKGjAHmJq3V32Scw==
-  dependencies:
-    resolve "^1.12.0"
-
-"@zerollup/ts-transform-paths@^1.7.3":
-  version "1.7.13"
-  resolved "https://registry.yarnpkg.com/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.13.tgz#1ac3c0771b88d6b6b6688748f29f6d3c1e077320"
-  integrity sha512-8Ig2NmB3kI0bey67Fu1qK34jE/me4qRzJ3wl0YpEMKErIRX7UzrynG835Kx3UvsV9FhVEpjsXe5DV3AKzt1IcA==
-  dependencies:
-    "@zerollup/ts-helpers" "^1.7.13"
-
 abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
@@ -3560,7 +3546,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2, resolve@^1.9.0:
+resolve@1.x, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -4129,13 +4115,6 @@ tsutils@^3.17.1:
   dependencies:
     tslib "^1.8.1"
 
-ttypescript@^1.5.7:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.10.tgz#5045083a91cf09a735ecc95d4711c1f3b83f2059"
-  integrity sha512-Hk7TRej1hM+p+Fo+Pyb/XK9pe9CAt3Sh5n5YRutxFS8hUgkh2u1Vd2K40kMcNP3WYhiVFBMqXwM/2E8O95Ep6g==
-  dependencies:
-    resolve "^1.9.0"
-
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -4170,10 +4149,10 @@ typescript@^2.7.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^3.5.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR adds relative paths support to the converter making building possible without the previously required`ts-transform-paths` plugin.