### PR TITLE
Relax token id format

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.4.0",
+  "version": "14.4.1",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/core/components/fare.ts
+++ b/maas-schemas-ts/src/core/components/fare.ts
@@ -35,7 +35,7 @@ export type TokenId = t.Branded<string, TokenIdBrand>;
 export const TokenId = t.brand(
   t.string,
   (x): x is t.Branded<string, TokenIdBrand> =>
-    typeof x !== 'string' || x.match(RegExp('^[a-z]+(-[a-z]+)*-[a-z0-9_]+$')) !== null,
+    typeof x !== 'string' || x.match(RegExp('^[a-z]+(-[a-z0-9_]+)+$')) !== null,
   'TokenId',
 );
 export interface TokenIdBrand {

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.4.0",
+  "version": "14.4.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/fare.json
+++ b/maas-schemas/schemas/core/components/fare.json
@@ -5,7 +5,7 @@
   "definitions": {
     "tokenId": {
       "type": "string",
-      "pattern": "^[a-z]+(-[a-z]+)*-[a-z0-9_]+$"
+      "pattern": "^[a-z]+(-[a-z0-9_]+)+$"
     }
   },
   "properties": {


### PR DESCRIPTION
Regex for tokenId does not allow numbers in the middle of the token string, for example
`jp-tobu-300yen-ticket`

This schema allows it