### PR TITLE
Amend personal documents api

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "13.5.4",
+  "version": "13.6.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/request.ts
@@ -36,6 +36,7 @@ export const schemaId =
 export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
+    customerId?: Units_.IdentityId;
     payload?: {
       agencyId?: Common_.AgencyId;
     } & {
@@ -53,6 +54,7 @@ export const Request = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
+      customerId: Units_.IdentityId,
       payload: t.intersection([
         t.partial({
           agencyId: Common_.AgencyId,
@@ -74,6 +76,7 @@ export const Request = t.brand(
   ): x is t.Branded<
     {
       identityId?: Units_.IdentityId;
+      customerId?: Units_.IdentityId;
       payload?: {
         agencyId?: Common_.AgencyId;
       } & {

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/create/request.ts
@@ -36,6 +36,7 @@ export const schemaId =
 export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
+    customerId?: Units_.IdentityId;
     payload?: PersonalDocument_.PersonalDocument;
     headers?: ApiCommon_.Headers;
   } & {
@@ -49,6 +50,7 @@ export const Request = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
+      customerId: Units_.IdentityId,
       payload: PersonalDocument_.PersonalDocument,
       headers: ApiCommon_.Headers,
     }),
@@ -63,6 +65,7 @@ export const Request = t.brand(
   ): x is t.Branded<
     {
       identityId?: Units_.IdentityId;
+      customerId?: Units_.IdentityId;
       payload?: PersonalDocument_.PersonalDocument;
       headers?: ApiCommon_.Headers;
     } & {

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/request.ts
@@ -37,6 +37,7 @@ export const schemaId =
 export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
+    customerId?: Units_.IdentityId;
     payload?: {
       type?: PersonalDocument_.DocumentType;
       location?: UnitsGeo_.ShortLocationString;
@@ -56,6 +57,7 @@ export const Request = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
+      customerId: Units_.IdentityId,
       payload: t.intersection([
         t.partial({
           type: PersonalDocument_.DocumentType,
@@ -79,6 +81,7 @@ export const Request = t.brand(
   ): x is t.Branded<
     {
       identityId?: Units_.IdentityId;
+      customerId?: Units_.IdentityId;
       payload?: {
         type?: PersonalDocument_.DocumentType;
         location?: UnitsGeo_.ShortLocationString;

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/remove/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/remove/request.ts
@@ -36,6 +36,7 @@ export const schemaId =
 export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
+    customerId?: Units_.IdentityId;
     payload?: {
       type?: PersonalDocument_.DocumentType;
     } & {
@@ -53,6 +54,7 @@ export const Request = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
+      customerId: Units_.IdentityId,
       payload: t.intersection([
         t.partial({
           type: PersonalDocument_.DocumentType,
@@ -74,6 +76,7 @@ export const Request = t.brand(
   ): x is t.Branded<
     {
       identityId?: Units_.IdentityId;
+      customerId?: Units_.IdentityId;
       payload?: {
         type?: PersonalDocument_.DocumentType;
       } & {

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/revoke-consent/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/revoke-consent/request.ts
@@ -36,6 +36,7 @@ export const schemaId =
 export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
+    customerId?: Units_.IdentityId;
     payload?: {
       agencyId?: Common_.AgencyId;
     } & {
@@ -53,6 +54,7 @@ export const Request = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
+      customerId: Units_.IdentityId,
       payload: t.intersection([
         t.partial({
           agencyId: Common_.AgencyId,
@@ -74,6 +76,7 @@ export const Request = t.brand(
   ): x is t.Branded<
     {
       identityId?: Units_.IdentityId;
+      customerId?: Units_.IdentityId;
       payload?: {
         agencyId?: Common_.AgencyId;
       } & {

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "13.5.4",
+  "version": "13.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/maas-backend/customers/personal-documents/consent/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/personal-documents/consent/request.json
@@ -8,6 +8,9 @@
     "identityId": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
+    "customerId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
     "payload": {
       "type": "object",
       "properties": {

--- a/maas-schemas/schemas/maas-backend/customers/personal-documents/create/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/personal-documents/create/request.json
@@ -8,6 +8,9 @@
     "identityId": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
+    "customerId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
     "payload": {
       "$ref": "http://maasglobal.com/core/personal-document.json"
     },

--- a/maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/request.json
@@ -8,6 +8,9 @@
     "identityId": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
+    "customerId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
     "payload": {
       "type": "object",
       "properties": {

--- a/maas-schemas/schemas/maas-backend/customers/personal-documents/remove/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/personal-documents/remove/request.json
@@ -8,6 +8,9 @@
     "identityId": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
+    "customerId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
     "payload": {
       "type": "object",
       "properties": {

--- a/maas-schemas/schemas/maas-backend/customers/personal-documents/revoke-consent/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/personal-documents/revoke-consent/request.json
@@ -8,6 +8,9 @@
     "identityId": {
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
+    "customerId": {
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
+    },
     "payload": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## What has been implemented?
Fixes for customers-personal-documets-* request schemas, related to this backend PR:
https://github.com/maasglobal/maas-backend/pull/2992

This just adds an optional `customerId` parameter to the requests, and am minor version bump, so it's safe to merge.