### PR TITLE
EX-49 - Moved message inside payload

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-create/request.ts
@@ -71,8 +71,8 @@ export type Request = t.Branded<
       paymentSourceId?: Common_.PaymentSourceId;
       outward?: OutwardReturnWrapper;
       return?: OutwardReturnWrapper;
+      message?: Message_.Message;
     };
-    message?: Message_.Message;
   },
   RequestBrand
 >;
@@ -85,8 +85,8 @@ export const Request = t.brand(
       paymentSourceId: Common_.PaymentSourceId,
       outward: OutwardReturnWrapper,
       return: OutwardReturnWrapper,
+      message: Message_.Message,
     }),
-    message: Message_.Message,
   }),
   (
     x,
@@ -99,8 +99,8 @@ export const Request = t.brand(
         paymentSourceId?: Common_.PaymentSourceId;
         outward?: OutwardReturnWrapper;
         return?: OutwardReturnWrapper;
+        message?: Message_.Message;
       };
-      message?: Message_.Message;
     },
     RequestBrand
   > => true,

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/maas-backend/itineraries/itinerary-create/request.json
+++ b/maas-schemas/schemas/maas-backend/itineraries/itinerary-create/request.json
@@ -24,12 +24,12 @@
         },
         "return": {
           "$ref": "#/definitions/outwardReturnWrapper"
+        },
+        "message": {
+          "$ref": "http://maasglobal.com/core/components/message.json"
         }
       },
       "additionalProperties": false
-    },
-    "message": {
-      "$ref": "http://maasglobal.com/core/components/message.json"
     }
   },
   "definitions": {


### PR DESCRIPTION
## What has been implemented?

Moved `message` into `payload` with accordance to the latest code changes.

See this PR: https://github.com/maasglobal/maas-backend/pull/2880/files#diff-bc91330859a8f68c97240fe071d1c3b6R212

Deployed and tested in `dev`