### PR TITLE
Add missing ARRIVED state to webhook update

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.6.3",
+  "version": "14.6.4",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
+++ b/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-request.ts
@@ -39,7 +39,14 @@ export type RemoteRequest = t.Branded<
   {
     tspId?: Booking_.TspId;
     cost?: Booking_.Cost;
-    state?: 'RESERVED' | 'CONFIRMED' | 'ACTIVATED' | 'EXPIRED' | 'CANCELLED' | 'REJECTED';
+    state?:
+      | 'RESERVED'
+      | 'CONFIRMED'
+      | 'ARRIVED'
+      | 'ACTIVATED'
+      | 'EXPIRED'
+      | 'CANCELLED'
+      | 'REJECTED';
     leg?: BookingOption_.LegDelta;
     meta?: BookingMeta_.BookingMeta;
     terms?: Booking_.Terms;
@@ -59,6 +66,7 @@ export const RemoteRequest = t.brand(
       state: t.union([
         t.literal('RESERVED'),
         t.literal('CONFIRMED'),
+        t.literal('ARRIVED'),
         t.literal('ACTIVATED'),
         t.literal('EXPIRED'),
         t.literal('CANCELLED'),
@@ -84,6 +92,7 @@ export const RemoteRequest = t.brand(
       state?:
         | 'RESERVED'
         | 'CONFIRMED'
+        | 'ARRIVED'
         | 'ACTIVATED'
         | 'EXPIRED'
         | 'CANCELLED'

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.6.3",
+  "version": "14.6.4",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/tsp/webhooks-bookings-update/remote-request.json
+++ b/maas-schemas/schemas/tsp/webhooks-bookings-update/remote-request.json
@@ -10,7 +10,7 @@
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/cost"
     },
     "state": {
-      "enum": ["RESERVED", "CONFIRMED", "ACTIVATED", "EXPIRED", "CANCELLED", "REJECTED"]
+      "enum": ["RESERVED", "CONFIRMED", "ARRIVED", "ACTIVATED", "EXPIRED", "CANCELLED", "REJECTED"]
     },
     "leg": {
       "$ref": "http://maasglobal.com/core/booking-option.json#/definitions/legDelta"


### PR DESCRIPTION
## What has been implemented?

Webhook update request was missing `ARRIVED` state, which prevented e.g. TAXIs to report arrival via webhook.