### PR TITLE
Fix timestamp range

### DIFF
--- a/maas-schemas-ts/src/core/components/units.ts
+++ b/maas-schemas-ts/src/core/components/units.ts
@@ -216,7 +216,7 @@ export type TimeC = t.BrandC<t.NumberC, TimeBrand>;
 export const Time: TimeC = t.brand(
   t.number,
   (x): x is t.Branded<number, TimeBrand> =>
-    (typeof x !== 'number' || x >= 1451606400) &&
+    (typeof x !== 'number' || x >= 126230400000) &&
     (typeof x !== 'number' || x <= 9007199254740991) &&
     Number.isInteger(x),
   'Time',

--- a/maas-schemas/schemas/core/components/units.json
+++ b/maas-schemas/schemas/core/components/units.json
@@ -60,7 +60,7 @@
       "description": "POSIX time in milliseconds, https://en.wikipedia.org/wiki/Unix_time",
       "type": "integer",
       "maximum": 9007199254740991,
-      "minimum": 1451606400
+      "minimum": 126230400000
     },
     "duration": {
       "description": "duration in milliseconds (negative values permitted), https://en.wikipedia.org/wiki/Unix_time",


### PR DESCRIPTION
I had some bugs related to incorrect timestamps. This PR sets the minimum to beginning of 1974 to avoid way out of range numbers.

