### PR TITLE
Fix broken ref objects

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "fp-ts": "^2.0.5",
     "io-ts": "^2.1.2",
-    "io-ts-from-json-schema": "^0.0.10",
+    "io-ts-from-json-schema": "^0.0.12",
     "io-ts-types": "^0.5.2",
     "io-ts-validator": "^0.0.2",
     "jest": "^24.9.0",

--- a/maas-schemas-ts/src/core/booking-option.ts
+++ b/maas-schemas-ts/src/core/booking-option.ts
@@ -177,10 +177,17 @@ export interface TspProductBrand {
 }
 
 // Customer
-// The purpose of this remains a mystery
-export type Customer = Customer_.Customer;
-// exists type CustomerC extends t.AnyC
-export const Customer: CustomerC = Customer_.Customer;
+// MaaS booking customer
+export type Customer = t.Branded<Customer_.Customer, CustomerBrand>;
+export type CustomerC = t.BrandC<typeof Customer_.Customer, CustomerBrand>;
+export const Customer: CustomerC = t.brand(
+  Customer_.Customer,
+  (x): x is t.Branded<Customer_.Customer, CustomerBrand> => true,
+  'Customer',
+);
+export interface CustomerBrand {
+  readonly Customer: unique symbol;
+}
 
 // ContentWithCost
 // The purpose of this remains a mystery
@@ -422,7 +429,6 @@ export interface BookingOptionBrand {
   readonly BookingOption: unique symbol;
 }
 
-export type CustomerC = Customer_.CustomerC;
 export default BookingOption;
 
 // Success

--- a/maas-schemas-ts/src/core/booking.ts
+++ b/maas-schemas-ts/src/core/booking.ts
@@ -44,9 +44,16 @@ export const schemaId = 'http://maasglobal.com/core/booking.json';
 
 // Id
 // The purpose of this remains a mystery
-export type Id = Units_.Uuid;
-// exists type IdC extends t.AnyC
-export const Id: IdC = Units_.Uuid;
+export type Id = t.Branded<Units_.Uuid, IdBrand>;
+export type IdC = t.BrandC<typeof Units_.Uuid, IdBrand>;
+export const Id: IdC = t.brand(
+  Units_.Uuid,
+  (x): x is t.Branded<Units_.Uuid, IdBrand> => true,
+  'Id',
+);
+export interface IdBrand {
+  readonly Id: unique symbol;
+}
 
 // Fares
 // The purpose of this remains a mystery
@@ -63,15 +70,32 @@ export interface FaresBrand {
 
 // Cost
 // The purpose of this remains a mystery
-export type Cost = Cost_.Cost;
-// exists type CostC extends t.AnyC
-export const Cost: CostC = Cost_.Cost;
+export type Cost = t.Branded<Cost_.Cost, CostBrand>;
+export type CostC = t.BrandC<typeof Cost_.Cost, CostBrand>;
+export const Cost: CostC = t.brand(
+  Cost_.Cost,
+  (x): x is t.Branded<Cost_.Cost, CostBrand> => true,
+  'Cost',
+);
+export interface CostBrand {
+  readonly Cost: unique symbol;
+}
 
 // Configurator
 // The purpose of this remains a mystery
-export type Configurator = Configurator_.Configurator;
-// exists type ConfiguratorC extends t.AnyC
-export const Configurator: ConfiguratorC = Configurator_.Configurator;
+export type Configurator = t.Branded<Configurator_.Configurator, ConfiguratorBrand>;
+export type ConfiguratorC = t.BrandC<
+  typeof Configurator_.Configurator,
+  ConfiguratorBrand
+>;
+export const Configurator: ConfiguratorC = t.brand(
+  Configurator_.Configurator,
+  (x): x is t.Branded<Configurator_.Configurator, ConfiguratorBrand> => true,
+  'Configurator',
+);
+export interface ConfiguratorBrand {
+  readonly Configurator: unique symbol;
+}
 
 // TspId
 // The purpose of this remains a mystery
@@ -190,9 +214,16 @@ export interface LegBrand {
 
 // Terms
 // The purpose of this remains a mystery
-export type Terms = Terms_.Terms;
-// exists type TermsC extends t.AnyC
-export const Terms: TermsC = Terms_.Terms;
+export type Terms = t.Branded<Terms_.Terms, TermsBrand>;
+export type TermsC = t.BrandC<typeof Terms_.Terms, TermsBrand>;
+export const Terms: TermsC = t.brand(
+  Terms_.Terms,
+  (x): x is t.Branded<Terms_.Terms, TermsBrand> => true,
+  'Terms',
+);
+export interface TermsBrand {
+  readonly Terms: unique symbol;
+}
 
 // Token
 // The validity token (such as booking ID, travel ticket etc.) that MaaS clients will display to validate the trip when starting the leg.
@@ -513,10 +544,6 @@ export const examplesBooking: NonEmptyArray<Booking> = ([
   },
 ] as unknown) as NonEmptyArray<Booking>;
 
-export type IdC = Units_.UuidC;
-export type CostC = Cost_.CostC;
-export type ConfiguratorC = Configurator_.ConfiguratorC;
-export type TermsC = Terms_.TermsC;
 export default Booking;
 
 // Success

--- a/maas-schemas-ts/src/core/components/address.ts
+++ b/maas-schemas-ts/src/core/components/address.ts
@@ -71,28 +71,56 @@ export interface PlaceNameBrand {
 }
 
 // FirstName
-// The purpose of this remains a mystery
-export type FirstName = Common_.PersonalName;
-// exists type FirstNameC extends t.AnyC
-export const FirstName: FirstNameC = Common_.PersonalName;
+// First name of the customer (e.g. John)
+export type FirstName = t.Branded<Common_.PersonalName, FirstNameBrand>;
+export type FirstNameC = t.BrandC<typeof Common_.PersonalName, FirstNameBrand>;
+export const FirstName: FirstNameC = t.brand(
+  Common_.PersonalName,
+  (x): x is t.Branded<Common_.PersonalName, FirstNameBrand> => true,
+  'FirstName',
+);
+export interface FirstNameBrand {
+  readonly FirstName: unique symbol;
+}
 
 // LastName
-// The purpose of this remains a mystery
-export type LastName = Common_.PersonalName;
-// exists type LastNameC extends t.AnyC
-export const LastName: LastNameC = Common_.PersonalName;
+// Last name of the customer (e.g. Doe)
+export type LastName = t.Branded<Common_.PersonalName, LastNameBrand>;
+export type LastNameC = t.BrandC<typeof Common_.PersonalName, LastNameBrand>;
+export const LastName: LastNameC = t.brand(
+  Common_.PersonalName,
+  (x): x is t.Branded<Common_.PersonalName, LastNameBrand> => true,
+  'LastName',
+);
+export interface LastNameBrand {
+  readonly LastName: unique symbol;
+}
 
 // Phone
-// The purpose of this remains a mystery
-export type Phone = Common_.Phone;
-// exists type PhoneC extends t.AnyC
-export const Phone: PhoneC = Common_.Phone;
+// ITU-T E.164 phone number
+export type Phone = t.Branded<Common_.Phone, PhoneBrand>;
+export type PhoneC = t.BrandC<typeof Common_.Phone, PhoneBrand>;
+export const Phone: PhoneC = t.brand(
+  Common_.Phone,
+  (x): x is t.Branded<Common_.Phone, PhoneBrand> => true,
+  'Phone',
+);
+export interface PhoneBrand {
+  readonly Phone: unique symbol;
+}
 
 // Email
-// The purpose of this remains a mystery
-export type Email = Common_.Email;
-// exists type EmailC extends t.AnyC
-export const Email: EmailC = Common_.Email;
+// Rough validation of a valid e-mail address
+export type Email = t.Branded<Common_.Email, EmailBrand>;
+export type EmailC = t.BrandC<typeof Common_.Email, EmailBrand>;
+export const Email: EmailC = t.brand(
+  Common_.Email,
+  (x): x is t.Branded<Common_.Email, EmailBrand> => true,
+  'Email',
+);
+export interface EmailBrand {
+  readonly Email: unique symbol;
+}
 
 // Address
 // Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html
@@ -177,10 +205,5 @@ export const City: CityC = t.brand(
 export interface CityBrand {
   readonly City: unique symbol;
 }
-
-export type FirstNameC = Common_.PersonalNameC;
-export type LastNameC = Common_.PersonalNameC;
-export type PhoneC = Common_.PhoneC;
-export type EmailC = Common_.EmailC;
 
 // Success

--- a/maas-schemas-ts/src/core/components/station.ts
+++ b/maas-schemas-ts/src/core/components/station.ts
@@ -59,33 +59,68 @@ export interface NameBrand {
 
 // Location
 // The purpose of this remains a mystery
-export type Location = UnitsGeo_.ShortLocationString;
-// exists type LocationC extends t.AnyC
-export const Location: LocationC = UnitsGeo_.ShortLocationString;
+export type Location = t.Branded<UnitsGeo_.ShortLocationString, LocationBrand>;
+export type LocationC = t.BrandC<typeof UnitsGeo_.ShortLocationString, LocationBrand>;
+export const Location: LocationC = t.brand(
+  UnitsGeo_.ShortLocationString,
+  (x): x is t.Branded<UnitsGeo_.ShortLocationString, LocationBrand> => true,
+  'Location',
+);
+export interface LocationBrand {
+  readonly Location: unique symbol;
+}
 
 // Address
 // The purpose of this remains a mystery
-export type Address = Address_.Address;
-// exists type AddressC extends t.AnyC
-export const Address: AddressC = Address_.Address;
+export type Address = t.Branded<Address_.Address, AddressBrand>;
+export type AddressC = t.BrandC<typeof Address_.Address, AddressBrand>;
+export const Address: AddressC = t.brand(
+  Address_.Address,
+  (x): x is t.Branded<Address_.Address, AddressBrand> => true,
+  'Address',
+);
+export interface AddressBrand {
+  readonly Address: unique symbol;
+}
 
 // City
 // The purpose of this remains a mystery
-export type City = Address_.City;
-// exists type CityC extends t.AnyC
-export const City: CityC = Address_.City;
+export type City = t.Branded<Address_.City, CityBrand>;
+export type CityC = t.BrandC<typeof Address_.City, CityBrand>;
+export const City: CityC = t.brand(
+  Address_.City,
+  (x): x is t.Branded<Address_.City, CityBrand> => true,
+  'City',
+);
+export interface CityBrand {
+  readonly City: unique symbol;
+}
 
 // Country
 // The purpose of this remains a mystery
-export type Country = Address_.Country;
-// exists type CountryC extends t.AnyC
-export const Country: CountryC = Address_.Country;
+export type Country = t.Branded<Address_.Country, CountryBrand>;
+export type CountryC = t.BrandC<typeof Address_.Country, CountryBrand>;
+export const Country: CountryC = t.brand(
+  Address_.Country,
+  (x): x is t.Branded<Address_.Country, CountryBrand> => true,
+  'Country',
+);
+export interface CountryBrand {
+  readonly Country: unique symbol;
+}
 
 // AgencyId
 // The purpose of this remains a mystery
-export type AgencyId = Common_.AgencyId;
-// exists type AgencyIdC extends t.AnyC
-export const AgencyId: AgencyIdC = Common_.AgencyId;
+export type AgencyId = t.Branded<Common_.AgencyId, AgencyIdBrand>;
+export type AgencyIdC = t.BrandC<typeof Common_.AgencyId, AgencyIdBrand>;
+export const AgencyId: AgencyIdC = t.brand(
+  Common_.AgencyId,
+  (x): x is t.Branded<Common_.AgencyId, AgencyIdBrand> => true,
+  'AgencyId',
+);
+export interface AgencyIdBrand {
+  readonly AgencyId: unique symbol;
+}
 
 // OpeningHours
 // Opening hour of the station, object format is left for TSP to decide
@@ -225,11 +260,6 @@ export interface StationBrand {
   readonly Station: unique symbol;
 }
 
-export type LocationC = UnitsGeo_.ShortLocationStringC;
-export type AddressC = Address_.AddressC;
-export type CityC = Address_.CityC;
-export type CountryC = Address_.CountryC;
-export type AgencyIdC = Common_.AgencyIdC;
 export default Station;
 
 // Success

--- a/maas-schemas-ts/src/core/itinerary.ts
+++ b/maas-schemas-ts/src/core/itinerary.ts
@@ -36,9 +36,16 @@ export const schemaId = 'http://maasglobal.com/core/itinerary.json';
 
 // Id
 // The purpose of this remains a mystery
-export type Id = Units_.Uuid;
-// exists type IdC extends t.AnyC
-export const Id: IdC = Units_.Uuid;
+export type Id = t.Branded<Units_.Uuid, IdBrand>;
+export type IdC = t.BrandC<typeof Units_.Uuid, IdBrand>;
+export const Id: IdC = t.brand(
+  Units_.Uuid,
+  (x): x is t.Branded<Units_.Uuid, IdBrand> => true,
+  'Id',
+);
+export interface IdBrand {
+  readonly Id: unique symbol;
+}
 
 // Itinerary
 // The default export. More information at the top.
@@ -148,7 +155,6 @@ export interface ItineraryBrand {
   readonly Itinerary: unique symbol;
 }
 
-export type IdC = Units_.UuidC;
 export default Itinerary;
 
 // Success

--- a/maas-schemas-ts/src/core/leg.ts
+++ b/maas-schemas-ts/src/core/leg.ts
@@ -37,33 +37,68 @@ export const schemaId = 'http://maasglobal.com/core/leg.json';
 
 // State
 // The purpose of this remains a mystery
-export type State = State_.LegState;
-// exists type StateC extends t.AnyC
-export const State: StateC = State_.LegState;
+export type State = t.Branded<State_.LegState, StateBrand>;
+export type StateC = t.BrandC<typeof State_.LegState, StateBrand>;
+export const State: StateC = t.brand(
+  State_.LegState,
+  (x): x is t.Branded<State_.LegState, StateBrand> => true,
+  'State',
+);
+export interface StateBrand {
+  readonly State: unique symbol;
+}
 
 // From
 // The purpose of this remains a mystery
-export type From = Place_.Place;
-// exists type FromC extends t.AnyC
-export const From: FromC = Place_.Place;
+export type From = t.Branded<Place_.Place, FromBrand>;
+export type FromC = t.BrandC<typeof Place_.Place, FromBrand>;
+export const From: FromC = t.brand(
+  Place_.Place,
+  (x): x is t.Branded<Place_.Place, FromBrand> => true,
+  'From',
+);
+export interface FromBrand {
+  readonly From: unique symbol;
+}
 
 // To
 // The purpose of this remains a mystery
-export type To = Place_.Place;
-// exists type ToC extends t.AnyC
-export const To: ToC = Place_.Place;
+export type To = t.Branded<Place_.Place, ToBrand>;
+export type ToC = t.BrandC<typeof Place_.Place, ToBrand>;
+export const To: ToC = t.brand(
+  Place_.Place,
+  (x): x is t.Branded<Place_.Place, ToBrand> => true,
+  'To',
+);
+export interface ToBrand {
+  readonly To: unique symbol;
+}
 
 // StartTime
 // The purpose of this remains a mystery
-export type StartTime = Units_.Time;
-// exists type StartTimeC extends t.AnyC
-export const StartTime: StartTimeC = Units_.Time;
+export type StartTime = t.Branded<Units_.Time, StartTimeBrand>;
+export type StartTimeC = t.BrandC<typeof Units_.Time, StartTimeBrand>;
+export const StartTime: StartTimeC = t.brand(
+  Units_.Time,
+  (x): x is t.Branded<Units_.Time, StartTimeBrand> => true,
+  'StartTime',
+);
+export interface StartTimeBrand {
+  readonly StartTime: unique symbol;
+}
 
 // EndTime
 // The purpose of this remains a mystery
-export type EndTime = Units_.Time;
-// exists type EndTimeC extends t.AnyC
-export const EndTime: EndTimeC = Units_.Time;
+export type EndTime = t.Branded<Units_.Time, EndTimeBrand>;
+export type EndTimeC = t.BrandC<typeof Units_.Time, EndTimeBrand>;
+export const EndTime: EndTimeC = t.brand(
+  Units_.Time,
+  (x): x is t.Branded<Units_.Time, EndTimeBrand> => true,
+  'EndTime',
+);
+export interface EndTimeBrand {
+  readonly EndTime: unique symbol;
+}
 
 // Mode
 // The purpose of this remains a mystery
@@ -118,21 +153,42 @@ export interface StopsBrand {
 
 // DepartureDelay
 // The purpose of this remains a mystery
-export type DepartureDelay = Units_.Duration;
-// exists type DepartureDelayC extends t.AnyC
-export const DepartureDelay: DepartureDelayC = Units_.Duration;
+export type DepartureDelay = t.Branded<Units_.Duration, DepartureDelayBrand>;
+export type DepartureDelayC = t.BrandC<typeof Units_.Duration, DepartureDelayBrand>;
+export const DepartureDelay: DepartureDelayC = t.brand(
+  Units_.Duration,
+  (x): x is t.Branded<Units_.Duration, DepartureDelayBrand> => true,
+  'DepartureDelay',
+);
+export interface DepartureDelayBrand {
+  readonly DepartureDelay: unique symbol;
+}
 
 // ArrivalDelay
 // The purpose of this remains a mystery
-export type ArrivalDelay = Units_.Duration;
-// exists type ArrivalDelayC extends t.AnyC
-export const ArrivalDelay: ArrivalDelayC = Units_.Duration;
+export type ArrivalDelay = t.Branded<Units_.Duration, ArrivalDelayBrand>;
+export type ArrivalDelayC = t.BrandC<typeof Units_.Duration, ArrivalDelayBrand>;
+export const ArrivalDelay: ArrivalDelayC = t.brand(
+  Units_.Duration,
+  (x): x is t.Branded<Units_.Duration, ArrivalDelayBrand> => true,
+  'ArrivalDelay',
+);
+export interface ArrivalDelayBrand {
+  readonly ArrivalDelay: unique symbol;
+}
 
 // Distance
 // The purpose of this remains a mystery
-export type Distance = UnitsGeo_.Distance;
-// exists type DistanceC extends t.AnyC
-export const Distance: DistanceC = UnitsGeo_.Distance;
+export type Distance = t.Branded<UnitsGeo_.Distance, DistanceBrand>;
+export type DistanceC = t.BrandC<typeof UnitsGeo_.Distance, DistanceBrand>;
+export const Distance: DistanceC = t.brand(
+  UnitsGeo_.Distance,
+  (x): x is t.Branded<UnitsGeo_.Distance, DistanceBrand> => true,
+  'Distance',
+);
+export interface DistanceBrand {
+  readonly Distance: unique symbol;
+}
 
 // Route
 // The purpose of this remains a mystery
@@ -180,9 +236,16 @@ export interface RouteLongNameBrand {
 
 // AgencyId
 // The purpose of this remains a mystery
-export type AgencyId = Common_.AgencyId;
-// exists type AgencyIdC extends t.AnyC
-export const AgencyId: AgencyIdC = Common_.AgencyId;
+export type AgencyId = t.Branded<Common_.AgencyId, AgencyIdBrand>;
+export type AgencyIdC = t.BrandC<typeof Common_.AgencyId, AgencyIdBrand>;
+export const AgencyId: AgencyIdC = t.brand(
+  Common_.AgencyId,
+  (x): x is t.Branded<Common_.AgencyId, AgencyIdBrand> => true,
+  'AgencyId',
+);
+export interface AgencyIdBrand {
+  readonly AgencyId: unique symbol;
+}
 
 // LegGeometry
 // The purpose of this remains a mystery
@@ -218,9 +281,16 @@ export interface LegGeometryBrand {
 
 // TspProduct
 // The purpose of this remains a mystery
-export type TspProduct = BookingOption_.TspProduct;
-// exists type TspProductC extends t.AnyC
-export const TspProduct: TspProductC = BookingOption_.TspProduct;
+export type TspProduct = t.Branded<BookingOption_.TspProduct, TspProductBrand>;
+export type TspProductC = t.BrandC<typeof BookingOption_.TspProduct, TspProductBrand>;
+export const TspProduct: TspProductC = t.brand(
+  BookingOption_.TspProduct,
+  (x): x is t.Branded<BookingOption_.TspProduct, TspProductBrand> => true,
+  'TspProduct',
+);
+export interface TspProductBrand {
+  readonly TspProduct: unique symbol;
+}
 
 // ProductOption
 // Index of the productOption used in the itinerary's productOptions
@@ -568,16 +638,6 @@ export interface LegBrand {
   readonly Leg: unique symbol;
 }
 
-export type StateC = State_.LegStateC;
-export type FromC = Place_.PlaceC;
-export type ToC = Place_.PlaceC;
-export type StartTimeC = Units_.TimeC;
-export type EndTimeC = Units_.TimeC;
-export type DepartureDelayC = Units_.DurationC;
-export type ArrivalDelayC = Units_.DurationC;
-export type DistanceC = UnitsGeo_.DistanceC;
-export type AgencyIdC = Common_.AgencyIdC;
-export type TspProductC = BookingOption_.TspProductC;
 export default Leg;
 
 // Success

--- a/maas-schemas-ts/src/core/modes/MODE_CAR.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_CAR.ts
@@ -8,17 +8,24 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as CarRental_ from '../components/car-rental';
 
 export const schemaId = 'http://maasglobal.com/core/modes/MODE_CAR.json';
 
 // MODE_CAR
 // The default export. More information at the top.
-export type MODE_CAR = CarRental_.CarRental;
-// exists type MODE_CARC extends t.AnyC
-export const MODE_CAR: MODE_CARC = CarRental_.CarRental;
+export type MODE_CAR = t.Branded<CarRental_.CarRental, MODE_CARBrand>;
+export type MODE_CARC = t.BrandC<typeof CarRental_.CarRental, MODE_CARBrand>;
+export const MODE_CAR: MODE_CARC = t.brand(
+  CarRental_.CarRental,
+  (x): x is t.Branded<CarRental_.CarRental, MODE_CARBrand> => true,
+  'MODE_CAR',
+);
+export interface MODE_CARBrand {
+  readonly MODE_CAR: unique symbol;
+}
 
 export default MODE_CAR;
-export type MODE_CARC = CarRental_.CarRentalC;
 
 // Success

--- a/maas-schemas-ts/src/core/modes/MODE_SHARED_CAR.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_SHARED_CAR.ts
@@ -8,17 +8,27 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as CarRental_ from '../components/car-rental';
 
 export const schemaId = 'http://maasglobal.com/core/modes/MODE_SHARED_CAR.json';
 
 // MODE_SHARED_CAR
 // The default export. More information at the top.
-export type MODE_SHARED_CAR = CarRental_.CarRental;
-// exists type MODE_SHARED_CARC extends t.AnyC
-export const MODE_SHARED_CAR: MODE_SHARED_CARC = CarRental_.CarRental;
+export type MODE_SHARED_CAR = t.Branded<CarRental_.CarRental, MODE_SHARED_CARBrand>;
+export type MODE_SHARED_CARC = t.BrandC<
+  typeof CarRental_.CarRental,
+  MODE_SHARED_CARBrand
+>;
+export const MODE_SHARED_CAR: MODE_SHARED_CARC = t.brand(
+  CarRental_.CarRental,
+  (x): x is t.Branded<CarRental_.CarRental, MODE_SHARED_CARBrand> => true,
+  'MODE_SHARED_CAR',
+);
+export interface MODE_SHARED_CARBrand {
+  readonly MODE_SHARED_CAR: unique symbol;
+}
 
 export default MODE_SHARED_CAR;
-export type MODE_SHARED_CARC = CarRental_.CarRentalC;
 
 // Success

--- a/maas-schemas-ts/src/maas-backend/autocomplete/autocomplete-query/request.ts
+++ b/maas-schemas-ts/src/maas-backend/autocomplete/autocomplete-query/request.ts
@@ -42,7 +42,7 @@ export type Request = t.Branded<
       lat?: UnitsGeo_.RelaxedLatitude;
       lon?: UnitsGeo_.RelaxedLongitude;
       count?: number;
-      radius?: UnitsGeo_.Distance;
+      radius?: UnitsGeo_.Distance & unknown;
     } & {
       name: Defined;
     };
@@ -60,7 +60,7 @@ export type RequestC = t.BrandC<
           lat: typeof UnitsGeo_.RelaxedLatitude;
           lon: typeof UnitsGeo_.RelaxedLongitude;
           count: t.NumberC;
-          radius: typeof UnitsGeo_.Distance;
+          radius: t.IntersectionC<[typeof UnitsGeo_.Distance, t.UnknownC]>;
         }>,
         t.TypeC<{
           name: typeof Defined;
@@ -80,7 +80,7 @@ export const Request: RequestC = t.brand(
         lat: UnitsGeo_.RelaxedLatitude,
         lon: UnitsGeo_.RelaxedLongitude,
         count: t.number,
-        radius: UnitsGeo_.Distance,
+        radius: t.intersection([UnitsGeo_.Distance, t.unknown]),
       }),
       t.type({
         name: Defined,
@@ -98,7 +98,7 @@ export const Request: RequestC = t.brand(
         lat?: UnitsGeo_.RelaxedLatitude;
         lon?: UnitsGeo_.RelaxedLongitude;
         count?: number;
-        radius?: UnitsGeo_.Distance;
+        radius?: UnitsGeo_.Distance & unknown;
       } & {
         name: Defined;
       };

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/request.ts
@@ -37,7 +37,11 @@ export type Request = t.Branded<
   {
     identityId?: Units_.IdentityId;
     customerId?: Units_.IdentityId;
-    payload?: PartialFavoriteLocation_.PartialFavoriteLocation;
+    payload?: PartialFavoriteLocation_.PartialFavoriteLocation & {
+      type: Defined;
+      name: Defined;
+      location: Defined;
+    };
     headers?: ApiCommon_.Headers;
   } & {
     identityId: Defined;
@@ -53,7 +57,16 @@ export type RequestC = t.BrandC<
       t.PartialC<{
         identityId: typeof Units_.IdentityId;
         customerId: typeof Units_.IdentityId;
-        payload: typeof PartialFavoriteLocation_.PartialFavoriteLocation;
+        payload: t.IntersectionC<
+          [
+            typeof PartialFavoriteLocation_.PartialFavoriteLocation,
+            t.TypeC<{
+              type: typeof Defined;
+              name: typeof Defined;
+              location: typeof Defined;
+            }>,
+          ]
+        >;
         headers: typeof ApiCommon_.Headers;
       }>,
       t.TypeC<{
@@ -71,7 +84,14 @@ export const Request: RequestC = t.brand(
     t.partial({
       identityId: Units_.IdentityId,
       customerId: Units_.IdentityId,
-      payload: PartialFavoriteLocation_.PartialFavoriteLocation,
+      payload: t.intersection([
+        PartialFavoriteLocation_.PartialFavoriteLocation,
+        t.type({
+          type: Defined,
+          name: Defined,
+          location: Defined,
+        }),
+      ]),
       headers: ApiCommon_.Headers,
     }),
     t.type({
@@ -87,7 +107,11 @@ export const Request: RequestC = t.brand(
     {
       identityId?: Units_.IdentityId;
       customerId?: Units_.IdentityId;
-      payload?: PartialFavoriteLocation_.PartialFavoriteLocation;
+      payload?: PartialFavoriteLocation_.PartialFavoriteLocation & {
+        type: Defined;
+        name: Defined;
+        location: Defined;
+      };
       headers?: ApiCommon_.Headers;
     } & {
       identityId: Defined;

--- a/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/favorite-locations/add/response.ts
@@ -11,6 +11,21 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 import * as t from 'io-ts';
 import * as PartialFavoriteLocation_ from '../../../../core/partialFavoriteLocation';
 
+export type Defined = {} | null;
+export class DefinedType extends t.Type<Defined> {
+  readonly _tag: 'DefinedType' = 'DefinedType';
+  constructor() {
+    super(
+      'defined',
+      (u): u is Defined => typeof u !== 'undefined',
+      (u, c) => (this.is(u) ? t.success(u) : t.failure(u, c)),
+      t.identity,
+    );
+  }
+}
+export interface DefinedC extends DefinedType {}
+export const Defined: DefinedC = new DefinedType();
+
 export const schemaId =
   'http://maasglobal.com/maas-backend/customers/favorite-locations/add/response.json';
 
@@ -18,25 +33,57 @@ export const schemaId =
 // The default export. More information at the top.
 export type Response = t.Branded<
   {
-    favoriteLocation?: PartialFavoriteLocation_.PartialFavoriteLocation;
+    favoriteLocation?: PartialFavoriteLocation_.PartialFavoriteLocation & {
+      type: Defined;
+      name: Defined;
+      location: Defined;
+      id: Defined;
+      identityId: Defined;
+    };
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
   t.PartialC<{
-    favoriteLocation: typeof PartialFavoriteLocation_.PartialFavoriteLocation;
+    favoriteLocation: t.IntersectionC<
+      [
+        typeof PartialFavoriteLocation_.PartialFavoriteLocation,
+        t.TypeC<{
+          type: typeof Defined;
+          name: typeof Defined;
+          location: typeof Defined;
+          id: typeof Defined;
+          identityId: typeof Defined;
+        }>,
+      ]
+    >;
   }>,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
   t.partial({
-    favoriteLocation: PartialFavoriteLocation_.PartialFavoriteLocation,
+    favoriteLocation: t.intersection([
+      PartialFavoriteLocation_.PartialFavoriteLocation,
+      t.type({
+        type: Defined,
+        name: Defined,
+        location: Defined,
+        id: Defined,
+        identityId: Defined,
+      }),
+    ]),
   }),
   (
     x,
   ): x is t.Branded<
     {
-      favoriteLocation?: PartialFavoriteLocation_.PartialFavoriteLocation;
+      favoriteLocation?: PartialFavoriteLocation_.PartialFavoriteLocation & {
+        type: Defined;
+        name: Defined;
+        location: Defined;
+        id: Defined;
+        identityId: Defined;
+      };
     },
     ResponseBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/initiate/response.ts
@@ -8,6 +8,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as KycService_ from '../../../../core/kyc-service';
 
 export const schemaId =
@@ -15,11 +16,17 @@ export const schemaId =
 
 // Response
 // The default export. More information at the top.
-export type Response = KycService_.KycService;
-// exists type ResponseC extends t.AnyC
-export const Response: ResponseC = KycService_.KycService;
+export type Response = t.Branded<KycService_.KycService, ResponseBrand>;
+export type ResponseC = t.BrandC<typeof KycService_.KycService, ResponseBrand>;
+export const Response: ResponseC = t.brand(
+  KycService_.KycService,
+  (x): x is t.Branded<KycService_.KycService, ResponseBrand> => true,
+  'Response',
+);
+export interface ResponseBrand {
+  readonly Response: unique symbol;
+}
 
 export default Response;
-export type ResponseC = KycService_.KycServiceC;
 
 // Success

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/request.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/request.ts
@@ -43,7 +43,7 @@ export type Request = t.Branded<
       lon?: UnitsGeo_.RelaxedLongitude;
       count?: number;
       distance?: UnitsGeo_.Distance;
-      locale?: I18n_.Locale;
+      locale?: I18n_.Locale & unknown;
     } & {
       name: Defined;
       lat: Defined;
@@ -68,7 +68,7 @@ export type RequestC = t.BrandC<
               lon: typeof UnitsGeo_.RelaxedLongitude;
               count: t.NumberC;
               distance: typeof UnitsGeo_.Distance;
-              locale: typeof I18n_.Locale;
+              locale: t.IntersectionC<[typeof I18n_.Locale, t.UnknownC]>;
             }>,
             t.TypeC<{
               name: typeof Defined;
@@ -97,7 +97,7 @@ export const Request: RequestC = t.brand(
           lon: UnitsGeo_.RelaxedLongitude,
           count: t.number,
           distance: UnitsGeo_.Distance,
-          locale: I18n_.Locale,
+          locale: t.intersection([I18n_.Locale, t.unknown]),
         }),
         t.type({
           name: Defined,
@@ -122,7 +122,7 @@ export const Request: RequestC = t.brand(
         lon?: UnitsGeo_.RelaxedLongitude;
         count?: number;
         distance?: UnitsGeo_.Distance;
-        locale?: I18n_.Locale;
+        locale?: I18n_.Locale & unknown;
       } & {
         name: Defined;
         lat: Defined;

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/request.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/request.ts
@@ -42,7 +42,7 @@ export type Request = t.Branded<
       lon?: UnitsGeo_.RelaxedLongitude;
       count?: number;
       radius?: UnitsGeo_.Distance;
-      locale?: I18n_.Locale;
+      locale?: I18n_.Locale & unknown;
     } & {
       lat: Defined;
       lon: Defined;
@@ -65,7 +65,7 @@ export type RequestC = t.BrandC<
               lon: typeof UnitsGeo_.RelaxedLongitude;
               count: t.NumberC;
               radius: typeof UnitsGeo_.Distance;
-              locale: typeof I18n_.Locale;
+              locale: t.IntersectionC<[typeof I18n_.Locale, t.UnknownC]>;
             }>,
             t.TypeC<{
               lat: typeof Defined;
@@ -92,7 +92,7 @@ export const Request: RequestC = t.brand(
           lon: UnitsGeo_.RelaxedLongitude,
           count: t.number,
           radius: UnitsGeo_.Distance,
-          locale: I18n_.Locale,
+          locale: t.intersection([I18n_.Locale, t.unknown]),
         }),
         t.type({
           lat: Defined,
@@ -115,7 +115,7 @@ export const Request: RequestC = t.brand(
         lon?: UnitsGeo_.RelaxedLongitude;
         count?: number;
         radius?: UnitsGeo_.Distance;
-        locale?: I18n_.Locale;
+        locale?: I18n_.Locale & unknown;
       } & {
         lat: Defined;
         lon: Defined;

--- a/maas-schemas-ts/src/maas-backend/stations/stations-list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/stations/stations-list/response.ts
@@ -8,6 +8,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as Response_ from '../../../tsp/stations-list/response';
 
 export const schemaId =
@@ -15,11 +16,17 @@ export const schemaId =
 
 // Response
 // The default export. More information at the top.
-export type Response = Response_.Response;
-// exists type ResponseC extends t.AnyC
-export const Response: ResponseC = Response_.Response;
+export type Response = t.Branded<Response_.Response, ResponseBrand>;
+export type ResponseC = t.BrandC<typeof Response_.Response, ResponseBrand>;
+export const Response: ResponseC = t.brand(
+  Response_.Response,
+  (x): x is t.Branded<Response_.Response, ResponseBrand> => true,
+  'Response',
+);
+export interface ResponseBrand {
+  readonly Response: unique symbol;
+}
 
 export default Response;
-export type ResponseC = Response_.ResponseC;
 
 // Success

--- a/maas-schemas-ts/src/maas-backend/stations/stations-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/stations/stations-retrieve/response.ts
@@ -8,6 +8,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as Response_ from '../../../tsp/stations-retrieve/response';
 
 export const schemaId =
@@ -15,11 +16,17 @@ export const schemaId =
 
 // Response
 // The default export. More information at the top.
-export type Response = Response_.Response;
-// exists type ResponseC extends t.AnyC
-export const Response: ResponseC = Response_.Response;
+export type Response = t.Branded<Response_.Response, ResponseBrand>;
+export type ResponseC = t.BrandC<typeof Response_.Response, ResponseBrand>;
+export const Response: ResponseC = t.brand(
+  Response_.Response,
+  (x): x is t.Branded<Response_.Response, ResponseBrand> => true,
+  'Response',
+);
+export interface ResponseBrand {
+  readonly Response: unique symbol;
+}
 
 export default Response;
-export type ResponseC = Response_.ResponseC;
 
 // Success

--- a/maas-schemas-ts/src/maas-backend/subscriptions/contact.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/contact.ts
@@ -32,9 +32,16 @@ export const schemaId = 'http://maasglobal.com/maas-backend/subscriptions/contac
 
 // IdentityId
 // The purpose of this remains a mystery
-export type IdentityId = Units_.IdentityId;
-// exists type IdentityIdC extends t.AnyC
-export const IdentityId: IdentityIdC = Units_.IdentityId;
+export type IdentityId = t.Branded<Units_.IdentityId, IdentityIdBrand>;
+export type IdentityIdC = t.BrandC<typeof Units_.IdentityId, IdentityIdBrand>;
+export const IdentityId: IdentityIdC = t.brand(
+  Units_.IdentityId,
+  (x): x is t.Branded<Units_.IdentityId, IdentityIdBrand> => true,
+  'IdentityId',
+);
+export interface IdentityIdBrand {
+  readonly IdentityId: unique symbol;
+}
 
 // ContactBase
 // The purpose of this remains a mystery
@@ -505,7 +512,6 @@ export interface ContactBrand {
   readonly Contact: unique symbol;
 }
 
-export type IdentityIdC = Units_.IdentityIdC;
 export default Contact;
 
 // Success

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscription.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscription.ts
@@ -51,9 +51,16 @@ export interface SubscriptionItemIdBrand {
 
 // Price
 // The purpose of this remains a mystery
-export type Price = Cost_.Cost;
-// exists type PriceC extends t.AnyC
-export const Price: PriceC = Cost_.Cost;
+export type Price = t.Branded<Cost_.Cost, PriceBrand>;
+export type PriceC = t.BrandC<typeof Cost_.Cost, PriceBrand>;
+export const Price: PriceC = t.brand(
+  Cost_.Cost,
+  (x): x is t.Branded<Cost_.Cost, PriceBrand> => true,
+  'Price',
+);
+export interface PriceBrand {
+  readonly Price: unique symbol;
+}
 
 // Plan
 // Customer subscription plan
@@ -445,25 +452,117 @@ export interface SubscriptionBaseBrand {
 
 // Subscription
 // The purpose of this remains a mystery
-export type Subscription = SubscriptionBase;
-// exists type SubscriptionC extends t.AnyC
-export const Subscription: SubscriptionC = SubscriptionBase;
+export type Subscription = t.Branded<
+  SubscriptionBase & {
+    plan: Defined;
+    addons: Defined;
+    coupons: Defined;
+    changeState: Defined;
+  },
+  SubscriptionBrand
+>;
+export type SubscriptionC = t.BrandC<
+  t.IntersectionC<
+    [
+      typeof SubscriptionBase,
+      t.TypeC<{
+        plan: typeof Defined;
+        addons: typeof Defined;
+        coupons: typeof Defined;
+        changeState: typeof Defined;
+      }>,
+    ]
+  >,
+  SubscriptionBrand
+>;
+export const Subscription: SubscriptionC = t.brand(
+  t.intersection([
+    SubscriptionBase,
+    t.type({
+      plan: Defined,
+      addons: Defined,
+      coupons: Defined,
+      changeState: Defined,
+    }),
+  ]),
+  (
+    x,
+  ): x is t.Branded<
+    SubscriptionBase & {
+      plan: Defined;
+      addons: Defined;
+      coupons: Defined;
+      changeState: Defined;
+    },
+    SubscriptionBrand
+  > => true,
+  'Subscription',
+);
+export interface SubscriptionBrand {
+  readonly Subscription: unique symbol;
+}
 
 // SubscriptionCreatePayload
 // The purpose of this remains a mystery
-export type SubscriptionCreatePayload = SubscriptionBase;
-// exists type SubscriptionCreatePayloadC extends t.AnyC
-export const SubscriptionCreatePayload: SubscriptionCreatePayloadC = SubscriptionBase;
+export type SubscriptionCreatePayload = t.Branded<
+  SubscriptionBase & {
+    plan: Defined;
+    addons: Defined;
+  },
+  SubscriptionCreatePayloadBrand
+>;
+export type SubscriptionCreatePayloadC = t.BrandC<
+  t.IntersectionC<
+    [
+      typeof SubscriptionBase,
+      t.TypeC<{
+        plan: typeof Defined;
+        addons: typeof Defined;
+      }>,
+    ]
+  >,
+  SubscriptionCreatePayloadBrand
+>;
+export const SubscriptionCreatePayload: SubscriptionCreatePayloadC = t.brand(
+  t.intersection([
+    SubscriptionBase,
+    t.type({
+      plan: Defined,
+      addons: Defined,
+    }),
+  ]),
+  (
+    x,
+  ): x is t.Branded<
+    SubscriptionBase & {
+      plan: Defined;
+      addons: Defined;
+    },
+    SubscriptionCreatePayloadBrand
+  > => true,
+  'SubscriptionCreatePayload',
+);
+export interface SubscriptionCreatePayloadBrand {
+  readonly SubscriptionCreatePayload: unique symbol;
+}
 
 // SubscriptionUpdatePayload
 // The purpose of this remains a mystery
-export type SubscriptionUpdatePayload = SubscriptionBase;
-// exists type SubscriptionUpdatePayloadC extends t.AnyC
-export const SubscriptionUpdatePayload: SubscriptionUpdatePayloadC = SubscriptionBase;
-
-export type SubscriptionC = SubscriptionBaseC;
-export type SubscriptionCreatePayloadC = SubscriptionBaseC;
-export type SubscriptionUpdatePayloadC = SubscriptionBaseC;
-export type PriceC = Cost_.CostC;
+export type SubscriptionUpdatePayload = t.Branded<
+  SubscriptionBase & {},
+  SubscriptionUpdatePayloadBrand
+>;
+export type SubscriptionUpdatePayloadC = t.BrandC<
+  t.IntersectionC<[typeof SubscriptionBase, t.TypeC<{}>]>,
+  SubscriptionUpdatePayloadBrand
+>;
+export const SubscriptionUpdatePayload: SubscriptionUpdatePayloadC = t.brand(
+  t.intersection([SubscriptionBase, t.type({})]),
+  (x): x is t.Branded<SubscriptionBase & {}, SubscriptionUpdatePayloadBrand> => true,
+  'SubscriptionUpdatePayload',
+);
+export interface SubscriptionUpdatePayloadBrand {
+  readonly SubscriptionUpdatePayload: unique symbol;
+}
 
 // Success

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-update/response.ts
@@ -8,6 +8,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as RemoteResponse_ from '../../../tsp/webhooks-bookings-update/remote-response';
 
 export const schemaId =
@@ -15,11 +16,17 @@ export const schemaId =
 
 // Response
 // The default export. More information at the top.
-export type Response = RemoteResponse_.RemoteResponse;
-// exists type ResponseC extends t.AnyC
-export const Response: ResponseC = RemoteResponse_.RemoteResponse;
+export type Response = t.Branded<RemoteResponse_.RemoteResponse, ResponseBrand>;
+export type ResponseC = t.BrandC<typeof RemoteResponse_.RemoteResponse, ResponseBrand>;
+export const Response: ResponseC = t.brand(
+  RemoteResponse_.RemoteResponse,
+  (x): x is t.Branded<RemoteResponse_.RemoteResponse, ResponseBrand> => true,
+  'Response',
+);
+export interface ResponseBrand {
+  readonly Response: unique symbol;
+}
 
 export default Response;
-export type ResponseC = RemoteResponse_.RemoteResponseC;
 
 // Success

--- a/maas-schemas-ts/src/tsp/journey-planner/response.ts
+++ b/maas-schemas-ts/src/tsp/journey-planner/response.ts
@@ -8,17 +8,24 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 */
 
+import * as t from 'io-ts';
 import * as Response_ from '../../maas-backend/provider/routes/response';
 
 export const schemaId = 'http://maasglobal.com/tsp/journey-planner/response.json';
 
 // Response
 // The default export. More information at the top.
-export type Response = Response_.Response;
-// exists type ResponseC extends t.AnyC
-export const Response: ResponseC = Response_.Response;
+export type Response = t.Branded<Response_.Response, ResponseBrand>;
+export type ResponseC = t.BrandC<typeof Response_.Response, ResponseBrand>;
+export const Response: ResponseC = t.brand(
+  Response_.Response,
+  (x): x is t.Branded<Response_.Response, ResponseBrand> => true,
+  'Response',
+);
+export interface ResponseBrand {
+  readonly Response: unique symbol;
+}
 
 export default Response;
-export type ResponseC = Response_.ResponseC;
 
 // Success

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1,7 +1,3 @@
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/booking-option.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/booking-option.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/booking-option.json
 WARNING: minLength field not supported outside top-level definitions
@@ -16,24 +12,6 @@ INFO: missing description
   in ../maas-schemas/schemas/core/booking-option.json
 INFO: missing description
   in ../maas-schemas/schemas/core/booking-option.json
-INFO: missing description
-  in ../maas-schemas/schemas/core/booking-option.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
   in ../maas-schemas/schemas/core/booking.json
 INFO: missing description
@@ -70,31 +48,7 @@ WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/card.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/card.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/address.json
-WARNING: Naming clash, ignoring default export
-  in ../maas-schemas/schemas/core/components/address.json
-INFO: missing description
-  in ../maas-schemas/schemas/core/components/address.json
-INFO: missing description
-  in ../maas-schemas/schemas/core/components/address.json
-INFO: missing description
-  in ../maas-schemas/schemas/core/components/address.json
-INFO: missing description
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/core/components/address.json
 INFO: missing description
   in ../maas-schemas/schemas/core/components/api-common.json
@@ -478,26 +432,6 @@ INFO: missing description
   in ../maas-schemas/schemas/core/components/state-log.json
 INFO: missing description
   in ../maas-schemas/schemas/core/components/state-log.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/components/station.json
 INFO: primitive type "string" used outside top-level definitions
@@ -628,10 +562,6 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/error.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/error.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/itinerary.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/itinerary.json
 INFO: primitive type "number" used outside top-level definitions
   in ../maas-schemas/schemas/core/itinerary.json
 WARNING: minimum field not supported outside top-level definitions
@@ -644,46 +574,6 @@ INFO: missing description
   in ../maas-schemas/schemas/core/itinerary.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/kyc-service.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
   in ../maas-schemas/schemas/core/leg.json
 INFO: missing description
@@ -730,10 +620,6 @@ INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_BICYCLE.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/modes/MODE_CAR.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/modes/MODE_CAR.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_RAIL.json
 INFO: primitive type "string" used outside top-level definitions
@@ -748,10 +634,6 @@ INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_SHARED_BICYCLE.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_SHARED_BICYCLE.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/core/modes/MODE_SHARED_CAR.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/core/modes/MODE_SHARED_CAR.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_SHARED_E_BICYCLE.json
 INFO: primitive type "number" used outside top-level definitions
@@ -1112,7 +994,7 @@ WARNING: minItems field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/response.json
 WARNING: default field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/bookings/bookings-retrieve/request.json
-WARNING: Naming clash, ignoring default export
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/maas-backend/coupons/code.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/customers/customer.json
@@ -1156,7 +1038,7 @@ INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
-WARNING: Naming clash, ignoring default export
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/customers/payment-sources/paymentSource.json
@@ -1180,10 +1062,6 @@ INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/customers/personal-data-delete/request.json
 WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/customers/personal-data-delete/request.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/response.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/customers/personalData.json
 INFO: primitive type "string" used outside top-level definitions
@@ -1426,7 +1304,7 @@ WARNING: default field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
 WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/invoices/invoice.json
-WARNING: Naming clash, ignoring default export
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/maas-backend/invoices/invoice.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/invoices/invoice.json
@@ -1450,7 +1328,7 @@ WARNING: minimum field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 WARNING: multipleOf field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
-WARNING: Naming clash, ignoring default export
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/maas-backend/invoices/invoiceLineItem.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/invoices/invoiceUnits.json
@@ -1604,22 +1482,10 @@ INFO: primitive type "integer" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
 WARNING: minimum field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/stations/stations-list/request.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/stations/stations-list/response.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/stations/stations-list/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/request.json
 WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/request.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/response.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/stations/stations-retrieve/response.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/subscriptions/contact.json
 INFO: primitive type "string" used outside top-level definitions
@@ -1694,18 +1560,6 @@ INFO: missing description
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription-intent.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription-intent.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: minLength field not supported outside top-level definitions
@@ -1750,13 +1604,9 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 WARNING: default field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: Naming clash, ignoring default export
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
@@ -1768,7 +1618,7 @@ INFO: missing description
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscription.json
-WARNING: Naming clash, ignoring default export
+WARNING: naming clash, ignoring default export
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptionAddress.json
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/subscriptions/subscriptionAddress.json
@@ -1804,10 +1654,6 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/request.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/request.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/response.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/webhooks/webhooks-payments/gateway/avainpay.json
 WARNING: minLength field not supported outside top-level definitions
@@ -2032,10 +1878,6 @@ WARNING: patternProperty support has limitations
   in ../maas-schemas/schemas/tsp/journey-planner/request.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/tsp/journey-planner/request.json
-WARNING: skipping examples handling for $ref object
-  in ../maas-schemas/schemas/tsp/journey-planner/response.json
-WARNING: skipping default value handling for $ref object
-  in ../maas-schemas/schemas/tsp/journey-planner/response.json
 INFO: primitive type "number" used outside top-level definitions
   in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
 INFO: primitive type "string" used outside top-level definitions

--- a/maas-schemas-ts/yarn.lock
+++ b/maas-schemas-ts/yarn.lock
@@ -1965,10 +1965,10 @@ io-ts-codegen@^0.4.5:
   resolved "https://registry.yarnpkg.com/io-ts-codegen/-/io-ts-codegen-0.4.5.tgz#67a5e0e0d72751451ab6c2c70e2f304408f398de"
   integrity sha512-7Q6CbNyYOIelPt2OddqMIk5jGfUM5Z+Y2OSsPAJnaSRroCwedAp0cFNh5h02nsE/33P9xjyGhKTajMkPApEdcA==
 
-io-ts-from-json-schema@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/io-ts-from-json-schema/-/io-ts-from-json-schema-0.0.10.tgz#d650b49b43029d6257f34696ea98b69196bda561"
-  integrity sha512-peVbEXKehdzyYYCInxOVkTjly2HupKCuNwPRNipacC/n9pW6fIQbKwL+VnFt//knWY/RHIUgYIqV8fD+Vz9plA==
+io-ts-from-json-schema@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/io-ts-from-json-schema/-/io-ts-from-json-schema-0.0.12.tgz#a7facd8f76812247d5780f50b134f5cbf844feff"
+  integrity sha512-jJSwsuM2aDN6FPL6ZQp6OxQApvH7+aHrpgj8tP7PgIlHZZqH/IGBhuGRfAit1nd+iDeMbmqVbAAoXfBU9vcfPA==
   dependencies:
     glob "^7.1.6"
     io-ts-codegen "^0.4.5"

--- a/maas-schemas/schemas/core/booking-option.json
+++ b/maas-schemas/schemas/core/booking-option.json
@@ -60,7 +60,7 @@
     },
     "customer": {
       "description": "MaaS booking customer",
-      "$ref": "http://maasglobal.com/core/customer.json"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/customer.json" }]
     },
     "leg": {
       "type": "object",
@@ -77,7 +77,7 @@
         },
         "from": {
           "description": "Starting location's lat and lon pair of this request",
-          "$ref": "http://maasglobal.com/core/components/place.json"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/place.json" }]
         },
         "to": {
           "$ref": "http://maasglobal.com/core/components/place.json"

--- a/maas-schemas/schemas/core/booking.json
+++ b/maas-schemas/schemas/core/booking.json
@@ -117,11 +117,11 @@
           "properties": {
             "startTime": {
               "description": "The starting time from which the ticket is valid",
-              "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
+              "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }]
             },
             "endTime": {
               "description": "The finishing time the ticket is valid for",
-              "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
+              "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }]
             }
           }
         },

--- a/maas-schemas/schemas/core/components/address.json
+++ b/maas-schemas/schemas/core/components/address.json
@@ -35,19 +35,19 @@
     },
     "firstName": {
       "description": "First name of the customer (e.g. John)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "lastName": {
       "description": "Last name of the customer (e.g. Doe)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "phone": {
       "description": "ITU-T E.164 phone number",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone" }]
     },
     "email": {
       "description": "Rough validation of a valid e-mail address",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email" }]
     },
     "address": {
       "description": "Street address (and optional number), http://www.bitboost.com/ref/international-address-formats.html",

--- a/maas-schemas/schemas/core/components/agencyOptions.json
+++ b/maas-schemas/schemas/core/components/agencyOptions.json
@@ -23,22 +23,22 @@
     },
     "fromName": {
       "description": "The human understandable name for 'from'",
-      "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName" }]
     },
     "fromAddress": {
       "description": "Componentized from address",
-      "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
     },
     "fromRadius": {
       "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
     },
     "toName": {
       "description": "The human understandable name for 'to'",
-      "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName" }]
     },
     "toAddress": {
       "description": "Componentized to address",
-      "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
     },
     "toRadius": {
       "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"

--- a/maas-schemas/schemas/core/components/authorization.json
+++ b/maas-schemas/schemas/core/components/authorization.json
@@ -12,7 +12,7 @@
       "enum": ["VALID", "INVALID"]
     },
     "validTo": {
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }],
       "description": "Epoch when the authorization will be invalid"
     },
     "created": {

--- a/maas-schemas/schemas/core/components/car-rental.json
+++ b/maas-schemas/schemas/core/components/car-rental.json
@@ -95,22 +95,22 @@
         },
         "location": {
           "description": "Current geo location",
-          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/location"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/location" }]
         }
       },
       "required": ["classification"]
     },
     "pickupInfo": {
       "description": "Pickup instructions in HTML format",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/htmlBlock"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/htmlBlock" }]
     },
     "returnInfo": {
       "description": "Return Instructions in HTML format",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/htmlBlock"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/htmlBlock" }]
     },
     "startEndGeoRegionUrl": {
       "description": "Region in which car can be rented and returned. Url to GeoJSON file",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
     },
     "instructions": {
       "description": "Additional instruction sections displayed for booking",

--- a/maas-schemas/schemas/core/components/configurator.json
+++ b/maas-schemas/schemas/core/components/configurator.json
@@ -9,19 +9,19 @@
     "seatFeatures": { "$ref": "#/definitions/config" },
     "outboundSingle": {
       "description": "Single ticket for outwardJourney",
-      "$ref": "#/definitions/config"
+      "allOf": [{ "$ref": "#/definitions/config" }]
     },
     "inboundSingle": {
       "description": "Single ticket for return journey, go as a pair with outboundSingle",
-      "$ref": "#/definitions/config"
+      "allOf": [{ "$ref": "#/definitions/config" }]
     },
     "openReturn": {
       "description": "Open return ticket can be used for both outward and return journeys",
-      "$ref": "#/definitions/config"
+      "allOf": [{ "$ref": "#/definitions/config" }]
     },
     "freeReturn": {
       "description": "Going as a pair with open return, providing options for clients to choose return journey for it's open return tickets",
-      "$ref": "#/definitions/config"
+      "allOf": [{ "$ref": "#/definitions/config" }]
     },
     "ticketCollectionPoint": { "$ref": "#/definitions/text" }
   },

--- a/maas-schemas/schemas/core/components/subscriptionChangeState.json
+++ b/maas-schemas/schemas/core/components/subscriptionChangeState.json
@@ -5,7 +5,7 @@
   "properties": {
     "id": {
       "description": "Subscription change state id",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid" }]
     },
     "state": {
       "description": "State enum",

--- a/maas-schemas/schemas/core/components/terms.json
+++ b/maas-schemas/schemas/core/components/terms.json
@@ -21,19 +21,19 @@
       "type": "object",
       "properties": {
         "startTime": {
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }],
           "description": "Epoch when the outbound ticket will be valid"
         },
         "endTime": {
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }],
           "description": "Epoch when the outbound ticket will be invalid"
         },
         "startTimeReturn": {
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }],
           "description": "Epoch when the return ticket will be valid"
         },
         "endTimeReturn": {
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }],
           "description": "Epoch when the return ticket will be invalid"
         }
       },
@@ -71,11 +71,11 @@
       "properties": {
         "midnight": {
           "description": "Fee for booking during night time",
-          "$ref": "#/definitions/surcharge"
+          "allOf": [{ "$ref": "#/definitions/surcharge" }]
         },
         "pickup": {
           "description": "Fee for pickup, usually for TAXI bookings",
-          "$ref": "#/definitions/surcharge"
+          "allOf": [{ "$ref": "#/definitions/surcharge" }]
         }
       }
     },
@@ -84,7 +84,7 @@
       "properties": {
         "cancellationFormActionUrl": {
           "description": "User will fill in this form to cancel their ticket should programmed cancellation does not function. Edge case support",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
         },
         "outward": {
           "$ref": "#/definitions/cancellation"
@@ -107,7 +107,7 @@
     },
     "prePurchaseGuidanceUrl": {
       "description": "If flow requires additional instructions or resources presented to the customer before purchase, they can be embedded in the HTML page and booking option can link to that",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
     },
     "fareRates": {
       "type": "array",

--- a/maas-schemas/schemas/core/customer.json
+++ b/maas-schemas/schemas/core/customer.json
@@ -11,30 +11,30 @@
     },
     "firstName": {
       "description": "First name of the customer (e.g. John)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "lastName": {
       "description": "Last name of the customer (e.g. Doe)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "firstNameLocalized": {
       "description": "Localized first name of the customer (e.g. John)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "lastNameLocalized": {
       "description": "Localized last name of the customer (e.g. Doe)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "sex": {
       "type": "string"
     },
     "phone": {
       "description": "ITU-T E.164 phone number",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone" }]
     },
     "email": {
       "description": "Rough validation of a valid e-mail address",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email" }]
     },
     "address": {
       "$ref": "http://maasglobal.com/core/components/address.json#/definitions/address"
@@ -56,15 +56,15 @@
     },
     "appInstanceId": {
       "description": "An id specific to a user device",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/appInstanceId"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/appInstanceId" }]
     },
     "opaqueId": {
       "description": "Typically the hash of the identityId",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/opaqueId"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/opaqueId" }]
     },
     "clientId": {
       "description": "An id indicating the source of the client",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/clientId"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/clientId" }]
     },
     "dob": {
       "description": "The customer's date of birth or boolean indicating if the value is already in DB",
@@ -145,7 +145,7 @@
     },
     "authToken": {
       "description": "Authentication Token",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/encodedQueryParam"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/encodedQueryParam" }]
     },
     "cugHome": {
       "type": "string"

--- a/maas-schemas/schemas/core/modes/MODE_CAR.json
+++ b/maas-schemas/schemas/core/modes/MODE_CAR.json
@@ -1,5 +1,5 @@
 {
   "$id": "http://maasglobal.com/core/modes/MODE_CAR.json",
   "description": "Schemas for MODE_CAR meta field",
-  "$ref": "http://maasglobal.com/core/components/car-rental.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/core/components/car-rental.json" }]
 }

--- a/maas-schemas/schemas/core/modes/MODE_SHARED_CAR.json
+++ b/maas-schemas/schemas/core/modes/MODE_SHARED_CAR.json
@@ -1,5 +1,5 @@
 {
   "$id": "http://maasglobal.com/core/modes/MODE_SHARED_CAR.json",
   "description": "Schemas for MODE_SHARED_CAR meta field",
-  "$ref": "http://maasglobal.com/core/components/car-rental.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/core/components/car-rental.json" }]
 }

--- a/maas-schemas/schemas/core/product.json
+++ b/maas-schemas/schemas/core/product.json
@@ -57,7 +57,7 @@
         },
         "minimumExtra": {
           "description": "Minimum amount, expressed as a fare, that will be added as a safety margin to the estimated fare",
-          "$ref": "http://maasglobal.com/core/components/fare.json"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/fare.json" }]
         }
       },
       "additionalProperties": false

--- a/maas-schemas/schemas/core/profile.json
+++ b/maas-schemas/schemas/core/profile.json
@@ -75,7 +75,7 @@
         },
         "expiry": {
           "description": "When this payment method expires",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }]
         }
       },
       "required": ["type", "valid"]

--- a/maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
+++ b/maas-schemas/schemas/maas-backend/autocomplete/autocomplete-query/request.json
@@ -25,8 +25,14 @@
           "default": 5
         },
         "radius": {
-          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance",
-          "default": 5000
+          "allOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+            },
+            {
+              "default": 5000
+            }
+          ]
         }
       },
       "required": ["name"],

--- a/maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/request.json
+++ b/maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/request.json
@@ -40,29 +40,29 @@
         },
         "fromName": {
           "description": "The human understandable name for 'from'",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName" }]
         },
         "fromAddress": {
           "description": "Componentized from address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         "fromRadius": {
-          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance" }]
         },
         "toName": {
           "description": "The human understandable name for 'to'",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/placeName" }]
         },
         "toAddress": {
           "description": "Componentized to address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         "toRadius": {
-          "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance" }]
         },
         "bookingIdToExtend": {
           "description": "bookingId to fetch possible extension options for",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid" }]
         }
       },
       "patternProperties": {

--- a/maas-schemas/schemas/maas-backend/bookings/bookings-retrieve/request.json
+++ b/maas-schemas/schemas/maas-backend/bookings/bookings-retrieve/request.json
@@ -8,7 +8,7 @@
     },
     "bookingId": {
       "description": "bookingId of the requested booking",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid" }]
     },
     "refresh": {
       "description": "Whether or not to refresh the booking from the TSP end",

--- a/maas-schemas/schemas/maas-backend/bookings/bookings-update/request.json
+++ b/maas-schemas/schemas/maas-backend/bookings/bookings-update/request.json
@@ -8,7 +8,7 @@
     },
     "bookingId": {
       "description": "bookingId of the requested booking",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid" }]
     },
     "payload": {
       "$ref": "http://maasglobal.com/core/booking.json"

--- a/maas-schemas/schemas/maas-backend/customers/favorite-locations/add/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/favorite-locations/add/request.json
@@ -12,8 +12,14 @@
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
     "payload": {
-      "$ref": "http://maasglobal.com/core/partialFavoriteLocation.json",
-      "required": ["type", "name", "location"]
+      "allOf": [
+        {
+          "$ref": "http://maasglobal.com/core/partialFavoriteLocation.json"
+        },
+        {
+          "required": ["type", "name", "location"]
+        }
+      ]
     },
     "headers": {
       "$ref": "http://maasglobal.com/core/components/api-common.json#/definitions/headers"

--- a/maas-schemas/schemas/maas-backend/customers/favorite-locations/add/response.json
+++ b/maas-schemas/schemas/maas-backend/customers/favorite-locations/add/response.json
@@ -4,8 +4,14 @@
   "type": "object",
   "properties": {
     "favoriteLocation": {
-      "$ref": "http://maasglobal.com/core/partialFavoriteLocation.json",
-      "required": ["type", "name", "location", "id", "identityId"]
+      "allOf": [
+        {
+          "$ref": "http://maasglobal.com/core/partialFavoriteLocation.json"
+        },
+        {
+          "required": ["type", "name", "location", "id", "identityId"]
+        }
+      ]
     }
   },
   "additionalProperties": false

--- a/maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/response.json
+++ b/maas-schemas/schemas/maas-backend/customers/personal-documents/initiate/response.json
@@ -1,5 +1,5 @@
 {
   "$id": "http://maasglobal.com/maas-backend/customers/personal-documents/initiate/response.json",
   "description": "Initiate customer KYC process",
-  "$ref": "http://maasglobal.com/core/kyc-service.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/core/kyc-service.json" }]
 }

--- a/maas-schemas/schemas/maas-backend/customers/personalData.json
+++ b/maas-schemas/schemas/maas-backend/customers/personalData.json
@@ -8,30 +8,30 @@
     },
     "firstName": {
       "description": "First name of the customer (e.g. John)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "lastName": {
       "description": "Last name of the customer (e.g. Doe)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "firstNameLocalized": {
       "description": "Localized first name of the customer (e.g. John)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "lastNameLocalized": {
       "description": "Localized last name of the customer (e.g. Doe)",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/personalName" }]
     },
     "sex": {
       "type": "string"
     },
     "phone": {
       "description": "ITU-T E.164 phone number",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/phone" }]
     },
     "email": {
       "description": "Rough validation of a valid e-mail address",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/email" }]
     },
     "address": {
       "$ref": "http://maasglobal.com/core/components/address.json#/definitions/address"

--- a/maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
+++ b/maas-schemas/schemas/maas-backend/geocoding/geocoding-query/request.json
@@ -15,8 +15,14 @@
         "count": { "type": "integer", "minimum": 1, "maximum": 100, "default": 5 },
         "distance": { "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance" },
         "locale": {
-          "$ref": "http://maasglobal.com/core/components/i18n.json#/definitions/locale",
-          "default": "fi-FI"
+          "allOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/i18n.json#/definitions/locale"
+            },
+            {
+              "default": "fi-FI"
+            }
+          ]
         }
       },
       "required": ["name", "lat", "lon"],

--- a/maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
+++ b/maas-schemas/schemas/maas-backend/geocoding/geocoding-reverse/request.json
@@ -14,8 +14,14 @@
         "count": { "type": "integer", "minimum": 1, "maximum": 100, "default": 5 },
         "radius": { "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance" },
         "locale": {
-          "$ref": "http://maasglobal.com/core/components/i18n.json#/definitions/locale",
-          "default": "fi-FI"
+          "allOf": [
+            {
+              "$ref": "http://maasglobal.com/core/components/i18n.json#/definitions/locale"
+            },
+            {
+              "default": "fi-FI"
+            }
+          ]
         }
       },
       "required": ["lat", "lon"],

--- a/maas-schemas/schemas/maas-backend/invoices/invoice.json
+++ b/maas-schemas/schemas/maas-backend/invoices/invoice.json
@@ -13,7 +13,7 @@
         },
         "bookingId": {
           "description": "bookingId of the requested booking",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid" }]
         },
         "lineItems": {
           "type": "array",

--- a/maas-schemas/schemas/maas-backend/itineraries/itinerary-create/response.json
+++ b/maas-schemas/schemas/maas-backend/itineraries/itinerary-create/response.json
@@ -10,7 +10,7 @@
         },
         "paymentParameters": {
           "description": "Payment parameters for asynchronous payment methods",
-          "$ref": "#/definitions/paymentParameters"
+          "allOf": [{ "$ref": "#/definitions/paymentParameters" }]
         }
       },
       "required": ["itinerary"]
@@ -26,7 +26,7 @@
         },
         "paymentParameters": {
           "description": "Payment parameters for asynchronous payment methods",
-          "$ref": "#/definitions/paymentParameters"
+          "allOf": [{ "$ref": "#/definitions/paymentParameters" }]
         }
       },
       "required": ["outward"]

--- a/maas-schemas/schemas/maas-backend/products/provider.json
+++ b/maas-schemas/schemas/maas-backend/products/provider.json
@@ -34,15 +34,15 @@
         },
         "icon": {
           "description": "Icon shown in whim wheel, url to 240x240 png",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
         },
         "logoSolidColor": {
           "description": "Icon that can be shown against dark or light background, url to ???x105 png",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
         },
         "logoFullColor": {
           "description": "Icon that retains the providers brand identity, url to ???x105 png",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
         }
       }
     },
@@ -76,9 +76,9 @@
               "multipleOf": 0.01
             },
             "fixedFareCurrency": {
+              "description": "The currency of the maximum fixed fare",
               "oneOf": [
                 {
-                  "description": "The currency of the maximum fixed fare",
                   "$ref": "http://maasglobal.com/core/components/units.json#/definitions/currency"
                 },
                 {

--- a/maas-schemas/schemas/maas-backend/routes/routes-query/request.json
+++ b/maas-schemas/schemas/maas-backend/routes/routes-query/request.json
@@ -27,7 +27,7 @@
         },
         "fromAddress": {
           "description": "Componentized from address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         "fromStationId": {
           "$ref": "http://maasglobal.com/core/components/station.json#/definitions/id"
@@ -40,7 +40,7 @@
         },
         "toAddress": {
           "description": "Componentized to address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         "toStationId": {
           "$ref": "http://maasglobal.com/core/components/station.json#/definitions/id"
@@ -70,7 +70,7 @@
         },
         "bookingIdToExtend": {
           "description": "bookingId to fetch possible extension options for",
-          "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/uuid" }]
         }
       },
       "patternProperties": {

--- a/maas-schemas/schemas/maas-backend/stations/stations-list/response.json
+++ b/maas-schemas/schemas/maas-backend/stations/stations-list/response.json
@@ -1,4 +1,4 @@
 {
   "$id": "http://maasglobal.com/maas-backend/stations/stations-list/response.json",
-  "$ref": "http://maasglobal.com/tsp/stations-list/response.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/tsp/stations-list/response.json" }]
 }

--- a/maas-schemas/schemas/maas-backend/stations/stations-retrieve/response.json
+++ b/maas-schemas/schemas/maas-backend/stations/stations-retrieve/response.json
@@ -1,4 +1,4 @@
 {
   "$id": "http://maasglobal.com/maas-backend/stations/stations-retrieve/response.json",
-  "$ref": "http://maasglobal.com/tsp/stations-retrieve/response.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/tsp/stations-retrieve/response.json" }]
 }

--- a/maas-schemas/schemas/maas-backend/subscriptions/pricing.json
+++ b/maas-schemas/schemas/maas-backend/subscriptions/pricing.json
@@ -17,7 +17,7 @@
     },
     "total": {
       "description": "Sum of the quantity * unitPrice - sum of discounts",
-      "$ref": "http://maasglobal.com/core/components/cost.json"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/cost.json" }]
     },
     "terms": {
       "$ref": "#/definitions/terms"
@@ -49,7 +49,7 @@
         },
         "unitPrice": {
           "description": "Price of one unit after all taxes & discounts",
-          "$ref": "http://maasglobal.com/core/components/cost.json"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/cost.json" }]
         }
       },
       "required": ["id", "type", "description", "quantity", "unitPrice"],
@@ -65,7 +65,7 @@
         },
         "discount": {
           "description": "Price of one unit after all taxes & discounts",
-          "$ref": "http://maasglobal.com/core/components/cost.json"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/cost.json" }]
         }
       },
       "required": ["description", "discount"],

--- a/maas-schemas/schemas/maas-backend/subscriptions/subscription.json
+++ b/maas-schemas/schemas/maas-backend/subscriptions/subscription.json
@@ -3,19 +3,37 @@
   "description": "MaaS subscription schema",
   "definitions": {
     "subscription": {
-      "$ref": "#/definitions/subscriptionBase",
-      "required": ["plan", "addons", "coupons", "changeState"],
-      "additionalProperties": true
+      "allOf": [
+        {
+          "$ref": "#/definitions/subscriptionBase"
+        },
+        {
+          "required": ["plan", "addons", "coupons", "changeState"],
+          "additionalProperties": true
+        }
+      ]
     },
     "subscriptionCreatePayload": {
-      "$ref": "#/definitions/subscriptionBase",
-      "required": ["plan", "addons"],
-      "additionalProperties": true
+      "allOf": [
+        {
+          "$ref": "#/definitions/subscriptionBase"
+        },
+        {
+          "required": ["plan", "addons"],
+          "additionalProperties": true
+        }
+      ]
     },
     "subscriptionUpdatePayload": {
-      "$ref": "#/definitions/subscriptionBase",
-      "required": [],
-      "additionalProperties": true
+      "allOf": [
+        {
+          "$ref": "#/definitions/subscriptionBase"
+        },
+        {
+          "required": [],
+          "additionalProperties": true
+        }
+      ]
     },
     "subscriptionBase": {
       "type": "object",

--- a/maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/response.json
+++ b/maas-schemas/schemas/maas-backend/webhooks/webhooks-bookings-update/response.json
@@ -1,5 +1,5 @@
 {
   "$id": "http://maasglobal.com/maas-backend/webhooks/webhooks-bookings-update/response.json",
   "description": "MaaS webhook to update bookings for tsp adapter callback response schema.",
-  "$ref": "http://maasglobal.com/tsp/webhooks-bookings-update/remote-response.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/tsp/webhooks-bookings-update/remote-response.json" }]
 }

--- a/maas-schemas/schemas/tsp/booking-options-list/request.json
+++ b/maas-schemas/schemas/tsp/booking-options-list/request.json
@@ -30,7 +30,7 @@
       "anyOf": [
         {
           "description": "Componentized from address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         {
           "type": "string",
@@ -40,7 +40,7 @@
     },
     "fromRadius": {
       "description": "'from' location radius in meters",
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance" }]
     },
     "to": {
       "anyOf": [
@@ -77,7 +77,7 @@
     },
     "toRadius": {
       "description": "'to' location radius in meters",
-      "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance" }]
     },
     "distance": {
       "$ref": "http://maasglobal.com/core/components/units-geo.json#/definitions/distance"
@@ -94,11 +94,11 @@
     },
     "tspIdToExtend": {
       "description": "Request for possible booking extension options for tspId",
-      "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId" }]
     },
     "purchasingAppInstanceId": {
       "description": "appInstanceId to use for options and purchase",
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/appInstanceId"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/common.json#/definitions/appInstanceId" }]
     }
   },
   "patternProperties": {

--- a/maas-schemas/schemas/tsp/booking-ticket/response.json
+++ b/maas-schemas/schemas/tsp/booking-ticket/response.json
@@ -15,7 +15,7 @@
       "enum": ["application/pdf", "image/svg+xml", "image/png", "text/html"]
     },
     "refreshAt": {
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time",
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }],
       "description": "Epoch when the ticket needs to be refreshed"
     }
   },

--- a/maas-schemas/schemas/tsp/customer-auth/request.json
+++ b/maas-schemas/schemas/tsp/customer-auth/request.json
@@ -8,7 +8,7 @@
     },
     "returnUrl": {
       "description": "URL where client is returned after authorization flow is completed.",
-      "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url"
+      "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }]
     },
     "locale": {
       "$ref": "http://maasglobal.com/core/components/i18n.json#/definitions/locale"

--- a/maas-schemas/schemas/tsp/journey-planner/request.json
+++ b/maas-schemas/schemas/tsp/journey-planner/request.json
@@ -19,7 +19,7 @@
         },
         "fromAddress": {
           "description": "Componentized from address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         "fromStationId": {
           "$ref": "http://maasglobal.com/core/components/station.json#/definitions/id"
@@ -32,7 +32,7 @@
         },
         "toAddress": {
           "description": "Componentized to address",
-          "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress"
+          "allOf": [{ "$ref": "http://maasglobal.com/core/components/address.json#/definitions/componentAddress" }]
         },
         "toStationId": {
           "$ref": "http://maasglobal.com/core/components/station.json#/definitions/id"

--- a/maas-schemas/schemas/tsp/journey-planner/response.json
+++ b/maas-schemas/schemas/tsp/journey-planner/response.json
@@ -1,5 +1,5 @@
 {
   "$id": "http://maasglobal.com/tsp/journey-planner/response.json",
   "description": "Response schema for getting journey options from a TSP adapter.",
-  "$ref": "http://maasglobal.com/maas-backend/provider/routes/response.json"
+  "allOf": [{ "$ref": "http://maasglobal.com/maas-backend/provider/routes/response.json" }]
 }


### PR DESCRIPTION
Objects with key `$ref` can not contain JSON Schema definitions. This is because JSON Schema processor will throw the object a way when dealing with the reference. I added a feature to the schema converter that will complain about such cases. This PR should also fix all broken ref objects currently existing in the code base.