### PR TITLE
Add prePurchaseGuidanceUrl to terms

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.6.1",
+  "version": "14.6.2",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/core/components/terms.ts
+++ b/maas-schemas-ts/src/core/components/terms.ts
@@ -227,6 +227,7 @@ export type Terms = t.Branded<
       outward?: Amendment;
       return?: Amendment;
     };
+    prePurchaseGuidanceUrl?: Units_.Url;
     fareRates?: Array<
       {
         amount?: number;
@@ -283,6 +284,7 @@ export const Terms = t.brand(
       outward: Amendment,
       return: Amendment,
     }),
+    prePurchaseGuidanceUrl: Units_.Url,
     fareRates: t.array(
       t.intersection([
         t.partial({
@@ -340,6 +342,7 @@ export const Terms = t.brand(
         outward?: Amendment;
         return?: Amendment;
       };
+      prePurchaseGuidanceUrl?: Units_.Url;
       fareRates?: Array<
         {
           amount?: number;

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.6.1",
+  "version": "14.6.2",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/terms.json
+++ b/maas-schemas/schemas/core/components/terms.json
@@ -105,6 +105,10 @@
         }
       }
     },
+    "prePurchaseGuidanceUrl": {
+      "description": "If flow requires additional instructions or resources presented to the customer before purchase, they can be embedded in the HTML page and booking option can link to that",
+      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+    },
     "fareRates": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## What has been implemented?

If flow requires to show a lot of information to the user along the links to e.g. timetables and route map for a BUS, url to a page can be provided using `terms.prePurchaseGuidanceUrl` on option.