### PR TITLE
Add explicit type to arrays and objects

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "fp-ts": "^2.0.5",
     "io-ts": "^2.1.2",
-    "io-ts-from-json-schema": "^0.0.12",
+    "io-ts-from-json-schema": "^0.0.13",
     "io-ts-types": "^0.5.2",
     "io-ts-validator": "^0.0.2",
     "jest": "^24.9.0",

--- a/maas-schemas-ts/src/core/booking.ts
+++ b/maas-schemas-ts/src/core/booking.ts
@@ -233,8 +233,8 @@ export type Token = t.Branded<
       startTime?: Units_.Time;
       endTime?: Units_.Time;
     };
-    data?: {};
-    meta?: {};
+    data?: Record<string, unknown>;
+    meta?: Record<string, unknown>;
   },
   TokenBrand
 >;
@@ -244,8 +244,8 @@ export type TokenC = t.BrandC<
       startTime: typeof Units_.Time;
       endTime: typeof Units_.Time;
     }>;
-    data: t.TypeC<{}>;
-    meta: t.TypeC<{}>;
+    data: t.UnknownRecordC;
+    meta: t.UnknownRecordC;
   }>,
   TokenBrand
 >;
@@ -255,8 +255,8 @@ export const Token: TokenC = t.brand(
       startTime: Units_.Time,
       endTime: Units_.Time,
     }),
-    data: t.type({}),
-    meta: t.type({}),
+    data: t.UnknownRecord,
+    meta: t.UnknownRecord,
   }),
   (
     x,
@@ -266,8 +266,8 @@ export const Token: TokenC = t.brand(
         startTime?: Units_.Time;
         endTime?: Units_.Time;
       };
-      data?: {};
-      meta?: {};
+      data?: Record<string, unknown>;
+      meta?: Record<string, unknown>;
     },
     TokenBrand
   > => true,

--- a/maas-schemas-ts/src/core/components/api-common.ts
+++ b/maas-schemas-ts/src/core/components/api-common.ts
@@ -51,28 +51,36 @@ export type Headers = t.Branded<
   {
     Accept?: AcceptHeader;
     'X-Whim-User-Agent'?: UserAgentHeader;
-  },
+  } & Record<string, unknown>,
   HeadersBrand
 >;
 export type HeadersC = t.BrandC<
-  t.PartialC<{
-    Accept: typeof AcceptHeader;
-    'X-Whim-User-Agent': typeof UserAgentHeader;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        Accept: typeof AcceptHeader;
+        'X-Whim-User-Agent': typeof UserAgentHeader;
+      }>,
+      t.RecordC<t.StringC, t.UnknownC>,
+    ]
+  >,
   HeadersBrand
 >;
 export const Headers: HeadersC = t.brand(
-  t.partial({
-    Accept: AcceptHeader,
-    'X-Whim-User-Agent': UserAgentHeader,
-  }),
+  t.intersection([
+    t.partial({
+      Accept: AcceptHeader,
+      'X-Whim-User-Agent': UserAgentHeader,
+    }),
+    t.record(t.string, t.unknown),
+  ]),
   (
     x,
   ): x is t.Branded<
     {
       Accept?: AcceptHeader;
       'X-Whim-User-Agent'?: UserAgentHeader;
-    },
+    } & Record<string, unknown>,
     HeadersBrand
   > => true,
   'Headers',

--- a/maas-schemas-ts/src/core/components/configurator.ts
+++ b/maas-schemas-ts/src/core/components/configurator.ts
@@ -41,7 +41,7 @@ export type Choice = t.Branded<
     cost?: Cost_.Cost;
     fares?: Array<Fare_.Fare>;
     terms?: Terms_.Terms;
-    meta?: {};
+    meta?: Record<string, unknown>;
   } & {
     id: Defined;
     name: Defined;
@@ -60,7 +60,7 @@ export type ChoiceC = t.BrandC<
         cost: typeof Cost_.Cost;
         fares: t.ArrayC<typeof Fare_.Fare>;
         terms: typeof Terms_.Terms;
-        meta: t.TypeC<{}>;
+        meta: t.UnknownRecordC;
       }>,
       t.TypeC<{
         id: typeof Defined;
@@ -81,7 +81,7 @@ export const Choice: ChoiceC = t.brand(
       cost: Cost_.Cost,
       fares: t.array(Fare_.Fare),
       terms: Terms_.Terms,
-      meta: t.type({}),
+      meta: t.UnknownRecord,
     }),
     t.type({
       id: Defined,
@@ -100,7 +100,7 @@ export const Choice: ChoiceC = t.brand(
       cost?: Cost_.Cost;
       fares?: Array<Fare_.Fare>;
       terms?: Terms_.Terms;
-      meta?: {};
+      meta?: Record<string, unknown>;
     } & {
       id: Defined;
       name: Defined;

--- a/maas-schemas-ts/src/core/components/geometry.ts
+++ b/maas-schemas-ts/src/core/components/geometry.ts
@@ -102,41 +102,143 @@ export interface PolygonBrand {
 // Geometry
 // The default export. More information at the top.
 export type Geometry = t.Branded<
-  {} & {
+  Record<string, unknown> & {
     type: Defined;
     coordinates: Defined;
-  } & (unknown | unknown | unknown | unknown | unknown | unknown),
+  } & (
+      | {
+          type?: 'Point';
+          coordinates?: Position;
+        }
+      | {
+          type?: 'MultiPoint';
+          coordinates?: PositionArray;
+        }
+      | {
+          type?: 'LineString';
+          coordinates?: LineString;
+        }
+      | {
+          type?: 'MultiLineString';
+          coordinates?: Array<LineString>;
+        }
+      | {
+          type?: 'Polygon';
+          coordinates?: Polygon;
+        }
+      | {
+          type?: 'MultiPolygon';
+          coordinates?: Array<Polygon>;
+        }
+    ),
   GeometryBrand
 >;
 export type GeometryC = t.BrandC<
   t.IntersectionC<
     [
-      t.TypeC<{}>,
+      t.UnknownRecordC,
       t.TypeC<{
         type: typeof Defined;
         coordinates: typeof Defined;
       }>,
-      t.UnionC<[t.UnknownC, t.UnknownC, t.UnknownC, t.UnknownC, t.UnknownC, t.UnknownC]>,
+      t.UnionC<
+        [
+          t.PartialC<{
+            type: t.LiteralC<'Point'>;
+            coordinates: typeof Position;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'MultiPoint'>;
+            coordinates: typeof PositionArray;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'LineString'>;
+            coordinates: typeof LineString;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'MultiLineString'>;
+            coordinates: t.ArrayC<typeof LineString>;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'Polygon'>;
+            coordinates: typeof Polygon;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'MultiPolygon'>;
+            coordinates: t.ArrayC<typeof Polygon>;
+          }>,
+        ]
+      >,
     ]
   >,
   GeometryBrand
 >;
 export const Geometry: GeometryC = t.brand(
   t.intersection([
-    t.type({}),
+    t.UnknownRecord,
     t.type({
       type: Defined,
       coordinates: Defined,
     }),
-    t.union([t.unknown, t.unknown, t.unknown, t.unknown, t.unknown, t.unknown]),
+    t.union([
+      t.partial({
+        type: t.literal('Point'),
+        coordinates: Position,
+      }),
+      t.partial({
+        type: t.literal('MultiPoint'),
+        coordinates: PositionArray,
+      }),
+      t.partial({
+        type: t.literal('LineString'),
+        coordinates: LineString,
+      }),
+      t.partial({
+        type: t.literal('MultiLineString'),
+        coordinates: t.array(LineString),
+      }),
+      t.partial({
+        type: t.literal('Polygon'),
+        coordinates: Polygon,
+      }),
+      t.partial({
+        type: t.literal('MultiPolygon'),
+        coordinates: t.array(Polygon),
+      }),
+    ]),
   ]),
   (
     x,
   ): x is t.Branded<
-    {} & {
+    Record<string, unknown> & {
       type: Defined;
       coordinates: Defined;
-    } & (unknown | unknown | unknown | unknown | unknown | unknown),
+    } & (
+        | {
+            type?: 'Point';
+            coordinates?: Position;
+          }
+        | {
+            type?: 'MultiPoint';
+            coordinates?: PositionArray;
+          }
+        | {
+            type?: 'LineString';
+            coordinates?: LineString;
+          }
+        | {
+            type?: 'MultiLineString';
+            coordinates?: Array<LineString>;
+          }
+        | {
+            type?: 'Polygon';
+            coordinates?: Polygon;
+          }
+        | {
+            type?: 'MultiPolygon';
+            coordinates?: Array<Polygon>;
+          }
+      ),
     GeometryBrand
   > => true,
   'Geometry',

--- a/maas-schemas-ts/src/core/components/personalDataValidation.ts
+++ b/maas-schemas-ts/src/core/components/personalDataValidation.ts
@@ -29,7 +29,7 @@ export type PersonalDataValidation = t.Branded<
         value?: string | number | boolean;
         name?: string;
         description?: string;
-        meta?: {};
+        meta?: Record<string, unknown>;
       }>;
       length?: number;
       regex?: string;
@@ -39,7 +39,7 @@ export type PersonalDataValidation = t.Branded<
         day?: number;
         hour?: number;
       };
-      meta?: {};
+      meta?: Record<string, unknown>;
     };
     errorCode?: string;
   },
@@ -79,7 +79,7 @@ export type PersonalDataValidationC = t.BrandC<
           value: t.UnionC<[t.StringC, t.NumberC, t.BooleanC]>;
           name: t.StringC;
           description: t.StringC;
-          meta: t.TypeC<{}>;
+          meta: t.UnknownRecordC;
         }>
       >;
       length: t.NumberC;
@@ -90,7 +90,7 @@ export type PersonalDataValidationC = t.BrandC<
         day: t.NumberC;
         hour: t.NumberC;
       }>;
-      meta: t.TypeC<{}>;
+      meta: t.UnknownRecordC;
     }>;
     errorCode: t.StringC;
   }>,
@@ -126,7 +126,7 @@ export const PersonalDataValidation: PersonalDataValidationC = t.brand(
           value: t.union([t.string, t.number, t.boolean]),
           name: t.string,
           description: t.string,
-          meta: t.type({}),
+          meta: t.UnknownRecord,
         }),
       ),
       length: t.number,
@@ -137,7 +137,7 @@ export const PersonalDataValidation: PersonalDataValidationC = t.brand(
         day: t.number,
         hour: t.number,
       }),
-      meta: t.type({}),
+      meta: t.UnknownRecord,
     }),
     errorCode: t.string,
   }),
@@ -157,7 +157,7 @@ export const PersonalDataValidation: PersonalDataValidationC = t.brand(
           value?: string | number | boolean;
           name?: string;
           description?: string;
-          meta?: {};
+          meta?: Record<string, unknown>;
         }>;
         length?: number;
         regex?: string;
@@ -167,7 +167,7 @@ export const PersonalDataValidation: PersonalDataValidationC = t.brand(
           day?: number;
           hour?: number;
         };
-        meta?: {};
+        meta?: Record<string, unknown>;
       };
       errorCode?: string;
     },

--- a/maas-schemas-ts/src/core/components/place.ts
+++ b/maas-schemas-ts/src/core/components/place.ts
@@ -33,79 +33,11 @@ export const schemaId = 'http://maasglobal.com/core/components/place.json';
 // Place
 // The default export. More information at the top.
 export type Place = t.Branded<
-  {} & {
+  Record<string, unknown> & {
     lat: Defined;
     lon: Defined;
-  } & (UnitsGeo_.RelaxedLocation & {
-      name?: Address_.PlaceName;
-      address?: Address_.ComponentAddress;
-      localeAddress?: string;
-      stopId?: string;
-      stopCode?: string;
-      stationId?: string;
-      facilities?: Array<string>;
-      openingHours?: Station_.OpeningHours;
-      zone?: Station_.Zone;
-    }),
-  PlaceBrand
->;
-export type PlaceC = t.BrandC<
-  t.IntersectionC<
-    [
-      t.TypeC<{}>,
-      t.TypeC<{
-        lat: typeof Defined;
-        lon: typeof Defined;
-      }>,
-      t.IntersectionC<
-        [
-          typeof UnitsGeo_.RelaxedLocation,
-          t.PartialC<{
-            name: typeof Address_.PlaceName;
-            address: typeof Address_.ComponentAddress;
-            localeAddress: t.StringC;
-            stopId: t.StringC;
-            stopCode: t.StringC;
-            stationId: t.StringC;
-            facilities: t.ArrayC<t.StringC>;
-            openingHours: typeof Station_.OpeningHours;
-            zone: typeof Station_.Zone;
-          }>,
-        ]
-      >,
-    ]
-  >,
-  PlaceBrand
->;
-export const Place: PlaceC = t.brand(
-  t.intersection([
-    t.type({}),
-    t.type({
-      lat: Defined,
-      lon: Defined,
-    }),
-    t.intersection([
-      UnitsGeo_.RelaxedLocation,
-      t.partial({
-        name: Address_.PlaceName,
-        address: Address_.ComponentAddress,
-        localeAddress: t.string,
-        stopId: t.string,
-        stopCode: t.string,
-        stationId: t.string,
-        facilities: t.array(t.string),
-        openingHours: Station_.OpeningHours,
-        zone: Station_.Zone,
-      }),
-    ]),
-  ]),
-  (
-    x,
-  ): x is t.Branded<
-    {} & {
-      lat: Defined;
-      lon: Defined;
-    } & (UnitsGeo_.RelaxedLocation & {
+  } & (UnitsGeo_.RelaxedLocation &
+      ({
         name?: Address_.PlaceName;
         address?: Address_.ComponentAddress;
         localeAddress?: string;
@@ -115,7 +47,85 @@ export const Place: PlaceC = t.brand(
         facilities?: Array<string>;
         openingHours?: Station_.OpeningHours;
         zone?: Station_.Zone;
-      }),
+      } & Record<string, unknown>)),
+  PlaceBrand
+>;
+export type PlaceC = t.BrandC<
+  t.IntersectionC<
+    [
+      t.RecordC<t.StringC, t.UnknownC>,
+      t.TypeC<{
+        lat: typeof Defined;
+        lon: typeof Defined;
+      }>,
+      t.IntersectionC<
+        [
+          typeof UnitsGeo_.RelaxedLocation,
+          t.IntersectionC<
+            [
+              t.PartialC<{
+                name: typeof Address_.PlaceName;
+                address: typeof Address_.ComponentAddress;
+                localeAddress: t.StringC;
+                stopId: t.StringC;
+                stopCode: t.StringC;
+                stationId: t.StringC;
+                facilities: t.ArrayC<t.StringC>;
+                openingHours: typeof Station_.OpeningHours;
+                zone: typeof Station_.Zone;
+              }>,
+              t.RecordC<t.StringC, t.UnknownC>,
+            ]
+          >,
+        ]
+      >,
+    ]
+  >,
+  PlaceBrand
+>;
+export const Place: PlaceC = t.brand(
+  t.intersection([
+    t.record(t.string, t.unknown),
+    t.type({
+      lat: Defined,
+      lon: Defined,
+    }),
+    t.intersection([
+      UnitsGeo_.RelaxedLocation,
+      t.intersection([
+        t.partial({
+          name: Address_.PlaceName,
+          address: Address_.ComponentAddress,
+          localeAddress: t.string,
+          stopId: t.string,
+          stopCode: t.string,
+          stationId: t.string,
+          facilities: t.array(t.string),
+          openingHours: Station_.OpeningHours,
+          zone: Station_.Zone,
+        }),
+        t.record(t.string, t.unknown),
+      ]),
+    ]),
+  ]),
+  (
+    x,
+  ): x is t.Branded<
+    Record<string, unknown> & {
+      lat: Defined;
+      lon: Defined;
+    } & (UnitsGeo_.RelaxedLocation &
+        ({
+          name?: Address_.PlaceName;
+          address?: Address_.ComponentAddress;
+          localeAddress?: string;
+          stopId?: string;
+          stopCode?: string;
+          stationId?: string;
+          facilities?: Array<string>;
+          openingHours?: Station_.OpeningHours;
+          zone?: Station_.Zone;
+        } & Record<string, unknown>)),
     PlaceBrand
   > => true,
   'Place',

--- a/maas-schemas-ts/src/core/components/state-log.ts
+++ b/maas-schemas-ts/src/core/components/state-log.ts
@@ -47,13 +47,13 @@ export interface ObsoleteTimeBrand {
 // BookingStateTransition
 // The purpose of this remains a mystery
 export type BookingStateTransition = t.Branded<
-  {
+  ({
     timestamp?: Units_.Time | ObsoleteTime;
     oldState?: State_.BookingState;
     newState?: State_.BookingState;
     invalid?: boolean;
     reason?: Errors_.Reason;
-  } & {
+  } & Record<string, unknown>) & {
     newState: Defined;
     oldState: Defined;
     timestamp: Defined;
@@ -63,13 +63,18 @@ export type BookingStateTransition = t.Branded<
 export type BookingStateTransitionC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        timestamp: t.UnionC<[typeof Units_.Time, typeof ObsoleteTime]>;
-        oldState: typeof State_.BookingState;
-        newState: typeof State_.BookingState;
-        invalid: t.BooleanC;
-        reason: typeof Errors_.Reason;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            timestamp: t.UnionC<[typeof Units_.Time, typeof ObsoleteTime]>;
+            oldState: typeof State_.BookingState;
+            newState: typeof State_.BookingState;
+            invalid: t.BooleanC;
+            reason: typeof Errors_.Reason;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         newState: typeof Defined;
         oldState: typeof Defined;
@@ -81,13 +86,16 @@ export type BookingStateTransitionC = t.BrandC<
 >;
 export const BookingStateTransition: BookingStateTransitionC = t.brand(
   t.intersection([
-    t.partial({
-      timestamp: t.union([Units_.Time, ObsoleteTime]),
-      oldState: State_.BookingState,
-      newState: State_.BookingState,
-      invalid: t.boolean,
-      reason: Errors_.Reason,
-    }),
+    t.intersection([
+      t.partial({
+        timestamp: t.union([Units_.Time, ObsoleteTime]),
+        oldState: State_.BookingState,
+        newState: State_.BookingState,
+        invalid: t.boolean,
+        reason: Errors_.Reason,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       newState: Defined,
       oldState: Defined,
@@ -97,13 +105,13 @@ export const BookingStateTransition: BookingStateTransitionC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       timestamp?: Units_.Time | ObsoleteTime;
       oldState?: State_.BookingState;
       newState?: State_.BookingState;
       invalid?: boolean;
       reason?: Errors_.Reason;
-    } & {
+    } & Record<string, unknown>) & {
       newState: Defined;
       oldState: Defined;
       timestamp: Defined;

--- a/maas-schemas-ts/src/core/components/station.ts
+++ b/maas-schemas-ts/src/core/components/station.ts
@@ -124,11 +124,11 @@ export interface AgencyIdBrand {
 
 // OpeningHours
 // Opening hour of the station, object format is left for TSP to decide
-export type OpeningHours = t.Branded<{}, OpeningHoursBrand>;
-export type OpeningHoursC = t.BrandC<t.TypeC<{}>, OpeningHoursBrand>;
+export type OpeningHours = t.Branded<Record<string, unknown>, OpeningHoursBrand>;
+export type OpeningHoursC = t.BrandC<t.UnknownRecordC, OpeningHoursBrand>;
 export const OpeningHours: OpeningHoursC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, OpeningHoursBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, OpeningHoursBrand> => true,
   'OpeningHours',
 );
 export interface OpeningHoursBrand {
@@ -249,11 +249,11 @@ export interface PlatformCodeBrand {
 
 // Station
 // The default export. More information at the top.
-export type Station = t.Branded<{}, StationBrand>;
-export type StationC = t.BrandC<t.TypeC<{}>, StationBrand>;
+export type Station = t.Branded<Record<string, unknown>, StationBrand>;
+export type StationC = t.BrandC<t.UnknownRecordC, StationBrand>;
 export const Station: StationC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, StationBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, StationBrand> => true,
   'Station',
 );
 export interface StationBrand {

--- a/maas-schemas-ts/src/core/components/terms.ts
+++ b/maas-schemas-ts/src/core/components/terms.ts
@@ -262,7 +262,7 @@ export type Terms = t.Branded<
     restrictions?: {
       singleDevice?: boolean;
       skipRestrictionCheck?: boolean;
-      freeTicket?: {};
+      freeTicket?: Record<string, unknown>;
     };
     surcharges?: {
       midnight?: Surcharge;
@@ -295,135 +295,143 @@ export type Terms = t.Branded<
         currency: Defined;
       }
     >;
-  },
+  } & Record<string, unknown>,
   TermsBrand
 >;
 export type TermsC = t.BrandC<
-  t.PartialC<{
-    type: t.StringC;
-    seatings: t.ArrayC<typeof Seat>;
-    validity: t.IntersectionC<
-      [
-        t.PartialC<{
-          startTime: typeof Units_.Time;
-          endTime: typeof Units_.Time;
-          startTimeReturn: typeof Units_.Time;
-          endTimeReturn: typeof Units_.Time;
-        }>,
-        t.TypeC<{
-          startTime: typeof Defined;
-          endTime: typeof Defined;
-        }>,
-      ]
-    >;
-    reusable: t.BooleanC;
-    reconcilable: t.BooleanC;
-    restrictions: t.PartialC<{
-      singleDevice: t.BooleanC;
-      skipRestrictionCheck: t.BooleanC;
-      freeTicket: t.TypeC<{}>;
-    }>;
-    surcharges: t.PartialC<{
-      midnight: typeof Surcharge;
-      pickup: typeof Surcharge;
-    }>;
-    cancellation: t.PartialC<{
-      cancellationFormActionUrl: typeof Units_.Url;
-      outward: typeof Cancellation;
-      return: typeof Cancellation;
-    }>;
-    amendment: t.PartialC<{
-      outward: typeof Amendment;
-      return: typeof Amendment;
-    }>;
-    prePurchaseGuidanceUrl: typeof Units_.Url;
-    fareRates: t.ArrayC<
-      t.IntersectionC<
-        [
-          t.PartialC<{
-            amount: t.NumberC;
-            currency: typeof Units_.Currency;
-            timeInterval: t.NumberC;
-            startAt: t.NumberC;
-            type: t.UnionC<
-              [
-                t.LiteralC<'maxRate'>,
-                t.LiteralC<'missedReturnPenalty'>,
-                t.LiteralC<'extra'>,
-                t.LiteralC<'perKilometer'>,
-                t.LiteralC<'perParkMinute'>,
-              ]
-            >;
-          }>,
-          t.TypeC<{
-            amount: typeof Defined;
-            currency: typeof Defined;
-          }>,
-        ]
-      >
-    >;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        type: t.StringC;
+        seatings: t.ArrayC<typeof Seat>;
+        validity: t.IntersectionC<
+          [
+            t.PartialC<{
+              startTime: typeof Units_.Time;
+              endTime: typeof Units_.Time;
+              startTimeReturn: typeof Units_.Time;
+              endTimeReturn: typeof Units_.Time;
+            }>,
+            t.TypeC<{
+              startTime: typeof Defined;
+              endTime: typeof Defined;
+            }>,
+          ]
+        >;
+        reusable: t.BooleanC;
+        reconcilable: t.BooleanC;
+        restrictions: t.PartialC<{
+          singleDevice: t.BooleanC;
+          skipRestrictionCheck: t.BooleanC;
+          freeTicket: t.UnknownRecordC;
+        }>;
+        surcharges: t.PartialC<{
+          midnight: typeof Surcharge;
+          pickup: typeof Surcharge;
+        }>;
+        cancellation: t.PartialC<{
+          cancellationFormActionUrl: typeof Units_.Url;
+          outward: typeof Cancellation;
+          return: typeof Cancellation;
+        }>;
+        amendment: t.PartialC<{
+          outward: typeof Amendment;
+          return: typeof Amendment;
+        }>;
+        prePurchaseGuidanceUrl: typeof Units_.Url;
+        fareRates: t.ArrayC<
+          t.IntersectionC<
+            [
+              t.PartialC<{
+                amount: t.NumberC;
+                currency: typeof Units_.Currency;
+                timeInterval: t.NumberC;
+                startAt: t.NumberC;
+                type: t.UnionC<
+                  [
+                    t.LiteralC<'maxRate'>,
+                    t.LiteralC<'missedReturnPenalty'>,
+                    t.LiteralC<'extra'>,
+                    t.LiteralC<'perKilometer'>,
+                    t.LiteralC<'perParkMinute'>,
+                  ]
+                >;
+              }>,
+              t.TypeC<{
+                amount: typeof Defined;
+                currency: typeof Defined;
+              }>,
+            ]
+          >
+        >;
+      }>,
+      t.RecordC<t.StringC, t.UnknownC>,
+    ]
+  >,
   TermsBrand
 >;
 export const Terms: TermsC = t.brand(
-  t.partial({
-    type: t.string,
-    seatings: t.array(Seat),
-    validity: t.intersection([
-      t.partial({
-        startTime: Units_.Time,
-        endTime: Units_.Time,
-        startTimeReturn: Units_.Time,
-        endTimeReturn: Units_.Time,
-      }),
-      t.type({
-        startTime: Defined,
-        endTime: Defined,
-      }),
-    ]),
-    reusable: t.boolean,
-    reconcilable: t.boolean,
-    restrictions: t.partial({
-      singleDevice: t.boolean,
-      skipRestrictionCheck: t.boolean,
-      freeTicket: t.type({}),
-    }),
-    surcharges: t.partial({
-      midnight: Surcharge,
-      pickup: Surcharge,
-    }),
-    cancellation: t.partial({
-      cancellationFormActionUrl: Units_.Url,
-      outward: Cancellation,
-      return: Cancellation,
-    }),
-    amendment: t.partial({
-      outward: Amendment,
-      return: Amendment,
-    }),
-    prePurchaseGuidanceUrl: Units_.Url,
-    fareRates: t.array(
-      t.intersection([
+  t.intersection([
+    t.partial({
+      type: t.string,
+      seatings: t.array(Seat),
+      validity: t.intersection([
         t.partial({
-          amount: t.number,
-          currency: Units_.Currency,
-          timeInterval: t.number,
-          startAt: t.number,
-          type: t.union([
-            t.literal('maxRate'),
-            t.literal('missedReturnPenalty'),
-            t.literal('extra'),
-            t.literal('perKilometer'),
-            t.literal('perParkMinute'),
-          ]),
+          startTime: Units_.Time,
+          endTime: Units_.Time,
+          startTimeReturn: Units_.Time,
+          endTimeReturn: Units_.Time,
         }),
         t.type({
-          amount: Defined,
-          currency: Defined,
+          startTime: Defined,
+          endTime: Defined,
         }),
       ]),
-    ),
-  }),
+      reusable: t.boolean,
+      reconcilable: t.boolean,
+      restrictions: t.partial({
+        singleDevice: t.boolean,
+        skipRestrictionCheck: t.boolean,
+        freeTicket: t.UnknownRecord,
+      }),
+      surcharges: t.partial({
+        midnight: Surcharge,
+        pickup: Surcharge,
+      }),
+      cancellation: t.partial({
+        cancellationFormActionUrl: Units_.Url,
+        outward: Cancellation,
+        return: Cancellation,
+      }),
+      amendment: t.partial({
+        outward: Amendment,
+        return: Amendment,
+      }),
+      prePurchaseGuidanceUrl: Units_.Url,
+      fareRates: t.array(
+        t.intersection([
+          t.partial({
+            amount: t.number,
+            currency: Units_.Currency,
+            timeInterval: t.number,
+            startAt: t.number,
+            type: t.union([
+              t.literal('maxRate'),
+              t.literal('missedReturnPenalty'),
+              t.literal('extra'),
+              t.literal('perKilometer'),
+              t.literal('perParkMinute'),
+            ]),
+          }),
+          t.type({
+            amount: Defined,
+            currency: Defined,
+          }),
+        ]),
+      ),
+    }),
+    t.record(t.string, t.unknown),
+  ]),
   (
     x,
   ): x is t.Branded<
@@ -444,7 +452,7 @@ export const Terms: TermsC = t.brand(
       restrictions?: {
         singleDevice?: boolean;
         skipRestrictionCheck?: boolean;
-        freeTicket?: {};
+        freeTicket?: Record<string, unknown>;
       };
       surcharges?: {
         midnight?: Surcharge;
@@ -477,7 +485,7 @@ export const Terms: TermsC = t.brand(
           currency: Defined;
         }
       >;
-    },
+    } & Record<string, unknown>,
     TermsBrand
   > => true,
   'Terms',

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -61,27 +61,27 @@ export type Customer = t.Branded<
     ssid?: boolean | Common_.Ssid;
     documents?: Array<PersonalDocument_.PersonalDocument>;
     balances?: ({
-      WMP?: {
+      WMP?: ({
         currency?: Common_.MetaCurrencyWMP;
         amount?: number;
-      } & {
+      } & Record<string, unknown>) & {
         currency: Defined;
         amount: Defined;
       };
     } & Record<
       string,
-      | ({
+      | (({
           currency?: Common_.MetaCurrencyWMP;
           amount?: number;
-        } & {
+        } & Record<string, unknown>) & {
           currency: Defined;
           amount: Defined;
         })
-      | ({
+      | (({
           currency?: Common_.MetaCurrencyTOKEN;
           tokenId?: Fare_.TokenId;
           amount?: number | null;
-        } & {
+        } & Record<string, unknown>) & {
           currency: Defined;
           tokenId: Defined;
           amount: Defined;
@@ -128,10 +128,15 @@ export type CustomerC = t.BrandC<
             t.PartialC<{
               WMP: t.IntersectionC<
                 [
-                  t.PartialC<{
-                    currency: typeof Common_.MetaCurrencyWMP;
-                    amount: t.NumberC;
-                  }>,
+                  t.IntersectionC<
+                    [
+                      t.PartialC<{
+                        currency: typeof Common_.MetaCurrencyWMP;
+                        amount: t.NumberC;
+                      }>,
+                      t.RecordC<t.StringC, t.UnknownC>,
+                    ]
+                  >,
                   t.TypeC<{
                     currency: typeof Defined;
                     amount: typeof Defined;
@@ -145,10 +150,15 @@ export type CustomerC = t.BrandC<
                 [
                   t.IntersectionC<
                     [
-                      t.PartialC<{
-                        currency: typeof Common_.MetaCurrencyWMP;
-                        amount: t.NumberC;
-                      }>,
+                      t.IntersectionC<
+                        [
+                          t.PartialC<{
+                            currency: typeof Common_.MetaCurrencyWMP;
+                            amount: t.NumberC;
+                          }>,
+                          t.RecordC<t.StringC, t.UnknownC>,
+                        ]
+                      >,
                       t.TypeC<{
                         currency: typeof Defined;
                         amount: typeof Defined;
@@ -157,11 +167,16 @@ export type CustomerC = t.BrandC<
                   >,
                   t.IntersectionC<
                     [
-                      t.PartialC<{
-                        currency: typeof Common_.MetaCurrencyTOKEN;
-                        tokenId: typeof Fare_.TokenId;
-                        amount: t.UnionC<[t.NumberC, t.NullC]>;
-                      }>,
+                      t.IntersectionC<
+                        [
+                          t.PartialC<{
+                            currency: typeof Common_.MetaCurrencyTOKEN;
+                            tokenId: typeof Fare_.TokenId;
+                            amount: t.UnionC<[t.NumberC, t.NullC]>;
+                          }>,
+                          t.RecordC<t.StringC, t.UnknownC>,
+                        ]
+                      >,
                       t.TypeC<{
                         currency: typeof Defined;
                         tokenId: typeof Defined;
@@ -215,10 +230,13 @@ export const Customer: CustomerC = t.brand(
       t.intersection([
         t.partial({
           WMP: t.intersection([
-            t.partial({
-              currency: Common_.MetaCurrencyWMP,
-              amount: t.number,
-            }),
+            t.intersection([
+              t.partial({
+                currency: Common_.MetaCurrencyWMP,
+                amount: t.number,
+              }),
+              t.record(t.string, t.unknown),
+            ]),
             t.type({
               currency: Defined,
               amount: Defined,
@@ -229,21 +247,27 @@ export const Customer: CustomerC = t.brand(
           t.string,
           t.union([
             t.intersection([
-              t.partial({
-                currency: Common_.MetaCurrencyWMP,
-                amount: t.number,
-              }),
+              t.intersection([
+                t.partial({
+                  currency: Common_.MetaCurrencyWMP,
+                  amount: t.number,
+                }),
+                t.record(t.string, t.unknown),
+              ]),
               t.type({
                 currency: Defined,
                 amount: Defined,
               }),
             ]),
             t.intersection([
-              t.partial({
-                currency: Common_.MetaCurrencyTOKEN,
-                tokenId: Fare_.TokenId,
-                amount: t.union([t.number, t.null]),
-              }),
+              t.intersection([
+                t.partial({
+                  currency: Common_.MetaCurrencyTOKEN,
+                  tokenId: Fare_.TokenId,
+                  amount: t.union([t.number, t.null]),
+                }),
+                t.record(t.string, t.unknown),
+              ]),
               t.type({
                 currency: Defined,
                 tokenId: Defined,
@@ -290,27 +314,27 @@ export const Customer: CustomerC = t.brand(
       ssid?: boolean | Common_.Ssid;
       documents?: Array<PersonalDocument_.PersonalDocument>;
       balances?: ({
-        WMP?: {
+        WMP?: ({
           currency?: Common_.MetaCurrencyWMP;
           amount?: number;
-        } & {
+        } & Record<string, unknown>) & {
           currency: Defined;
           amount: Defined;
         };
       } & Record<
         string,
-        | ({
+        | (({
             currency?: Common_.MetaCurrencyWMP;
             amount?: number;
-          } & {
+          } & Record<string, unknown>) & {
             currency: Defined;
             amount: Defined;
           })
-        | ({
+        | (({
             currency?: Common_.MetaCurrencyTOKEN;
             tokenId?: Fare_.TokenId;
             amount?: number | null;
-          } & {
+          } & Record<string, unknown>) & {
             currency: Defined;
             tokenId: Defined;
             amount: Defined;

--- a/maas-schemas-ts/src/core/leg.ts
+++ b/maas-schemas-ts/src/core/leg.ts
@@ -604,13 +604,13 @@ export interface TransferLegBrand {
 // Leg
 // The default export. More information at the top.
 export type Leg = t.Branded<
-  {} & (LegExtensions & (LegCore | WaitingLeg | TransferLeg)),
+  Record<string, unknown> & (LegExtensions & (LegCore | WaitingLeg | TransferLeg)),
   LegBrand
 >;
 export type LegC = t.BrandC<
   t.IntersectionC<
     [
-      t.TypeC<{}>,
+      t.UnknownRecordC,
       t.IntersectionC<
         [
           typeof LegExtensions,
@@ -623,13 +623,13 @@ export type LegC = t.BrandC<
 >;
 export const Leg: LegC = t.brand(
   t.intersection([
-    t.type({}),
+    t.UnknownRecord,
     t.intersection([LegExtensions, t.union([LegCore, WaitingLeg, TransferLeg])]),
   ]),
   (
     x,
   ): x is t.Branded<
-    {} & (LegExtensions & (LegCore | WaitingLeg | TransferLeg)),
+    Record<string, unknown> & (LegExtensions & (LegCore | WaitingLeg | TransferLeg)),
     LegBrand
   > => true,
   'Leg',

--- a/maas-schemas-ts/src/core/modes/MODE_BUS.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_BUS.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_BUS.json';
 
 // MODE_BUS
 // The default export. More information at the top.
-export type MODE_BUS = t.Branded<{}, MODE_BUSBrand>;
-export type MODE_BUSC = t.BrandC<t.TypeC<{}>, MODE_BUSBrand>;
+export type MODE_BUS = t.Branded<Record<string, unknown>, MODE_BUSBrand>;
+export type MODE_BUSC = t.BrandC<t.UnknownRecordC, MODE_BUSBrand>;
 export const MODE_BUS: MODE_BUSC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_BUSBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_BUSBrand> => true,
   'MODE_BUS',
 );
 export interface MODE_BUSBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_BUSISH.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_BUSISH.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_BUSISH.json';
 
 // MODE_BUSISH
 // The default export. More information at the top.
-export type MODE_BUSISH = t.Branded<{}, MODE_BUSISHBrand>;
-export type MODE_BUSISHC = t.BrandC<t.TypeC<{}>, MODE_BUSISHBrand>;
+export type MODE_BUSISH = t.Branded<Record<string, unknown>, MODE_BUSISHBrand>;
+export type MODE_BUSISHC = t.BrandC<t.UnknownRecordC, MODE_BUSISHBrand>;
 export const MODE_BUSISH: MODE_BUSISHC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_BUSISHBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_BUSISHBrand> => true,
   'MODE_BUSISH',
 );
 export interface MODE_BUSISHBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_CABLE_CAR.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_CABLE_CAR.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_CABLE_CAR.json';
 
 // MODE_CABLE_CAR
 // The default export. More information at the top.
-export type MODE_CABLE_CAR = t.Branded<{}, MODE_CABLE_CARBrand>;
-export type MODE_CABLE_CARC = t.BrandC<t.TypeC<{}>, MODE_CABLE_CARBrand>;
+export type MODE_CABLE_CAR = t.Branded<Record<string, unknown>, MODE_CABLE_CARBrand>;
+export type MODE_CABLE_CARC = t.BrandC<t.UnknownRecordC, MODE_CABLE_CARBrand>;
 export const MODE_CABLE_CAR: MODE_CABLE_CARC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_CABLE_CARBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_CABLE_CARBrand> => true,
   'MODE_CABLE_CAR',
 );
 export interface MODE_CABLE_CARBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_FERRY.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_FERRY.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_FERRY.json';
 
 // MODE_FERRY
 // The default export. More information at the top.
-export type MODE_FERRY = t.Branded<{}, MODE_FERRYBrand>;
-export type MODE_FERRYC = t.BrandC<t.TypeC<{}>, MODE_FERRYBrand>;
+export type MODE_FERRY = t.Branded<Record<string, unknown>, MODE_FERRYBrand>;
+export type MODE_FERRYC = t.BrandC<t.UnknownRecordC, MODE_FERRYBrand>;
 export const MODE_FERRY: MODE_FERRYC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_FERRYBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_FERRYBrand> => true,
   'MODE_FERRY',
 );
 export interface MODE_FERRYBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_FUNICULAR.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_FUNICULAR.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_FUNICULAR.json';
 
 // MODE_FUNICULAR
 // The default export. More information at the top.
-export type MODE_FUNICULAR = t.Branded<{}, MODE_FUNICULARBrand>;
-export type MODE_FUNICULARC = t.BrandC<t.TypeC<{}>, MODE_FUNICULARBrand>;
+export type MODE_FUNICULAR = t.Branded<Record<string, unknown>, MODE_FUNICULARBrand>;
+export type MODE_FUNICULARC = t.BrandC<t.UnknownRecordC, MODE_FUNICULARBrand>;
 export const MODE_FUNICULAR: MODE_FUNICULARC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_FUNICULARBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_FUNICULARBrand> => true,
   'MODE_FUNICULAR',
 );
 export interface MODE_FUNICULARBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_GONDOLA.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_GONDOLA.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_GONDOLA.json';
 
 // MODE_GONDOLA
 // The default export. More information at the top.
-export type MODE_GONDOLA = t.Branded<{}, MODE_GONDOLABrand>;
-export type MODE_GONDOLAC = t.BrandC<t.TypeC<{}>, MODE_GONDOLABrand>;
+export type MODE_GONDOLA = t.Branded<Record<string, unknown>, MODE_GONDOLABrand>;
+export type MODE_GONDOLAC = t.BrandC<t.UnknownRecordC, MODE_GONDOLABrand>;
 export const MODE_GONDOLA: MODE_GONDOLAC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_GONDOLABrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_GONDOLABrand> => true,
   'MODE_GONDOLA',
 );
 export interface MODE_GONDOLABrand {

--- a/maas-schemas-ts/src/core/modes/MODE_SUBWAY.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_SUBWAY.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_SUBWAY.json';
 
 // MODE_SUBWAY
 // The default export. More information at the top.
-export type MODE_SUBWAY = t.Branded<{}, MODE_SUBWAYBrand>;
-export type MODE_SUBWAYC = t.BrandC<t.TypeC<{}>, MODE_SUBWAYBrand>;
+export type MODE_SUBWAY = t.Branded<Record<string, unknown>, MODE_SUBWAYBrand>;
+export type MODE_SUBWAYC = t.BrandC<t.UnknownRecordC, MODE_SUBWAYBrand>;
 export const MODE_SUBWAY: MODE_SUBWAYC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_SUBWAYBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_SUBWAYBrand> => true,
   'MODE_SUBWAY',
 );
 export interface MODE_SUBWAYBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_TRAIN.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_TRAIN.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_TRAIN.json';
 
 // MODE_TRAIN
 // The default export. More information at the top.
-export type MODE_TRAIN = t.Branded<{}, MODE_TRAINBrand>;
-export type MODE_TRAINC = t.BrandC<t.TypeC<{}>, MODE_TRAINBrand>;
+export type MODE_TRAIN = t.Branded<Record<string, unknown>, MODE_TRAINBrand>;
+export type MODE_TRAINC = t.BrandC<t.UnknownRecordC, MODE_TRAINBrand>;
 export const MODE_TRAIN: MODE_TRAINC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_TRAINBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_TRAINBrand> => true,
   'MODE_TRAIN',
 );
 export interface MODE_TRAINBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_TRAINISH.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_TRAINISH.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_TRAINISH.json';
 
 // MODE_TRAINISH
 // The default export. More information at the top.
-export type MODE_TRAINISH = t.Branded<{}, MODE_TRAINISHBrand>;
-export type MODE_TRAINISHC = t.BrandC<t.TypeC<{}>, MODE_TRAINISHBrand>;
+export type MODE_TRAINISH = t.Branded<Record<string, unknown>, MODE_TRAINISHBrand>;
+export type MODE_TRAINISHC = t.BrandC<t.UnknownRecordC, MODE_TRAINISHBrand>;
 export const MODE_TRAINISH: MODE_TRAINISHC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_TRAINISHBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_TRAINISHBrand> => true,
   'MODE_TRAINISH',
 );
 export interface MODE_TRAINISHBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_TRAM.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_TRAM.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_TRAM.json';
 
 // MODE_TRAM
 // The default export. More information at the top.
-export type MODE_TRAM = t.Branded<{}, MODE_TRAMBrand>;
-export type MODE_TRAMC = t.BrandC<t.TypeC<{}>, MODE_TRAMBrand>;
+export type MODE_TRAM = t.Branded<Record<string, unknown>, MODE_TRAMBrand>;
+export type MODE_TRAMC = t.BrandC<t.UnknownRecordC, MODE_TRAMBrand>;
 export const MODE_TRAM: MODE_TRAMC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_TRAMBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_TRAMBrand> => true,
   'MODE_TRAM',
 );
 export interface MODE_TRAMBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_TRANSIT.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_TRANSIT.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_TRANSIT.json';
 
 // MODE_TRANSIT
 // The default export. More information at the top.
-export type MODE_TRANSIT = t.Branded<{}, MODE_TRANSITBrand>;
-export type MODE_TRANSITC = t.BrandC<t.TypeC<{}>, MODE_TRANSITBrand>;
+export type MODE_TRANSIT = t.Branded<Record<string, unknown>, MODE_TRANSITBrand>;
+export type MODE_TRANSITC = t.BrandC<t.UnknownRecordC, MODE_TRANSITBrand>;
 export const MODE_TRANSIT: MODE_TRANSITC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_TRANSITBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_TRANSITBrand> => true,
   'MODE_TRANSIT',
 );
 export interface MODE_TRANSITBrand {

--- a/maas-schemas-ts/src/core/modes/MODE_WALK.ts
+++ b/maas-schemas-ts/src/core/modes/MODE_WALK.ts
@@ -14,11 +14,11 @@ export const schemaId = 'http://maasglobal.com/core/modes/MODE_WALK.json';
 
 // MODE_WALK
 // The default export. More information at the top.
-export type MODE_WALK = t.Branded<{}, MODE_WALKBrand>;
-export type MODE_WALKC = t.BrandC<t.TypeC<{}>, MODE_WALKBrand>;
+export type MODE_WALK = t.Branded<Record<string, unknown>, MODE_WALKBrand>;
+export type MODE_WALKC = t.BrandC<t.UnknownRecordC, MODE_WALKBrand>;
 export const MODE_WALK: MODE_WALKC = t.brand(
-  t.type({}),
-  (x): x is t.Branded<{}, MODE_WALKBrand> => true,
+  t.UnknownRecord,
+  (x): x is t.Branded<Record<string, unknown>, MODE_WALKBrand> => true,
   'MODE_WALK',
 );
 export interface MODE_WALKBrand {

--- a/maas-schemas-ts/src/core/profile.ts
+++ b/maas-schemas-ts/src/core/profile.ts
@@ -185,7 +185,7 @@ export type Profile = t.Branded<
       type: Defined;
       valid: Defined;
     };
-    subscription?: {};
+    subscription?: Record<string, unknown>;
     subscriptionInstance?: SubscriptionInstance;
     balances?: Array<Fare_.Fare>;
     created?: Units_.Time;
@@ -239,7 +239,7 @@ export type ProfileC = t.BrandC<
             }>,
           ]
         >;
-        subscription: t.TypeC<{}>;
+        subscription: t.UnknownRecordC;
         subscriptionInstance: typeof SubscriptionInstance;
         balances: t.ArrayC<typeof Fare_.Fare>;
         created: typeof Units_.Time;
@@ -289,7 +289,7 @@ export const Profile: ProfileC = t.brand(
           valid: Defined,
         }),
       ]),
-      subscription: t.type({}),
+      subscription: t.UnknownRecord,
       subscriptionInstance: SubscriptionInstance,
       balances: t.array(Fare_.Fare),
       created: Units_.Time,
@@ -331,7 +331,7 @@ export const Profile: ProfileC = t.brand(
         type: Defined;
         valid: Defined;
       };
-      subscription?: {};
+      subscription?: Record<string, unknown>;
       subscriptionInstance?: SubscriptionInstance;
       balances?: Array<Fare_.Fare>;
       created?: Units_.Time;

--- a/maas-schemas-ts/src/core/region.ts
+++ b/maas-schemas-ts/src/core/region.ts
@@ -31,13 +31,13 @@ export const schemaId = 'http://maasglobal.com/core/region.json';
 // Region
 // The default export. More information at the top.
 export type Region = t.Branded<
-  {
+  ({
     id?: string;
     name?: string;
     countryCode?: Address_.Country;
     zipCode?: Address_.ZipCode;
-    availability?: {};
-  } & {
+    availability?: Record<string, unknown>;
+  } & Record<string, unknown>) & {
     id: Defined;
     countryCode: Defined;
     zipCode: Defined;
@@ -47,13 +47,18 @@ export type Region = t.Branded<
 export type RegionC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        id: t.StringC;
-        name: t.StringC;
-        countryCode: typeof Address_.Country;
-        zipCode: typeof Address_.ZipCode;
-        availability: t.TypeC<{}>;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            id: t.StringC;
+            name: t.StringC;
+            countryCode: typeof Address_.Country;
+            zipCode: typeof Address_.ZipCode;
+            availability: t.RecordC<t.StringC, t.UnknownC>;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         id: typeof Defined;
         countryCode: typeof Defined;
@@ -65,13 +70,16 @@ export type RegionC = t.BrandC<
 >;
 export const Region: RegionC = t.brand(
   t.intersection([
-    t.partial({
-      id: t.string,
-      name: t.string,
-      countryCode: Address_.Country,
-      zipCode: Address_.ZipCode,
-      availability: t.type({}),
-    }),
+    t.intersection([
+      t.partial({
+        id: t.string,
+        name: t.string,
+        countryCode: Address_.Country,
+        zipCode: Address_.ZipCode,
+        availability: t.record(t.string, t.unknown),
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       id: Defined,
       countryCode: Defined,
@@ -81,13 +89,13 @@ export const Region: RegionC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       id?: string;
       name?: string;
       countryCode?: Address_.Country;
       zipCode?: Address_.ZipCode;
-      availability?: {};
-    } & {
+      availability?: Record<string, unknown>;
+    } & Record<string, unknown>) & {
       id: Defined;
       countryCode: Defined;
       zipCode: Defined;

--- a/maas-schemas-ts/src/environments/environments.ts
+++ b/maas-schemas-ts/src/environments/environments.ts
@@ -286,9 +286,9 @@ export const examplesEnvironment: NonEmptyArray<Environment> = ([
 // The purpose of this remains a mystery
 export type DevEnvironment = t.Branded<
   Environment &
-    ({
+    (({
       live?: false;
-    } & {
+    } & Record<string, unknown>) & {
       live: Defined;
     }),
   DevEnvironmentBrand
@@ -299,9 +299,14 @@ export type DevEnvironmentC = t.BrandC<
       typeof Environment,
       t.IntersectionC<
         [
-          t.PartialC<{
-            live: t.LiteralC<false>;
-          }>,
+          t.IntersectionC<
+            [
+              t.PartialC<{
+                live: t.LiteralC<false>;
+              }>,
+              t.RecordC<t.StringC, t.UnknownC>,
+            ]
+          >,
           t.TypeC<{
             live: typeof Defined;
           }>,
@@ -315,9 +320,12 @@ export const DevEnvironment: DevEnvironmentC = t.brand(
   t.intersection([
     Environment,
     t.intersection([
-      t.partial({
-        live: t.literal(false),
-      }),
+      t.intersection([
+        t.partial({
+          live: t.literal(false),
+        }),
+        t.record(t.string, t.unknown),
+      ]),
       t.type({
         live: Defined,
       }),
@@ -327,9 +335,9 @@ export const DevEnvironment: DevEnvironmentC = t.brand(
     x,
   ): x is t.Branded<
     Environment &
-      ({
+      (({
         live?: false;
-      } & {
+      } & Record<string, unknown>) & {
         live: Defined;
       }),
     DevEnvironmentBrand

--- a/maas-schemas-ts/src/geojson/geometry.ts
+++ b/maas-schemas-ts/src/geojson/geometry.ts
@@ -102,41 +102,143 @@ export interface PolygonBrand {
 // Geometry
 // The default export. More information at the top.
 export type Geometry = t.Branded<
-  {} & {
+  Record<string, unknown> & {
     type: Defined;
     coordinates: Defined;
-  } & (unknown | unknown | unknown | unknown | unknown | unknown),
+  } & (
+      | {
+          type?: 'Point';
+          coordinates?: Position;
+        }
+      | {
+          type?: 'MultiPoint';
+          coordinates?: PositionArray;
+        }
+      | {
+          type?: 'LineString';
+          coordinates?: LineString;
+        }
+      | {
+          type?: 'MultiLineString';
+          coordinates?: Array<LineString>;
+        }
+      | {
+          type?: 'Polygon';
+          coordinates?: Polygon;
+        }
+      | {
+          type?: 'MultiPolygon';
+          coordinates?: Array<Polygon>;
+        }
+    ),
   GeometryBrand
 >;
 export type GeometryC = t.BrandC<
   t.IntersectionC<
     [
-      t.TypeC<{}>,
+      t.UnknownRecordC,
       t.TypeC<{
         type: typeof Defined;
         coordinates: typeof Defined;
       }>,
-      t.UnionC<[t.UnknownC, t.UnknownC, t.UnknownC, t.UnknownC, t.UnknownC, t.UnknownC]>,
+      t.UnionC<
+        [
+          t.PartialC<{
+            type: t.LiteralC<'Point'>;
+            coordinates: typeof Position;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'MultiPoint'>;
+            coordinates: typeof PositionArray;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'LineString'>;
+            coordinates: typeof LineString;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'MultiLineString'>;
+            coordinates: t.ArrayC<typeof LineString>;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'Polygon'>;
+            coordinates: typeof Polygon;
+          }>,
+          t.PartialC<{
+            type: t.LiteralC<'MultiPolygon'>;
+            coordinates: t.ArrayC<typeof Polygon>;
+          }>,
+        ]
+      >,
     ]
   >,
   GeometryBrand
 >;
 export const Geometry: GeometryC = t.brand(
   t.intersection([
-    t.type({}),
+    t.UnknownRecord,
     t.type({
       type: Defined,
       coordinates: Defined,
     }),
-    t.union([t.unknown, t.unknown, t.unknown, t.unknown, t.unknown, t.unknown]),
+    t.union([
+      t.partial({
+        type: t.literal('Point'),
+        coordinates: Position,
+      }),
+      t.partial({
+        type: t.literal('MultiPoint'),
+        coordinates: PositionArray,
+      }),
+      t.partial({
+        type: t.literal('LineString'),
+        coordinates: LineString,
+      }),
+      t.partial({
+        type: t.literal('MultiLineString'),
+        coordinates: t.array(LineString),
+      }),
+      t.partial({
+        type: t.literal('Polygon'),
+        coordinates: Polygon,
+      }),
+      t.partial({
+        type: t.literal('MultiPolygon'),
+        coordinates: t.array(Polygon),
+      }),
+    ]),
   ]),
   (
     x,
   ): x is t.Branded<
-    {} & {
+    Record<string, unknown> & {
       type: Defined;
       coordinates: Defined;
-    } & (unknown | unknown | unknown | unknown | unknown | unknown),
+    } & (
+        | {
+            type?: 'Point';
+            coordinates?: Position;
+          }
+        | {
+            type?: 'MultiPoint';
+            coordinates?: PositionArray;
+          }
+        | {
+            type?: 'LineString';
+            coordinates?: LineString;
+          }
+        | {
+            type?: 'MultiLineString';
+            coordinates?: Array<LineString>;
+          }
+        | {
+            type?: 'Polygon';
+            coordinates?: Polygon;
+          }
+        | {
+            type?: 'MultiPolygon';
+            coordinates?: Array<Polygon>;
+          }
+      ),
     GeometryBrand
   > => true,
   'Geometry',

--- a/maas-schemas-ts/src/maas-backend/autocomplete/autocomplete-query/response.ts
+++ b/maas-schemas-ts/src/maas-backend/autocomplete/autocomplete-query/response.ts
@@ -33,7 +33,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     suggestions?: Array<string>;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     suggestions: Defined;
   },
@@ -44,7 +44,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         suggestions: t.ArrayC<t.StringC>;
-        debug: t.TypeC<{}>;
+        debug: t.UnknownRecordC;
       }>,
       t.TypeC<{
         suggestions: typeof Defined;
@@ -57,7 +57,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       suggestions: t.array(t.string),
-      debug: t.type({}),
+      debug: t.UnknownRecord,
     }),
     t.type({
       suggestions: Defined,
@@ -68,7 +68,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       suggestions?: Array<string>;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       suggestions: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/booking-virtual-create/request.ts
+++ b/maas-schemas-ts/src/maas-backend/booking-virtual-create/request.ts
@@ -36,7 +36,7 @@ export const schemaId =
 // The default export. More information at the top.
 export type Request = t.Branded<
   Array<
-    {
+    ({
       paymentSourceId?: Common_.PaymentSourceId;
       productId?: Product_.Id;
       identityId?: Units_.IdentityId;
@@ -44,7 +44,7 @@ export type Request = t.Branded<
       description?: string;
       startTime?: Units_.Time;
       endTime?: Units_.Time;
-    } & {
+    } & Record<string, unknown>) & {
       productId: Defined;
       fare: Defined;
       identityId: Defined;
@@ -56,15 +56,20 @@ export type RequestC = t.BrandC<
   t.ArrayC<
     t.IntersectionC<
       [
-        t.PartialC<{
-          paymentSourceId: typeof Common_.PaymentSourceId;
-          productId: typeof Product_.Id;
-          identityId: typeof Units_.IdentityId;
-          fare: typeof Fare_.Fare;
-          description: t.StringC;
-          startTime: typeof Units_.Time;
-          endTime: typeof Units_.Time;
-        }>,
+        t.IntersectionC<
+          [
+            t.PartialC<{
+              paymentSourceId: typeof Common_.PaymentSourceId;
+              productId: typeof Product_.Id;
+              identityId: typeof Units_.IdentityId;
+              fare: typeof Fare_.Fare;
+              description: t.StringC;
+              startTime: typeof Units_.Time;
+              endTime: typeof Units_.Time;
+            }>,
+            t.RecordC<t.StringC, t.UnknownC>,
+          ]
+        >,
         t.TypeC<{
           productId: typeof Defined;
           fare: typeof Defined;
@@ -78,15 +83,18 @@ export type RequestC = t.BrandC<
 export const Request: RequestC = t.brand(
   t.array(
     t.intersection([
-      t.partial({
-        paymentSourceId: Common_.PaymentSourceId,
-        productId: Product_.Id,
-        identityId: Units_.IdentityId,
-        fare: Fare_.Fare,
-        description: t.string,
-        startTime: Units_.Time,
-        endTime: Units_.Time,
-      }),
+      t.intersection([
+        t.partial({
+          paymentSourceId: Common_.PaymentSourceId,
+          productId: Product_.Id,
+          identityId: Units_.IdentityId,
+          fare: Fare_.Fare,
+          description: t.string,
+          startTime: Units_.Time,
+          endTime: Units_.Time,
+        }),
+        t.record(t.string, t.unknown),
+      ]),
       t.type({
         productId: Defined,
         fare: Defined,
@@ -98,7 +106,7 @@ export const Request: RequestC = t.brand(
     x,
   ): x is t.Branded<
     Array<
-      {
+      ({
         paymentSourceId?: Common_.PaymentSourceId;
         productId?: Product_.Id;
         identityId?: Units_.IdentityId;
@@ -106,7 +114,7 @@ export const Request: RequestC = t.brand(
         description?: string;
         startTime?: Units_.Time;
         endTime?: Units_.Time;
-      } & {
+      } & Record<string, unknown>) & {
         productId: Defined;
         fare: Defined;
         identityId: Defined;

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-options/response.ts
@@ -165,7 +165,7 @@ export type Response = t.Branded<
     additional?: {
       bikeStations?: Array<BikeStation_.BikeStation>;
     };
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     options: Defined;
   },
@@ -179,7 +179,7 @@ export type ResponseC = t.BrandC<
         additional: t.PartialC<{
           bikeStations: t.ArrayC<typeof BikeStation_.BikeStation>;
         }>;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         options: typeof Defined;
@@ -195,7 +195,7 @@ export const Response: ResponseC = t.brand(
       additional: t.partial({
         bikeStations: t.array(BikeStation_.BikeStation),
       }),
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       options: Defined,
@@ -209,7 +209,7 @@ export const Response: ResponseC = t.brand(
       additional?: {
         bikeStations?: Array<BikeStation_.BikeStation>;
       };
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       options: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-products/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-agency-products/response.ts
@@ -34,16 +34,16 @@ export const schemaId =
 // Product
 // The purpose of this remains a mystery
 export type Product = t.Branded<
-  {
+  ({
     id?: string;
     agencyId?: string;
     tspProductId?: string;
     name?: string;
-    meta?: {};
+    meta?: Record<string, unknown>;
     icon?: Units_.Url;
     fares?: Array<Fare_.Fare>;
     description?: string;
-  } & {
+  } & Record<string, unknown>) & {
     id: Defined;
     agencyId: Defined;
     tspProductId: Defined;
@@ -57,16 +57,21 @@ export type Product = t.Branded<
 export type ProductC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        id: t.StringC;
-        agencyId: t.StringC;
-        tspProductId: t.StringC;
-        name: t.StringC;
-        meta: t.TypeC<{}>;
-        icon: typeof Units_.Url;
-        fares: t.ArrayC<typeof Fare_.Fare>;
-        description: t.StringC;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            id: t.StringC;
+            agencyId: t.StringC;
+            tspProductId: t.StringC;
+            name: t.StringC;
+            meta: t.RecordC<t.StringC, t.UnknownC>;
+            icon: typeof Units_.Url;
+            fares: t.ArrayC<typeof Fare_.Fare>;
+            description: t.StringC;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         id: typeof Defined;
         agencyId: typeof Defined;
@@ -82,16 +87,19 @@ export type ProductC = t.BrandC<
 >;
 export const Product: ProductC = t.brand(
   t.intersection([
-    t.partial({
-      id: t.string,
-      agencyId: t.string,
-      tspProductId: t.string,
-      name: t.string,
-      meta: t.type({}),
-      icon: Units_.Url,
-      fares: t.array(Fare_.Fare),
-      description: t.string,
-    }),
+    t.intersection([
+      t.partial({
+        id: t.string,
+        agencyId: t.string,
+        tspProductId: t.string,
+        name: t.string,
+        meta: t.record(t.string, t.unknown),
+        icon: Units_.Url,
+        fares: t.array(Fare_.Fare),
+        description: t.string,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       id: Defined,
       agencyId: Defined,
@@ -105,16 +113,16 @@ export const Product: ProductC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       id?: string;
       agencyId?: string;
       tspProductId?: string;
       name?: string;
-      meta?: {};
+      meta?: Record<string, unknown>;
       icon?: Units_.Url;
       fares?: Array<Fare_.Fare>;
       description?: string;
-    } & {
+    } & Record<string, unknown>) & {
       id: Defined;
       agencyId: Defined;
       tspProductId: Defined;

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-cancel/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-cancel/response.ts
@@ -9,6 +9,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 */
 
 import * as t from 'io-ts';
+import * as Booking_ from '../../../core/booking';
 
 export type Defined = {} | null;
 export class DefinedType extends t.Type<Defined> {
@@ -32,24 +33,70 @@ export const schemaId =
 // The default export. More information at the top.
 export type Response = t.Branded<
   {
+    booking?: Booking_.Booking & {
+      state?: string & ('CANCELLED' | 'CANCELLED_WITH_ERRORS');
+    };
+    debug?: Record<string, unknown>;
+  } & {
     booking: Defined;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
-  t.TypeC<{
-    booking: typeof Defined;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        booking: t.IntersectionC<
+          [
+            typeof Booking_.Booking,
+            t.PartialC<{
+              state: t.IntersectionC<
+                [
+                  t.StringC,
+                  t.UnionC<
+                    [t.LiteralC<'CANCELLED'>, t.LiteralC<'CANCELLED_WITH_ERRORS'>]
+                  >,
+                ]
+              >;
+            }>,
+          ]
+        >;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
+      }>,
+      t.TypeC<{
+        booking: typeof Defined;
+      }>,
+    ]
+  >,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
-  t.type({
-    booking: Defined,
-  }),
+  t.intersection([
+    t.partial({
+      booking: t.intersection([
+        Booking_.Booking,
+        t.partial({
+          state: t.intersection([
+            t.string,
+            t.union([t.literal('CANCELLED'), t.literal('CANCELLED_WITH_ERRORS')]),
+          ]),
+        }),
+      ]),
+      debug: t.record(t.string, t.unknown),
+    }),
+    t.type({
+      booking: Defined,
+    }),
+  ]),
   (
     x,
   ): x is t.Branded<
     {
+      booking?: Booking_.Booking & {
+        state?: string & ('CANCELLED' | 'CANCELLED_WITH_ERRORS');
+      };
+      debug?: Record<string, unknown>;
+    } & {
       booking: Defined;
     },
     ResponseBrand

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-create/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     booking?: Booking_.Booking;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     booking: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         booking: typeof Booking_.Booking;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         booking: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       booking: Booking_.Booking,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       booking: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       booking?: Booking_.Booking;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       booking: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-list/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     bookings?: Array<Booking_.Booking>;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     bookings: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         bookings: t.ArrayC<typeof Booking_.Booking>;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         bookings: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       bookings: t.array(Booking_.Booking),
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       bookings: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       bookings?: Array<Booking_.Booking>;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       bookings: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-retrieve/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     booking?: Booking_.Booking;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     booking: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         booking: typeof Booking_.Booking;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         booking: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       booking: Booking_.Booking,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       booking: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       booking?: Booking_.Booking;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       booking: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/bookings/bookings-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/bookings-update/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     booking?: Booking_.Booking;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     booking: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         booking: typeof Booking_.Booking;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         booking: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       booking: Booking_.Booking,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       booking: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       booking?: Booking_.Booking;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       booking: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/bookings/v2/bookings-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/bookings/v2/bookings-create/response.ts
@@ -39,7 +39,7 @@ export type Response = t.Branded<
       avainpay?: PaymentParameters_.AvainpayPaymentParameters;
       stripe?: PaymentParameters_.StripePaymentParameters;
     };
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     booking: Defined;
   },
@@ -54,7 +54,7 @@ export type ResponseC = t.BrandC<
           avainpay: typeof PaymentParameters_.AvainpayPaymentParameters;
           stripe: typeof PaymentParameters_.StripePaymentParameters;
         }>;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         booking: typeof Defined;
@@ -71,7 +71,7 @@ export const Response: ResponseC = t.brand(
         avainpay: PaymentParameters_.AvainpayPaymentParameters,
         stripe: PaymentParameters_.StripePaymentParameters,
       }),
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       booking: Defined,
@@ -86,7 +86,7 @@ export const Response: ResponseC = t.brand(
         avainpay?: PaymentParameters_.AvainpayPaymentParameters;
         stripe?: PaymentParameters_.StripePaymentParameters;
       };
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       booking: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/coupons/v2/coupons-redeem/response.ts
+++ b/maas-schemas-ts/src/maas-backend/coupons/v2/coupons-redeem/response.ts
@@ -33,13 +33,13 @@ export const schemaId =
 // Response
 // The default export. More information at the top.
 export type Response = t.Branded<
-  {
+  ({
     code?: Code_.Code;
     success?: boolean;
     data?: {
       subscription?: Subscription_.Subscription;
     };
-  } & {
+  } & Record<string, unknown>) & {
     code: Defined;
     success: Defined;
     data: Defined;
@@ -49,13 +49,18 @@ export type Response = t.Branded<
 export type ResponseC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        code: typeof Code_.Code;
-        success: t.BooleanC;
-        data: t.PartialC<{
-          subscription: typeof Subscription_.Subscription;
-        }>;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            code: typeof Code_.Code;
+            success: t.BooleanC;
+            data: t.PartialC<{
+              subscription: typeof Subscription_.Subscription;
+            }>;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         code: typeof Defined;
         success: typeof Defined;
@@ -67,13 +72,16 @@ export type ResponseC = t.BrandC<
 >;
 export const Response: ResponseC = t.brand(
   t.intersection([
-    t.partial({
-      code: Code_.Code,
-      success: t.boolean,
-      data: t.partial({
-        subscription: Subscription_.Subscription,
+    t.intersection([
+      t.partial({
+        code: Code_.Code,
+        success: t.boolean,
+        data: t.partial({
+          subscription: Subscription_.Subscription,
+        }),
       }),
-    }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       code: Defined,
       success: Defined,
@@ -83,13 +91,13 @@ export const Response: ResponseC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       code?: Code_.Code;
       success?: boolean;
       data?: {
         subscription?: Subscription_.Subscription;
       };
-    } & {
+    } & Record<string, unknown>) & {
       code: Defined;
       success: Defined;
       data: Defined;

--- a/maas-schemas-ts/src/maas-backend/customers/customer.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/customer.ts
@@ -49,7 +49,7 @@ export type Customer = t.Branded<
     balances?: Array<Fare_.Fare>;
     region?: Region_.Region;
     authorizations?: Array<Authorization_.Authorization>;
-    favoriteLocations?: Array<{}>;
+    favoriteLocations?: Array<Record<string, unknown>>;
     personalDocuments?: Array<
       {
         type?: PersonalDocument_.DocumentType;
@@ -83,7 +83,7 @@ export type CustomerC = t.BrandC<
         balances: t.ArrayC<typeof Fare_.Fare>;
         region: typeof Region_.Region;
         authorizations: t.ArrayC<typeof Authorization_.Authorization>;
-        favoriteLocations: t.ArrayC<t.TypeC<{}>>;
+        favoriteLocations: t.ArrayC<t.UnknownRecordC>;
         personalDocuments: t.ArrayC<
           t.IntersectionC<
             [
@@ -124,7 +124,7 @@ export const Customer: CustomerC = t.brand(
       balances: t.array(Fare_.Fare),
       region: Region_.Region,
       authorizations: t.array(Authorization_.Authorization),
-      favoriteLocations: t.array(t.type({})),
+      favoriteLocations: t.array(t.UnknownRecord),
       personalDocuments: t.array(
         t.intersection([
           t.partial({
@@ -161,7 +161,7 @@ export const Customer: CustomerC = t.brand(
       balances?: Array<Fare_.Fare>;
       region?: Region_.Region;
       authorizations?: Array<Authorization_.Authorization>;
-      favoriteLocations?: Array<{}>;
+      favoriteLocations?: Array<Record<string, unknown>>;
       personalDocuments?: Array<
         {
           type?: PersonalDocument_.DocumentType;

--- a/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personal-documents/consent/response.ts
@@ -33,12 +33,12 @@ export const schemaId =
 // Response
 // The default export. More information at the top.
 export type Response = t.Branded<
-  {
+  ({
     identityId?: Units_.IdentityId;
     id?: Units_.Uuid;
     partyId?: PersonalDocument_.PartyId;
     partyType?: PersonalDocument_.PartyType;
-  } & {
+  } & Record<string, unknown>) & {
     identityId: Defined;
     id: Defined;
     partyId: Defined;
@@ -49,12 +49,17 @@ export type Response = t.Branded<
 export type ResponseC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        identityId: typeof Units_.IdentityId;
-        id: typeof Units_.Uuid;
-        partyId: typeof PersonalDocument_.PartyId;
-        partyType: typeof PersonalDocument_.PartyType;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            identityId: typeof Units_.IdentityId;
+            id: typeof Units_.Uuid;
+            partyId: typeof PersonalDocument_.PartyId;
+            partyType: typeof PersonalDocument_.PartyType;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         identityId: typeof Defined;
         id: typeof Defined;
@@ -67,12 +72,15 @@ export type ResponseC = t.BrandC<
 >;
 export const Response: ResponseC = t.brand(
   t.intersection([
-    t.partial({
-      identityId: Units_.IdentityId,
-      id: Units_.Uuid,
-      partyId: PersonalDocument_.PartyId,
-      partyType: PersonalDocument_.PartyType,
-    }),
+    t.intersection([
+      t.partial({
+        identityId: Units_.IdentityId,
+        id: Units_.Uuid,
+        partyId: PersonalDocument_.PartyId,
+        partyType: PersonalDocument_.PartyType,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       identityId: Defined,
       id: Defined,
@@ -83,12 +91,12 @@ export const Response: ResponseC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       identityId?: Units_.IdentityId;
       id?: Units_.Uuid;
       partyId?: PersonalDocument_.PartyId;
       partyType?: PersonalDocument_.PartyType;
-    } & {
+    } & Record<string, unknown>) & {
       identityId: Defined;
       id: Defined;
       partyId: Defined;

--- a/maas-schemas-ts/src/maas-backend/customers/verification/webhooks/decision/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/verification/webhooks/decision/request.ts
@@ -44,7 +44,7 @@ export type Request = t.Branded<
         person?: {
           firstName?: Common_.PersonalName | null;
           lastName?: Common_.PersonalName | null;
-        };
+        } & Record<string, unknown>;
         document?: {
           number?: string | null;
           type?: PersonalDocument_.DocumentType;
@@ -55,7 +55,7 @@ export type Request = t.Branded<
         reason?: string;
         reasonCode?: number | null;
         status?: string;
-        additionalVerifiedData?: {};
+        additionalVerifiedData?: Record<string, unknown>;
         vendorData?: string;
         decisionTime?: string;
         acceptanceTime?: string;
@@ -115,10 +115,15 @@ export type RequestC = t.BrandC<
                         >,
                       ]
                     >;
-                    person: t.PartialC<{
-                      firstName: t.UnionC<[typeof Common_.PersonalName, t.NullC]>;
-                      lastName: t.UnionC<[typeof Common_.PersonalName, t.NullC]>;
-                    }>;
+                    person: t.IntersectionC<
+                      [
+                        t.PartialC<{
+                          firstName: t.UnionC<[typeof Common_.PersonalName, t.NullC]>;
+                          lastName: t.UnionC<[typeof Common_.PersonalName, t.NullC]>;
+                        }>,
+                        t.RecordC<t.StringC, t.UnknownC>,
+                      ]
+                    >;
                     document: t.PartialC<{
                       number: t.UnionC<[t.StringC, t.NullC]>;
                       type: typeof PersonalDocument_.DocumentType;
@@ -129,7 +134,7 @@ export type RequestC = t.BrandC<
                     reason: t.StringC;
                     reasonCode: t.UnionC<[t.NumberC, t.NullC]>;
                     status: t.StringC;
-                    additionalVerifiedData: t.TypeC<{}>;
+                    additionalVerifiedData: t.UnknownRecordC;
                     vendorData: t.StringC;
                     decisionTime: t.StringC;
                     acceptanceTime: t.StringC;
@@ -197,10 +202,13 @@ export const Request: RequestC = t.brand(
                   t.literal(9121),
                 ]),
               ]),
-              person: t.partial({
-                firstName: t.union([Common_.PersonalName, t.null]),
-                lastName: t.union([Common_.PersonalName, t.null]),
-              }),
+              person: t.intersection([
+                t.partial({
+                  firstName: t.union([Common_.PersonalName, t.null]),
+                  lastName: t.union([Common_.PersonalName, t.null]),
+                }),
+                t.record(t.string, t.unknown),
+              ]),
               document: t.partial({
                 number: t.union([t.string, t.null]),
                 type: PersonalDocument_.DocumentType,
@@ -211,7 +219,7 @@ export const Request: RequestC = t.brand(
               reason: t.string,
               reasonCode: t.union([t.number, t.null]),
               status: t.string,
-              additionalVerifiedData: t.type({}),
+              additionalVerifiedData: t.UnknownRecord,
               vendorData: t.string,
               decisionTime: t.string,
               acceptanceTime: t.string,
@@ -262,7 +270,7 @@ export const Request: RequestC = t.brand(
           person?: {
             firstName?: Common_.PersonalName | null;
             lastName?: Common_.PersonalName | null;
-          };
+          } & Record<string, unknown>;
           document?: {
             number?: string | null;
             type?: PersonalDocument_.DocumentType;
@@ -273,7 +281,7 @@ export const Request: RequestC = t.brand(
           reason?: string;
           reasonCode?: number | null;
           status?: string;
-          additionalVerifiedData?: {};
+          additionalVerifiedData?: Record<string, unknown>;
           vendorData?: string;
           decisionTime?: string;
           acceptanceTime?: string;

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/request.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/request.ts
@@ -41,7 +41,7 @@ export type Request = t.Branded<
       certificate?: string;
       nonce?: string;
       nonceSignature?: string;
-    };
+    } & Record<string, unknown>;
     headers?: ApiCommon_.Headers;
   } & {
     identityId: Defined;
@@ -59,11 +59,16 @@ export type RequestC = t.BrandC<
         identityId: typeof Units_.IdentityId;
         customerId: typeof Units_.IdentityId;
         virtualCardId: t.NumberC;
-        payload: t.PartialC<{
-          certificate: t.StringC;
-          nonce: t.StringC;
-          nonceSignature: t.StringC;
-        }>;
+        payload: t.IntersectionC<
+          [
+            t.PartialC<{
+              certificate: t.StringC;
+              nonce: t.StringC;
+              nonceSignature: t.StringC;
+            }>,
+            t.RecordC<t.StringC, t.UnknownC>,
+          ]
+        >;
         headers: typeof ApiCommon_.Headers;
       }>,
       t.TypeC<{
@@ -83,11 +88,14 @@ export const Request: RequestC = t.brand(
       identityId: Units_.IdentityId,
       customerId: Units_.IdentityId,
       virtualCardId: t.number,
-      payload: t.partial({
-        certificate: t.string,
-        nonce: t.string,
-        nonceSignature: t.string,
-      }),
+      payload: t.intersection([
+        t.partial({
+          certificate: t.string,
+          nonce: t.string,
+          nonceSignature: t.string,
+        }),
+        t.record(t.string, t.unknown),
+      ]),
       headers: ApiCommon_.Headers,
     }),
     t.type({
@@ -109,7 +117,7 @@ export const Request: RequestC = t.brand(
         certificate?: string;
         nonce?: string;
         nonceSignature?: string;
-      };
+      } & Record<string, unknown>;
       headers?: ApiCommon_.Headers;
     } & {
       identityId: Defined;

--- a/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/response.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/virtual-cards/provision/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     virtualCard?: VirtualCard_.VirtualCard;
-    provisionData?: {};
+    provisionData?: Record<string, unknown>;
   } & {
     virtualCard: Defined;
     provisionData: Defined;
@@ -46,7 +46,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         virtualCard: typeof VirtualCard_.VirtualCard;
-        provisionData: t.TypeC<{}>;
+        provisionData: t.UnknownRecordC;
       }>,
       t.TypeC<{
         virtualCard: typeof Defined;
@@ -60,7 +60,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       virtualCard: VirtualCard_.VirtualCard,
-      provisionData: t.type({}),
+      provisionData: t.UnknownRecord,
     }),
     t.type({
       virtualCard: Defined,
@@ -72,7 +72,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       virtualCard?: VirtualCard_.VirtualCard;
-      provisionData?: {};
+      provisionData?: Record<string, unknown>;
     } & {
       virtualCard: Defined;
       provisionData: Defined;

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/response.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-query/response.ts
@@ -35,7 +35,7 @@ export type Response = t.Branded<
   {
     type?: 'FeatureCollection';
     features?: Array<Geolocation_.Feature>;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     type: Defined;
     features: Defined;
@@ -48,7 +48,7 @@ export type ResponseC = t.BrandC<
       t.PartialC<{
         type: t.LiteralC<'FeatureCollection'>;
         features: t.ArrayC<typeof Geolocation_.Feature>;
-        debug: t.TypeC<{}>;
+        debug: t.UnknownRecordC;
       }>,
       t.TypeC<{
         type: typeof Defined;
@@ -63,7 +63,7 @@ export const Response: ResponseC = t.brand(
     t.partial({
       type: t.literal('FeatureCollection'),
       features: t.array(Geolocation_.Feature),
-      debug: t.type({}),
+      debug: t.UnknownRecord,
     }),
     t.type({
       type: Defined,
@@ -76,7 +76,7 @@ export const Response: ResponseC = t.brand(
     {
       type?: 'FeatureCollection';
       features?: Array<Geolocation_.Feature>;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       type: Defined;
       features: Defined;

--- a/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/response.ts
+++ b/maas-schemas-ts/src/maas-backend/geocoding/geocoding-reverse/response.ts
@@ -36,14 +36,14 @@ export type Response = t.Branded<
     type?: 'FeatureCollection';
     features?: Array<
       Geolocation_.Feature & {
-        properties?: {} & {
+        properties?: Record<string, unknown> & {
           city: Defined;
           country: Defined;
           countryCode: Defined;
         };
       }
     >;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     type: Defined;
     features: Defined;
@@ -62,7 +62,7 @@ export type ResponseC = t.BrandC<
               t.PartialC<{
                 properties: t.IntersectionC<
                   [
-                    t.TypeC<{}>,
+                    t.UnknownRecordC,
                     t.TypeC<{
                       city: typeof Defined;
                       country: typeof Defined;
@@ -74,7 +74,7 @@ export type ResponseC = t.BrandC<
             ]
           >
         >;
-        debug: t.TypeC<{}>;
+        debug: t.UnknownRecordC;
       }>,
       t.TypeC<{
         type: typeof Defined;
@@ -93,7 +93,7 @@ export const Response: ResponseC = t.brand(
           Geolocation_.Feature,
           t.partial({
             properties: t.intersection([
-              t.type({}),
+              t.UnknownRecord,
               t.type({
                 city: Defined,
                 country: Defined,
@@ -103,7 +103,7 @@ export const Response: ResponseC = t.brand(
           }),
         ]),
       ),
-      debug: t.type({}),
+      debug: t.UnknownRecord,
     }),
     t.type({
       type: Defined,
@@ -117,14 +117,14 @@ export const Response: ResponseC = t.brand(
       type?: 'FeatureCollection';
       features?: Array<
         Geolocation_.Feature & {
-          properties?: {} & {
+          properties?: Record<string, unknown> & {
             city: Defined;
             country: Defined;
             countryCode: Defined;
           };
         }
       >;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       type: Defined;
       features: Defined;

--- a/maas-schemas-ts/src/maas-backend/invoices/invoiceLineItem.ts
+++ b/maas-schemas-ts/src/maas-backend/invoices/invoiceLineItem.ts
@@ -46,7 +46,7 @@ export type InvoiceLineItem = t.Branded<
     currency?: Units_.Currency;
     referenceInvoiceLineItemId?: InvoiceUnits_.InvoiceLineItemId;
     tokenId?: Fare_.TokenId;
-    token?: {};
+    token?: Record<string, unknown>;
   } & {
     id: Defined;
     gatewayId: Defined;
@@ -84,7 +84,7 @@ export type InvoiceLineItemC = t.BrandC<
         currency: typeof Units_.Currency;
         referenceInvoiceLineItemId: typeof InvoiceUnits_.InvoiceLineItemId;
         tokenId: typeof Fare_.TokenId;
-        token: t.TypeC<{}>;
+        token: t.UnknownRecordC;
       }>,
       t.TypeC<{
         id: typeof Defined;
@@ -120,7 +120,7 @@ export const InvoiceLineItem: InvoiceLineItemC = t.brand(
       currency: Units_.Currency,
       referenceInvoiceLineItemId: InvoiceUnits_.InvoiceLineItemId,
       tokenId: Fare_.TokenId,
-      token: t.type({}),
+      token: t.UnknownRecord,
     }),
     t.type({
       id: Defined,
@@ -146,7 +146,7 @@ export const InvoiceLineItem: InvoiceLineItemC = t.brand(
       currency?: Units_.Currency;
       referenceInvoiceLineItemId?: InvoiceUnits_.InvoiceLineItemId;
       tokenId?: Fare_.TokenId;
-      token?: {};
+      token?: Record<string, unknown>;
     } & {
       id: Defined;
       gatewayId: Defined;

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-list/response.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-list/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     itineraries?: Array<Itinerary_.Itinerary>;
-    maas?: {};
+    maas?: Record<string, unknown>;
   } & {
     itineraries: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         itineraries: t.ArrayC<typeof Itinerary_.Itinerary>;
-        maas: t.TypeC<{}>;
+        maas: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         itineraries: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       itineraries: t.array(Itinerary_.Itinerary),
-      maas: t.type({}),
+      maas: t.record(t.string, t.unknown),
     }),
     t.type({
       itineraries: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       itineraries?: Array<Itinerary_.Itinerary>;
-      maas?: {};
+      maas?: Record<string, unknown>;
     } & {
       itineraries: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/itineraries/itinerary-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/itineraries/itinerary-retrieve/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     itinerary?: Itinerary_.Itinerary;
-    maas?: {};
+    maas?: Record<string, unknown>;
   } & {
     itinerary: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         itinerary: typeof Itinerary_.Itinerary;
-        maas: t.TypeC<{}>;
+        maas: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         itinerary: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       itinerary: Itinerary_.Itinerary,
-      maas: t.type({}),
+      maas: t.record(t.string, t.unknown),
     }),
     t.type({
       itinerary: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       itinerary?: Itinerary_.Itinerary;
-      maas?: {};
+      maas?: Record<string, unknown>;
     } & {
       itinerary: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/products/provider.ts
+++ b/maas-schemas-ts/src/maas-backend/products/provider.ts
@@ -362,7 +362,7 @@ export type Provider = t.Branded<
       PersonalDocumentRequiredItem_.PersonalDocumentRequiredItem
     >;
     optionalParameters?: Array<Selection | MessageToDriver | BookingPeriod>;
-    disruption?: {};
+    disruption?: Record<string, unknown>;
   } & {
     name: Defined;
     agencyId: Defined;
@@ -453,7 +453,7 @@ export type ProviderC = t.BrandC<
         optionalParameters: t.ArrayC<
           t.UnionC<[typeof Selection, typeof MessageToDriver, typeof BookingPeriod]>
         >;
-        disruption: t.TypeC<{}>;
+        disruption: t.UnknownRecordC;
       }>,
       t.TypeC<{
         name: typeof Defined;
@@ -530,7 +530,7 @@ export const Provider: ProviderC = t.brand(
         PersonalDocumentRequiredItem_.PersonalDocumentRequiredItem,
       ),
       optionalParameters: t.array(t.union([Selection, MessageToDriver, BookingPeriod])),
-      disruption: t.type({}),
+      disruption: t.UnknownRecord,
     }),
     t.type({
       name: Defined,
@@ -596,7 +596,7 @@ export const Provider: ProviderC = t.brand(
         PersonalDocumentRequiredItem_.PersonalDocumentRequiredItem
       >;
       optionalParameters?: Array<Selection | MessageToDriver | BookingPeriod>;
-      disruption?: {};
+      disruption?: Record<string, unknown>;
     } & {
       name: Defined;
       agencyId: Defined;

--- a/maas-schemas-ts/src/maas-backend/profile/profile-devices-put/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-devices-put/response.ts
@@ -103,7 +103,7 @@ export interface DeviceBrand {
 export type Response = t.Branded<
   {
     device?: Device;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     device: Defined;
   },
@@ -114,7 +114,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         device: typeof Device;
-        debug: t.TypeC<{}>;
+        debug: t.UnknownRecordC;
       }>,
       t.TypeC<{
         device: typeof Defined;
@@ -127,7 +127,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       device: Device,
-      debug: t.type({}),
+      debug: t.UnknownRecord,
     }),
     t.type({
       device: Defined,
@@ -138,7 +138,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       device?: Device;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       device: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/profile/profile-edit/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-edit/response.ts
@@ -19,28 +19,28 @@ export const schemaId =
 export type Response = t.Branded<
   {
     profile?: Profile_.Profile;
-    debug?: {};
+    debug?: Record<string, unknown>;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
   t.PartialC<{
     profile: typeof Profile_.Profile;
-    debug: t.TypeC<{}>;
+    debug: t.RecordC<t.StringC, t.UnknownC>;
   }>,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
   t.partial({
     profile: Profile_.Profile,
-    debug: t.type({}),
+    debug: t.record(t.string, t.unknown),
   }),
   (
     x,
   ): x is t.Branded<
     {
       profile?: Profile_.Profile;
-      debug?: {};
+      debug?: Record<string, unknown>;
     },
     ResponseBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-add/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-add/response.ts
@@ -19,28 +19,28 @@ export const schemaId =
 export type Response = t.Branded<
   {
     profile?: Profile_.Profile;
-    debug?: {};
+    debug?: Record<string, unknown>;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
   t.PartialC<{
     profile: typeof Profile_.Profile;
-    debug: t.TypeC<{}>;
+    debug: t.RecordC<t.StringC, t.UnknownC>;
   }>,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
   t.partial({
     profile: Profile_.Profile,
-    debug: t.type({}),
+    debug: t.record(t.string, t.unknown),
   }),
   (
     x,
   ): x is t.Branded<
     {
       profile?: Profile_.Profile;
-      debug?: {};
+      debug?: Record<string, unknown>;
     },
     ResponseBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-delete/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-favoriteLocations-delete/response.ts
@@ -19,28 +19,28 @@ export const schemaId =
 export type Response = t.Branded<
   {
     profile?: Profile_.Profile;
-    debug?: {};
+    debug?: Record<string, unknown>;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
   t.PartialC<{
     profile: typeof Profile_.Profile;
-    debug: t.TypeC<{}>;
+    debug: t.RecordC<t.StringC, t.UnknownC>;
   }>,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
   t.partial({
     profile: Profile_.Profile,
-    debug: t.type({}),
+    debug: t.record(t.string, t.unknown),
   }),
   (
     x,
   ): x is t.Branded<
     {
       profile?: Profile_.Profile;
-      debug?: {};
+      debug?: Record<string, unknown>;
     },
     ResponseBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/profile/profile-webhook/response.ts
+++ b/maas-schemas-ts/src/maas-backend/profile/profile-webhook/response.ts
@@ -19,28 +19,28 @@ export const schemaId =
 export type Response = t.Branded<
   {
     profile?: Profile_.Profile;
-    maas?: {};
+    maas?: Record<string, unknown>;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
   t.PartialC<{
     profile: typeof Profile_.Profile;
-    maas: t.TypeC<{}>;
+    maas: t.RecordC<t.StringC, t.UnknownC>;
   }>,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
   t.partial({
     profile: Profile_.Profile,
-    maas: t.type({}),
+    maas: t.record(t.string, t.unknown),
   }),
   (
     x,
   ): x is t.Branded<
     {
       profile?: Profile_.Profile;
-      maas?: {};
+      maas?: Record<string, unknown>;
     },
     ResponseBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/push-notification/request.ts
+++ b/maas-schemas-ts/src/maas-backend/push-notification/request.ts
@@ -47,26 +47,26 @@ export type Request = t.Branded<
       | 'VerificationUpdate'
       | 'AuthRequired';
     data?:
-      | ({
+      | (({
           objectType?: 'Itinerary' | 'Booking';
           ids?: Array<Units_.Uuid>;
-        } & {
+        } & Record<string, unknown>) & {
           objectType: Defined;
           ids: Defined;
         })
       | null
       | string
-      | ({
+      | (({
           objectType?: 'Profile' | 'Subscription';
           ids?: Array<Units_.IdentityId>;
-        } & {
+        } & Record<string, unknown>) & {
           objectType: Defined;
           ids: Defined;
         })
-      | ({
+      | (({
           objectType?: 'Reminder';
           authUrl?: Units_.Url;
-        } & {
+        } & Record<string, unknown>) & {
           objectType: Defined;
           authUrl: Defined;
         });
@@ -104,10 +104,17 @@ export type RequestC = t.BrandC<
           [
             t.IntersectionC<
               [
-                t.PartialC<{
-                  objectType: t.UnionC<[t.LiteralC<'Itinerary'>, t.LiteralC<'Booking'>]>;
-                  ids: t.ArrayC<typeof Units_.Uuid>;
-                }>,
+                t.IntersectionC<
+                  [
+                    t.PartialC<{
+                      objectType: t.UnionC<
+                        [t.LiteralC<'Itinerary'>, t.LiteralC<'Booking'>]
+                      >;
+                      ids: t.ArrayC<typeof Units_.Uuid>;
+                    }>,
+                    t.RecordC<t.StringC, t.UnknownC>,
+                  ]
+                >,
                 t.TypeC<{
                   objectType: typeof Defined;
                   ids: typeof Defined;
@@ -118,12 +125,17 @@ export type RequestC = t.BrandC<
             t.StringC,
             t.IntersectionC<
               [
-                t.PartialC<{
-                  objectType: t.UnionC<
-                    [t.LiteralC<'Profile'>, t.LiteralC<'Subscription'>]
-                  >;
-                  ids: t.ArrayC<typeof Units_.IdentityId>;
-                }>,
+                t.IntersectionC<
+                  [
+                    t.PartialC<{
+                      objectType: t.UnionC<
+                        [t.LiteralC<'Profile'>, t.LiteralC<'Subscription'>]
+                      >;
+                      ids: t.ArrayC<typeof Units_.IdentityId>;
+                    }>,
+                    t.RecordC<t.StringC, t.UnknownC>,
+                  ]
+                >,
                 t.TypeC<{
                   objectType: typeof Defined;
                   ids: typeof Defined;
@@ -132,10 +144,15 @@ export type RequestC = t.BrandC<
             >,
             t.IntersectionC<
               [
-                t.PartialC<{
-                  objectType: t.LiteralC<'Reminder'>;
-                  authUrl: typeof Units_.Url;
-                }>,
+                t.IntersectionC<
+                  [
+                    t.PartialC<{
+                      objectType: t.LiteralC<'Reminder'>;
+                      authUrl: typeof Units_.Url;
+                    }>,
+                    t.RecordC<t.StringC, t.UnknownC>,
+                  ]
+                >,
                 t.TypeC<{
                   objectType: typeof Defined;
                   authUrl: typeof Defined;
@@ -178,10 +195,13 @@ export const Request: RequestC = t.brand(
       ]),
       data: t.union([
         t.intersection([
-          t.partial({
-            objectType: t.union([t.literal('Itinerary'), t.literal('Booking')]),
-            ids: t.array(Units_.Uuid),
-          }),
+          t.intersection([
+            t.partial({
+              objectType: t.union([t.literal('Itinerary'), t.literal('Booking')]),
+              ids: t.array(Units_.Uuid),
+            }),
+            t.record(t.string, t.unknown),
+          ]),
           t.type({
             objectType: Defined,
             ids: Defined,
@@ -190,20 +210,26 @@ export const Request: RequestC = t.brand(
         t.null,
         t.string,
         t.intersection([
-          t.partial({
-            objectType: t.union([t.literal('Profile'), t.literal('Subscription')]),
-            ids: t.array(Units_.IdentityId),
-          }),
+          t.intersection([
+            t.partial({
+              objectType: t.union([t.literal('Profile'), t.literal('Subscription')]),
+              ids: t.array(Units_.IdentityId),
+            }),
+            t.record(t.string, t.unknown),
+          ]),
           t.type({
             objectType: Defined,
             ids: Defined,
           }),
         ]),
         t.intersection([
-          t.partial({
-            objectType: t.literal('Reminder'),
-            authUrl: Units_.Url,
-          }),
+          t.intersection([
+            t.partial({
+              objectType: t.literal('Reminder'),
+              authUrl: Units_.Url,
+            }),
+            t.record(t.string, t.unknown),
+          ]),
           t.type({
             objectType: Defined,
             authUrl: Defined,
@@ -236,26 +262,26 @@ export const Request: RequestC = t.brand(
         | 'VerificationUpdate'
         | 'AuthRequired';
       data?:
-        | ({
+        | (({
             objectType?: 'Itinerary' | 'Booking';
             ids?: Array<Units_.Uuid>;
-          } & {
+          } & Record<string, unknown>) & {
             objectType: Defined;
             ids: Defined;
           })
         | null
         | string
-        | ({
+        | (({
             objectType?: 'Profile' | 'Subscription';
             ids?: Array<Units_.IdentityId>;
-          } & {
+          } & Record<string, unknown>) & {
             objectType: Defined;
             ids: Defined;
           })
-        | ({
+        | (({
             objectType?: 'Reminder';
             authUrl?: Units_.Url;
-          } & {
+          } & Record<string, unknown>) & {
             objectType: Defined;
             authUrl: Defined;
           });

--- a/maas-schemas-ts/src/maas-backend/push-notification/response.ts
+++ b/maas-schemas-ts/src/maas-backend/push-notification/response.ts
@@ -35,6 +35,9 @@ export type Response = t.Branded<
   {
     identityId?: Units_.IdentityId;
     results?: {
+      successCount?: number;
+      failureCount?: number;
+    } & {
       successCount: Defined;
       failureCount: Defined;
     };
@@ -49,10 +52,18 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         identityId: typeof Units_.IdentityId;
-        results: t.TypeC<{
-          successCount: typeof Defined;
-          failureCount: typeof Defined;
-        }>;
+        results: t.IntersectionC<
+          [
+            t.PartialC<{
+              successCount: t.NumberC;
+              failureCount: t.NumberC;
+            }>,
+            t.TypeC<{
+              successCount: typeof Defined;
+              failureCount: typeof Defined;
+            }>,
+          ]
+        >;
       }>,
       t.TypeC<{
         identityId: typeof Defined;
@@ -66,10 +77,16 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       identityId: Units_.IdentityId,
-      results: t.type({
-        successCount: Defined,
-        failureCount: Defined,
-      }),
+      results: t.intersection([
+        t.partial({
+          successCount: t.number,
+          failureCount: t.number,
+        }),
+        t.type({
+          successCount: Defined,
+          failureCount: Defined,
+        }),
+      ]),
     }),
     t.type({
       identityId: Defined,
@@ -82,6 +99,9 @@ export const Response: ResponseC = t.brand(
     {
       identityId?: Units_.IdentityId;
       results?: {
+        successCount?: number;
+        failureCount?: number;
+      } & {
         successCount: Defined;
         failureCount: Defined;
       };

--- a/maas-schemas-ts/src/maas-backend/regions/regions-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/regions/regions-options/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     options?: Array<Region_.Region>;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     options: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         options: t.ArrayC<typeof Region_.Region>;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         options: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       options: t.array(Region_.Region),
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       options: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       options?: Array<Region_.Region>;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       options: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/routes/routes-query/request.ts
+++ b/maas-schemas-ts/src/maas-backend/routes/routes-query/request.ts
@@ -52,7 +52,7 @@ export type Payload = t.Branded<
     modes?: string &
       ('PUBLIC_TRANSIT' | 'TAXI' | 'CAR' | 'WALK' | 'BICYCLE' | 'BICYCLE_RENT');
     transitMode?: string & ('TRAIN' | 'BUS' | 'SUBWAY' | 'TRAM' | 'RAIL');
-    options?: {};
+    options?: Record<string, unknown>;
     bookingIdToExtend?: Units_.Uuid;
   } & Record<
     string,
@@ -70,7 +70,7 @@ export type Payload = t.Branded<
     | Units_.Time
     | (string & ('PUBLIC_TRANSIT' | 'TAXI' | 'CAR' | 'WALK' | 'BICYCLE' | 'BICYCLE_RENT'))
     | (string & ('TRAIN' | 'BUS' | 'SUBWAY' | 'TRAM' | 'RAIL'))
-    | {}
+    | Record<string, unknown>
     | Units_.Uuid
     | (string | number | boolean)
   >) & {
@@ -126,7 +126,7 @@ export type PayloadC = t.BrandC<
                 >,
               ]
             >;
-            options: t.TypeC<{}>;
+            options: t.UnknownRecordC;
             bookingIdToExtend: typeof Units_.Uuid;
           }>,
           t.RecordC<
@@ -174,7 +174,7 @@ export type PayloadC = t.BrandC<
                     >,
                   ]
                 >,
-                t.TypeC<{}>,
+                t.UnknownRecordC,
                 typeof Units_.Uuid,
                 t.UnionC<[t.StringC, t.NumberC, t.BooleanC]>,
               ]
@@ -227,7 +227,7 @@ export const Payload: PayloadC = t.brand(
             t.literal('RAIL'),
           ]),
         ]),
-        options: t.type({}),
+        options: t.UnknownRecord,
         bookingIdToExtend: Units_.Uuid,
       }),
       t.record(
@@ -266,7 +266,7 @@ export const Payload: PayloadC = t.brand(
               t.literal('RAIL'),
             ]),
           ]),
-          t.type({}),
+          t.UnknownRecord,
           Units_.Uuid,
           t.union([t.string, t.number, t.boolean]),
         ]),
@@ -296,7 +296,7 @@ export const Payload: PayloadC = t.brand(
       modes?: string &
         ('PUBLIC_TRANSIT' | 'TAXI' | 'CAR' | 'WALK' | 'BICYCLE' | 'BICYCLE_RENT');
       transitMode?: string & ('TRAIN' | 'BUS' | 'SUBWAY' | 'TRAM' | 'RAIL');
-      options?: {};
+      options?: Record<string, unknown>;
       bookingIdToExtend?: Units_.Uuid;
     } & Record<
       string,
@@ -315,7 +315,7 @@ export const Payload: PayloadC = t.brand(
       | (string &
           ('PUBLIC_TRANSIT' | 'TAXI' | 'CAR' | 'WALK' | 'BICYCLE' | 'BICYCLE_RENT'))
       | (string & ('TRAIN' | 'BUS' | 'SUBWAY' | 'TRAM' | 'RAIL'))
-      | {}
+      | Record<string, unknown>
       | Units_.Uuid
       | (string | number | boolean)
     >) & {

--- a/maas-schemas-ts/src/maas-backend/routes/routes-query/response.ts
+++ b/maas-schemas-ts/src/maas-backend/routes/routes-query/response.ts
@@ -9,6 +9,8 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 */
 
 import * as t from 'io-ts';
+import * as Plan_ from '../../../core/plan';
+import * as Errors_ from '../../../core/components/errors';
 
 export type Defined = {} | null;
 export class DefinedType extends t.Type<Defined> {
@@ -32,24 +34,48 @@ export const schemaId =
 // The default export. More information at the top.
 export type Response = t.Branded<
   {
+    plan?: Plan_.Plan;
+    reasons?: Array<Errors_.Reason>;
+    debug?: Record<string, unknown>;
+  } & {
     plan: Defined;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
-  t.TypeC<{
-    plan: typeof Defined;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        plan: typeof Plan_.Plan;
+        reasons: t.ArrayC<typeof Errors_.Reason>;
+        debug: t.UnknownRecordC;
+      }>,
+      t.TypeC<{
+        plan: typeof Defined;
+      }>,
+    ]
+  >,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
-  t.type({
-    plan: Defined,
-  }),
+  t.intersection([
+    t.partial({
+      plan: Plan_.Plan,
+      reasons: t.array(Errors_.Reason),
+      debug: t.UnknownRecord,
+    }),
+    t.type({
+      plan: Defined,
+    }),
+  ]),
   (
     x,
   ): x is t.Branded<
     {
+      plan?: Plan_.Plan;
+      reasons?: Array<Errors_.Reason>;
+      debug?: Record<string, unknown>;
+    } & {
       plan: Defined;
     },
     ResponseBrand

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscription.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscription.ts
@@ -65,12 +65,12 @@ export interface PriceBrand {
 // Plan
 // Customer subscription plan
 export type Plan = t.Branded<
-  {
+  ({
     id?: SubscriptionItemId;
     name?: string;
     description?: string;
     price?: Price;
-  } & {
+  } & Record<string, unknown>) & {
     id: Defined;
   },
   PlanBrand
@@ -78,12 +78,17 @@ export type Plan = t.Branded<
 export type PlanC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        id: typeof SubscriptionItemId;
-        name: t.StringC;
-        description: t.StringC;
-        price: typeof Price;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            id: typeof SubscriptionItemId;
+            name: t.StringC;
+            description: t.StringC;
+            price: typeof Price;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         id: typeof Defined;
       }>,
@@ -93,12 +98,15 @@ export type PlanC = t.BrandC<
 >;
 export const Plan: PlanC = t.brand(
   t.intersection([
-    t.partial({
-      id: SubscriptionItemId,
-      name: t.string,
-      description: t.string,
-      price: Price,
-    }),
+    t.intersection([
+      t.partial({
+        id: SubscriptionItemId,
+        name: t.string,
+        description: t.string,
+        price: Price,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       id: Defined,
     }),
@@ -106,12 +114,12 @@ export const Plan: PlanC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       id?: SubscriptionItemId;
       name?: string;
       description?: string;
       price?: Price;
-    } & {
+    } & Record<string, unknown>) & {
       id: Defined;
     },
     PlanBrand
@@ -125,14 +133,14 @@ export interface PlanBrand {
 // Addon
 // Customer subscription add-ons
 export type Addon = t.Branded<
-  {
+  ({
     id?: SubscriptionItemId;
     name?: string;
     description?: string;
     quantity?: number;
     unitPrice?: Price;
     image?: Units_.Url;
-  } & {
+  } & Record<string, unknown>) & {
     id: Defined;
     quantity: Defined;
   },
@@ -141,14 +149,19 @@ export type Addon = t.Branded<
 export type AddonC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        id: typeof SubscriptionItemId;
-        name: t.StringC;
-        description: t.StringC;
-        quantity: t.NumberC;
-        unitPrice: typeof Price;
-        image: typeof Units_.Url;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            id: typeof SubscriptionItemId;
+            name: t.StringC;
+            description: t.StringC;
+            quantity: t.NumberC;
+            unitPrice: typeof Price;
+            image: typeof Units_.Url;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         id: typeof Defined;
         quantity: typeof Defined;
@@ -159,14 +172,17 @@ export type AddonC = t.BrandC<
 >;
 export const Addon: AddonC = t.brand(
   t.intersection([
-    t.partial({
-      id: SubscriptionItemId,
-      name: t.string,
-      description: t.string,
-      quantity: t.number,
-      unitPrice: Price,
-      image: Units_.Url,
-    }),
+    t.intersection([
+      t.partial({
+        id: SubscriptionItemId,
+        name: t.string,
+        description: t.string,
+        quantity: t.number,
+        unitPrice: Price,
+        image: Units_.Url,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       id: Defined,
       quantity: Defined,
@@ -175,14 +191,14 @@ export const Addon: AddonC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       id?: SubscriptionItemId;
       name?: string;
       description?: string;
       quantity?: number;
       unitPrice?: Price;
       image?: Units_.Url;
-    } & {
+    } & Record<string, unknown>) & {
       id: Defined;
       quantity: Defined;
     },
@@ -355,10 +371,10 @@ export type SubscriptionBase = t.Branded<
     pointCost?: PointCost_.PointCost;
     region?: Region_.Region;
     shippingAddress?: SubscriptionAddress_.SubscriptionAddress;
-    availability?: {};
+    availability?: Record<string, unknown>;
     name?: string;
     description?: string;
-    meta?: {};
+    meta?: Record<string, unknown>;
     level?: number;
     wmpGrant?: number;
     active?: boolean;
@@ -366,57 +382,65 @@ export type SubscriptionBase = t.Branded<
     selectable?: boolean;
     topUpId?: string;
     changeState?: SubscriptionChangeState_.SubscriptionChangeState;
-  },
+  } & Record<string, unknown>,
   SubscriptionBaseBrand
 >;
 export type SubscriptionBaseC = t.BrandC<
-  t.PartialC<{
-    id: typeof Contact_.IdentityId;
-    customerId: typeof Contact_.IdentityId;
-    plan: typeof Plan;
-    addons: t.ArrayC<typeof Addon>;
-    coupons: t.ArrayC<typeof Coupon>;
-    terms: typeof Terms;
-    pointCost: typeof PointCost_.PointCost;
-    region: typeof Region_.Region;
-    shippingAddress: typeof SubscriptionAddress_.SubscriptionAddress;
-    availability: t.TypeC<{}>;
-    name: t.StringC;
-    description: t.StringC;
-    meta: t.TypeC<{}>;
-    level: t.NumberC;
-    wmpGrant: t.NumberC;
-    active: t.BooleanC;
-    hidden: t.BooleanC;
-    selectable: t.BooleanC;
-    topUpId: t.StringC;
-    changeState: typeof SubscriptionChangeState_.SubscriptionChangeState;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        id: typeof Contact_.IdentityId;
+        customerId: typeof Contact_.IdentityId;
+        plan: typeof Plan;
+        addons: t.ArrayC<typeof Addon>;
+        coupons: t.ArrayC<typeof Coupon>;
+        terms: typeof Terms;
+        pointCost: typeof PointCost_.PointCost;
+        region: typeof Region_.Region;
+        shippingAddress: typeof SubscriptionAddress_.SubscriptionAddress;
+        availability: t.RecordC<t.StringC, t.UnknownC>;
+        name: t.StringC;
+        description: t.StringC;
+        meta: t.RecordC<t.StringC, t.UnknownC>;
+        level: t.NumberC;
+        wmpGrant: t.NumberC;
+        active: t.BooleanC;
+        hidden: t.BooleanC;
+        selectable: t.BooleanC;
+        topUpId: t.StringC;
+        changeState: typeof SubscriptionChangeState_.SubscriptionChangeState;
+      }>,
+      t.RecordC<t.StringC, t.UnknownC>,
+    ]
+  >,
   SubscriptionBaseBrand
 >;
 export const SubscriptionBase: SubscriptionBaseC = t.brand(
-  t.partial({
-    id: Contact_.IdentityId,
-    customerId: Contact_.IdentityId,
-    plan: Plan,
-    addons: t.array(Addon),
-    coupons: t.array(Coupon),
-    terms: Terms,
-    pointCost: PointCost_.PointCost,
-    region: Region_.Region,
-    shippingAddress: SubscriptionAddress_.SubscriptionAddress,
-    availability: t.type({}),
-    name: t.string,
-    description: t.string,
-    meta: t.type({}),
-    level: t.number,
-    wmpGrant: t.number,
-    active: t.boolean,
-    hidden: t.boolean,
-    selectable: t.boolean,
-    topUpId: t.string,
-    changeState: SubscriptionChangeState_.SubscriptionChangeState,
-  }),
+  t.intersection([
+    t.partial({
+      id: Contact_.IdentityId,
+      customerId: Contact_.IdentityId,
+      plan: Plan,
+      addons: t.array(Addon),
+      coupons: t.array(Coupon),
+      terms: Terms,
+      pointCost: PointCost_.PointCost,
+      region: Region_.Region,
+      shippingAddress: SubscriptionAddress_.SubscriptionAddress,
+      availability: t.record(t.string, t.unknown),
+      name: t.string,
+      description: t.string,
+      meta: t.record(t.string, t.unknown),
+      level: t.number,
+      wmpGrant: t.number,
+      active: t.boolean,
+      hidden: t.boolean,
+      selectable: t.boolean,
+      topUpId: t.string,
+      changeState: SubscriptionChangeState_.SubscriptionChangeState,
+    }),
+    t.record(t.string, t.unknown),
+  ]),
   (
     x,
   ): x is t.Branded<
@@ -430,10 +454,10 @@ export const SubscriptionBase: SubscriptionBaseC = t.brand(
       pointCost?: PointCost_.PointCost;
       region?: Region_.Region;
       shippingAddress?: SubscriptionAddress_.SubscriptionAddress;
-      availability?: {};
+      availability?: Record<string, unknown>;
       name?: string;
       description?: string;
-      meta?: {};
+      meta?: Record<string, unknown>;
       level?: number;
       wmpGrant?: number;
       active?: boolean;
@@ -441,7 +465,7 @@ export const SubscriptionBase: SubscriptionBaseC = t.brand(
       selectable?: boolean;
       topUpId?: string;
       changeState?: SubscriptionChangeState_.SubscriptionChangeState;
-    },
+    } & Record<string, unknown>,
     SubscriptionBaseBrand
   > => true,
   'SubscriptionBase',
@@ -453,24 +477,30 @@ export interface SubscriptionBaseBrand {
 // Subscription
 // The purpose of this remains a mystery
 export type Subscription = t.Branded<
-  SubscriptionBase & {
-    plan: Defined;
-    addons: Defined;
-    coupons: Defined;
-    changeState: Defined;
-  },
+  SubscriptionBase &
+    (Record<string, unknown> & {
+      plan: Defined;
+      addons: Defined;
+      coupons: Defined;
+      changeState: Defined;
+    }),
   SubscriptionBrand
 >;
 export type SubscriptionC = t.BrandC<
   t.IntersectionC<
     [
       typeof SubscriptionBase,
-      t.TypeC<{
-        plan: typeof Defined;
-        addons: typeof Defined;
-        coupons: typeof Defined;
-        changeState: typeof Defined;
-      }>,
+      t.IntersectionC<
+        [
+          t.RecordC<t.StringC, t.UnknownC>,
+          t.TypeC<{
+            plan: typeof Defined;
+            addons: typeof Defined;
+            coupons: typeof Defined;
+            changeState: typeof Defined;
+          }>,
+        ]
+      >,
     ]
   >,
   SubscriptionBrand
@@ -478,22 +508,26 @@ export type SubscriptionC = t.BrandC<
 export const Subscription: SubscriptionC = t.brand(
   t.intersection([
     SubscriptionBase,
-    t.type({
-      plan: Defined,
-      addons: Defined,
-      coupons: Defined,
-      changeState: Defined,
-    }),
+    t.intersection([
+      t.record(t.string, t.unknown),
+      t.type({
+        plan: Defined,
+        addons: Defined,
+        coupons: Defined,
+        changeState: Defined,
+      }),
+    ]),
   ]),
   (
     x,
   ): x is t.Branded<
-    SubscriptionBase & {
-      plan: Defined;
-      addons: Defined;
-      coupons: Defined;
-      changeState: Defined;
-    },
+    SubscriptionBase &
+      (Record<string, unknown> & {
+        plan: Defined;
+        addons: Defined;
+        coupons: Defined;
+        changeState: Defined;
+      }),
     SubscriptionBrand
   > => true,
   'Subscription',
@@ -505,20 +539,26 @@ export interface SubscriptionBrand {
 // SubscriptionCreatePayload
 // The purpose of this remains a mystery
 export type SubscriptionCreatePayload = t.Branded<
-  SubscriptionBase & {
-    plan: Defined;
-    addons: Defined;
-  },
+  SubscriptionBase &
+    (Record<string, unknown> & {
+      plan: Defined;
+      addons: Defined;
+    }),
   SubscriptionCreatePayloadBrand
 >;
 export type SubscriptionCreatePayloadC = t.BrandC<
   t.IntersectionC<
     [
       typeof SubscriptionBase,
-      t.TypeC<{
-        plan: typeof Defined;
-        addons: typeof Defined;
-      }>,
+      t.IntersectionC<
+        [
+          t.RecordC<t.StringC, t.UnknownC>,
+          t.TypeC<{
+            plan: typeof Defined;
+            addons: typeof Defined;
+          }>,
+        ]
+      >,
     ]
   >,
   SubscriptionCreatePayloadBrand
@@ -526,18 +566,22 @@ export type SubscriptionCreatePayloadC = t.BrandC<
 export const SubscriptionCreatePayload: SubscriptionCreatePayloadC = t.brand(
   t.intersection([
     SubscriptionBase,
-    t.type({
-      plan: Defined,
-      addons: Defined,
-    }),
+    t.intersection([
+      t.record(t.string, t.unknown),
+      t.type({
+        plan: Defined,
+        addons: Defined,
+      }),
+    ]),
   ]),
   (
     x,
   ): x is t.Branded<
-    SubscriptionBase & {
-      plan: Defined;
-      addons: Defined;
-    },
+    SubscriptionBase &
+      (Record<string, unknown> & {
+        plan: Defined;
+        addons: Defined;
+      }),
     SubscriptionCreatePayloadBrand
   > => true,
   'SubscriptionCreatePayload',
@@ -549,16 +593,29 @@ export interface SubscriptionCreatePayloadBrand {
 // SubscriptionUpdatePayload
 // The purpose of this remains a mystery
 export type SubscriptionUpdatePayload = t.Branded<
-  SubscriptionBase & {},
+  SubscriptionBase & (Record<string, unknown> & {}),
   SubscriptionUpdatePayloadBrand
 >;
 export type SubscriptionUpdatePayloadC = t.BrandC<
-  t.IntersectionC<[typeof SubscriptionBase, t.TypeC<{}>]>,
+  t.IntersectionC<
+    [
+      typeof SubscriptionBase,
+      t.IntersectionC<[t.RecordC<t.StringC, t.UnknownC>, t.TypeC<{}>]>,
+    ]
+  >,
   SubscriptionUpdatePayloadBrand
 >;
 export const SubscriptionUpdatePayload: SubscriptionUpdatePayloadC = t.brand(
-  t.intersection([SubscriptionBase, t.type({})]),
-  (x): x is t.Branded<SubscriptionBase & {}, SubscriptionUpdatePayloadBrand> => true,
+  t.intersection([
+    SubscriptionBase,
+    t.intersection([t.record(t.string, t.unknown), t.type({})]),
+  ]),
+  (
+    x,
+  ): x is t.Branded<
+    SubscriptionBase & (Record<string, unknown> & {}),
+    SubscriptionUpdatePayloadBrand
+  > => true,
   'SubscriptionUpdatePayload',
 );
 export interface SubscriptionUpdatePayloadBrand {

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionOption.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptionOption.ts
@@ -35,13 +35,13 @@ export const schemaId =
 // SubscriptionAdditions
 // The purpose of this remains a mystery
 export type SubscriptionAdditions = t.Branded<
-  {
+  ({
     discounts?: Array<unknown>;
     requiredAuthorizations?: Array<Common_.AgencyId>;
     regionDefault?: boolean;
     personalDataCreateAllow?: Array<PersonalDataAllowItem_.PersonalDataAllowItem>;
     personalDataValidations?: Array<PersonalDataValidation_.PersonalDataValidation>;
-  } & {
+  } & Record<string, unknown>) & {
     plan: Defined;
     wmpGrant: Defined;
     pointCost: Defined;
@@ -55,17 +55,22 @@ export type SubscriptionAdditions = t.Branded<
 export type SubscriptionAdditionsC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        discounts: t.UnknownArrayC;
-        requiredAuthorizations: t.ArrayC<typeof Common_.AgencyId>;
-        regionDefault: t.BooleanC;
-        personalDataCreateAllow: t.ArrayC<
-          typeof PersonalDataAllowItem_.PersonalDataAllowItem
-        >;
-        personalDataValidations: t.ArrayC<
-          typeof PersonalDataValidation_.PersonalDataValidation
-        >;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            discounts: t.UnknownArrayC;
+            requiredAuthorizations: t.ArrayC<typeof Common_.AgencyId>;
+            regionDefault: t.BooleanC;
+            personalDataCreateAllow: t.ArrayC<
+              typeof PersonalDataAllowItem_.PersonalDataAllowItem
+            >;
+            personalDataValidations: t.ArrayC<
+              typeof PersonalDataValidation_.PersonalDataValidation
+            >;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         plan: typeof Defined;
         wmpGrant: typeof Defined;
@@ -81,13 +86,16 @@ export type SubscriptionAdditionsC = t.BrandC<
 >;
 export const SubscriptionAdditions: SubscriptionAdditionsC = t.brand(
   t.intersection([
-    t.partial({
-      discounts: t.UnknownArray,
-      requiredAuthorizations: t.array(Common_.AgencyId),
-      regionDefault: t.boolean,
-      personalDataCreateAllow: t.array(PersonalDataAllowItem_.PersonalDataAllowItem),
-      personalDataValidations: t.array(PersonalDataValidation_.PersonalDataValidation),
-    }),
+    t.intersection([
+      t.partial({
+        discounts: t.UnknownArray,
+        requiredAuthorizations: t.array(Common_.AgencyId),
+        regionDefault: t.boolean,
+        personalDataCreateAllow: t.array(PersonalDataAllowItem_.PersonalDataAllowItem),
+        personalDataValidations: t.array(PersonalDataValidation_.PersonalDataValidation),
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       plan: Defined,
       wmpGrant: Defined,
@@ -101,13 +109,13 @@ export const SubscriptionAdditions: SubscriptionAdditionsC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       discounts?: Array<unknown>;
       requiredAuthorizations?: Array<Common_.AgencyId>;
       regionDefault?: boolean;
       personalDataCreateAllow?: Array<PersonalDataAllowItem_.PersonalDataAllowItem>;
       personalDataValidations?: Array<PersonalDataValidation_.PersonalDataValidation>;
-    } & {
+    } & Record<string, unknown>) & {
       plan: Defined;
       wmpGrant: Defined;
       pointCost: Defined;

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-create/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     subscription?: Subscription_.Subscription;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     subscription: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         subscription: typeof Subscription_.Subscription;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         subscription: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       subscription: Subscription_.Subscription,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       subscription: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       subscription?: Subscription_.Subscription;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       subscription: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-estimate/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-estimate/response.ts
@@ -35,7 +35,7 @@ export type Response = t.Branded<
   {
     estimate?: Pricing_.Pricing;
     immediateUpdate?: boolean;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     estimate: Defined;
   },
@@ -47,7 +47,7 @@ export type ResponseC = t.BrandC<
       t.PartialC<{
         estimate: typeof Pricing_.Pricing;
         immediateUpdate: t.BooleanC;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         estimate: typeof Defined;
@@ -61,7 +61,7 @@ export const Response: ResponseC = t.brand(
     t.partial({
       estimate: Pricing_.Pricing,
       immediateUpdate: t.boolean,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       estimate: Defined,
@@ -73,7 +73,7 @@ export const Response: ResponseC = t.brand(
     {
       estimate?: Pricing_.Pricing;
       immediateUpdate?: boolean;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       estimate: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-intents-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-intents-create/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     subscriptionIntent?: SubscriptionIntent_.SubscriptionIntentBase;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     subscriptionIntent: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         subscriptionIntent: typeof SubscriptionIntent_.SubscriptionIntentBase;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         subscriptionIntent: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       subscriptionIntent: SubscriptionIntent_.SubscriptionIntentBase,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       subscriptionIntent: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       subscriptionIntent?: SubscriptionIntent_.SubscriptionIntentBase;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       subscriptionIntent: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-options/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-options/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     options?: Array<SubscriptionOption_.SubscriptionOption>;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     options: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         options: t.ArrayC<typeof SubscriptionOption_.SubscriptionOption>;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         options: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       options: t.array(SubscriptionOption_.SubscriptionOption),
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       options: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       options?: Array<SubscriptionOption_.SubscriptionOption>;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       options: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/request.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/request.ts
@@ -37,7 +37,7 @@ export type Request = t.Branded<
     identityId?: Units_.IdentityId;
     userId?: Units_.IdentityId;
     nextPeriod?: boolean;
-    payload?: {};
+    payload?: Record<string, unknown>;
     headers?: ApiCommon_.Headers;
   } & {
     identityId: Defined;
@@ -52,7 +52,7 @@ export type RequestC = t.BrandC<
         identityId: typeof Units_.IdentityId;
         userId: typeof Units_.IdentityId;
         nextPeriod: t.BooleanC;
-        payload: t.TypeC<{}>;
+        payload: t.UnknownRecordC;
         headers: typeof ApiCommon_.Headers;
       }>,
       t.TypeC<{
@@ -69,7 +69,7 @@ export const Request: RequestC = t.brand(
       identityId: Units_.IdentityId,
       userId: Units_.IdentityId,
       nextPeriod: t.boolean,
-      payload: t.type({}),
+      payload: t.UnknownRecord,
       headers: ApiCommon_.Headers,
     }),
     t.type({
@@ -84,7 +84,7 @@ export const Request: RequestC = t.brand(
       identityId?: Units_.IdentityId;
       userId?: Units_.IdentityId;
       nextPeriod?: boolean;
-      payload?: {};
+      payload?: Record<string, unknown>;
       headers?: ApiCommon_.Headers;
     } & {
       identityId: Defined;

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-retrieve/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     subscription?: Subscription_.Subscription;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     subscription: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         subscription: typeof Subscription_.Subscription;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         subscription: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       subscription: Subscription_.Subscription,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       subscription: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       subscription?: Subscription_.Subscription;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       subscription: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-scheduled-change-delete/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-scheduled-change-delete/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     subscription?: Subscription_.Subscription;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     subscription: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         subscription: typeof Subscription_.Subscription;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         subscription: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       subscription: Subscription_.Subscription,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       subscription: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       subscription?: Subscription_.Subscription;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       subscription: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-update/response.ts
+++ b/maas-schemas-ts/src/maas-backend/subscriptions/subscriptions-update/response.ts
@@ -35,7 +35,7 @@ export type Response = t.Branded<
   {
     subscription?: Subscription_.Subscription;
     immediateUpdate?: boolean;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     subscription: Defined;
   },
@@ -47,7 +47,7 @@ export type ResponseC = t.BrandC<
       t.PartialC<{
         subscription: typeof Subscription_.Subscription;
         immediateUpdate: t.BooleanC;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         subscription: typeof Defined;
@@ -61,7 +61,7 @@ export const Response: ResponseC = t.brand(
     t.partial({
       subscription: Subscription_.Subscription,
       immediateUpdate: t.boolean,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       subscription: Defined,
@@ -73,7 +73,7 @@ export const Response: ResponseC = t.brand(
     {
       subscription?: Subscription_.Subscription;
       immediateUpdate?: boolean;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       subscription: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/tsp-auth/validate/request.ts
+++ b/maas-schemas-ts/src/maas-backend/tsp-auth/validate/request.ts
@@ -25,7 +25,7 @@ export type Request = t.Branded<
       state?: Common_.EncodedQueryParam;
       error?: Common_.ErrorKey;
     };
-    headers?: {};
+    headers?: Record<string, unknown>;
   },
   RequestBrand
 >;
@@ -38,7 +38,7 @@ export type RequestC = t.BrandC<
       state: typeof Common_.EncodedQueryParam;
       error: typeof Common_.ErrorKey;
     }>;
-    headers: t.TypeC<{}>;
+    headers: t.RecordC<t.StringC, t.UnknownC>;
   }>,
   RequestBrand
 >;
@@ -51,7 +51,7 @@ export const Request: RequestC = t.brand(
       state: Common_.EncodedQueryParam,
       error: Common_.ErrorKey,
     }),
-    headers: t.type({}),
+    headers: t.record(t.string, t.unknown),
   }),
   (
     x,
@@ -64,7 +64,7 @@ export const Request: RequestC = t.brand(
         state?: Common_.EncodedQueryParam;
         error?: Common_.ErrorKey;
       };
-      headers?: {};
+      headers?: Record<string, unknown>;
     },
     RequestBrand
   > => true,

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-create/response.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-bookings-create/response.ts
@@ -34,7 +34,7 @@ export const schemaId =
 export type Response = t.Branded<
   {
     booking?: Booking_.Booking;
-    debug?: {};
+    debug?: Record<string, unknown>;
   } & {
     booking: Defined;
   },
@@ -45,7 +45,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         booking: typeof Booking_.Booking;
-        debug: t.TypeC<{}>;
+        debug: t.RecordC<t.StringC, t.UnknownC>;
       }>,
       t.TypeC<{
         booking: typeof Defined;
@@ -58,7 +58,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       booking: Booking_.Booking,
-      debug: t.type({}),
+      debug: t.record(t.string, t.unknown),
     }),
     t.type({
       booking: Defined,
@@ -69,7 +69,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       booking?: Booking_.Booking;
-      debug?: {};
+      debug?: Record<string, unknown>;
     } & {
       booking: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/gateway/avainpay.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/gateway/avainpay.ts
@@ -32,7 +32,7 @@ export const schemaId =
 // The purpose of this remains a mystery
 export type Request = t.Branded<
   {
-    payload?: {
+    payload?: ({
       action_str?: string;
       data_type?: string;
       log_list?: Array<unknown>;
@@ -41,8 +41,8 @@ export type Request = t.Branded<
         nonce?: string;
         signature?: string;
       };
-      request_map?: {};
-    } & {
+      request_map?: Record<string, unknown>;
+    } & Record<string, unknown>) & {
       action_str: Defined;
       data_type: Defined;
     };
@@ -66,17 +66,22 @@ export type RequestC = t.BrandC<
       t.PartialC<{
         payload: t.IntersectionC<
           [
-            t.PartialC<{
-              action_str: t.StringC;
-              data_type: t.StringC;
-              log_list: t.UnknownArrayC;
-              trans_map: t.PartialC<{
-                system_time: t.NumberC;
-                nonce: t.StringC;
-                signature: t.StringC;
-              }>;
-              request_map: t.TypeC<{}>;
-            }>,
+            t.IntersectionC<
+              [
+                t.PartialC<{
+                  action_str: t.StringC;
+                  data_type: t.StringC;
+                  log_list: t.UnknownArrayC;
+                  trans_map: t.PartialC<{
+                    system_time: t.NumberC;
+                    nonce: t.StringC;
+                    signature: t.StringC;
+                  }>;
+                  request_map: t.UnknownRecordC;
+                }>,
+                t.RecordC<t.StringC, t.UnknownC>,
+              ]
+            >,
             t.TypeC<{
               action_str: typeof Defined;
               data_type: typeof Defined;
@@ -109,17 +114,20 @@ export const Request: RequestC = t.brand(
   t.intersection([
     t.partial({
       payload: t.intersection([
-        t.partial({
-          action_str: t.string,
-          data_type: t.string,
-          log_list: t.UnknownArray,
-          trans_map: t.partial({
-            system_time: t.number,
-            nonce: t.string,
-            signature: t.string,
+        t.intersection([
+          t.partial({
+            action_str: t.string,
+            data_type: t.string,
+            log_list: t.UnknownArray,
+            trans_map: t.partial({
+              system_time: t.number,
+              nonce: t.string,
+              signature: t.string,
+            }),
+            request_map: t.UnknownRecord,
           }),
-          request_map: t.type({}),
-        }),
+          t.record(t.string, t.unknown),
+        ]),
         t.type({
           action_str: Defined,
           data_type: Defined,
@@ -146,7 +154,7 @@ export const Request: RequestC = t.brand(
     x,
   ): x is t.Branded<
     {
-      payload?: {
+      payload?: ({
         action_str?: string;
         data_type?: string;
         log_list?: Array<unknown>;
@@ -155,8 +163,8 @@ export const Request: RequestC = t.brand(
           nonce?: string;
           signature?: string;
         };
-        request_map?: {};
-      } & {
+        request_map?: Record<string, unknown>;
+      } & Record<string, unknown>) & {
         action_str: Defined;
         data_type: Defined;
       };

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/gateway/stripe.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/gateway/stripe.ts
@@ -32,7 +32,7 @@ export const schemaId =
 // The purpose of this remains a mystery
 export type Request = t.Branded<
   {
-    payload?: {
+    payload?: ({
       id?: string;
       type?: string;
       data?: {
@@ -51,7 +51,7 @@ export type Request = t.Branded<
           };
         };
       };
-    } & {
+    } & Record<string, unknown>) & {
       type: Defined;
       id: Defined;
       data: Defined;
@@ -73,28 +73,33 @@ export type RequestC = t.BrandC<
       t.PartialC<{
         payload: t.IntersectionC<
           [
-            t.PartialC<{
-              id: t.StringC;
-              type: t.StringC;
-              data: t.PartialC<{
-                object: t.PartialC<{
+            t.IntersectionC<
+              [
+                t.PartialC<{
                   id: t.StringC;
-                  amount: t.NumberC;
-                  amount_capturable: t.NumberC;
-                  amount_received: t.NumberC;
-                  charges: t.PartialC<{
-                    data: t.ArrayC<
-                      t.PartialC<{
-                        id: t.StringC;
-                        object: t.StringC;
-                        amount: t.NumberC;
-                        amount_refunded: t.NumberC;
-                      }>
-                    >;
+                  type: t.StringC;
+                  data: t.PartialC<{
+                    object: t.PartialC<{
+                      id: t.StringC;
+                      amount: t.NumberC;
+                      amount_capturable: t.NumberC;
+                      amount_received: t.NumberC;
+                      charges: t.PartialC<{
+                        data: t.ArrayC<
+                          t.PartialC<{
+                            id: t.StringC;
+                            object: t.StringC;
+                            amount: t.NumberC;
+                            amount_refunded: t.NumberC;
+                          }>
+                        >;
+                      }>;
+                    }>;
                   }>;
-                }>;
-              }>;
-            }>,
+                }>,
+                t.RecordC<t.StringC, t.UnknownC>,
+              ]
+            >,
             t.TypeC<{
               type: typeof Defined;
               id: typeof Defined;
@@ -125,28 +130,31 @@ export const Request: RequestC = t.brand(
   t.intersection([
     t.partial({
       payload: t.intersection([
-        t.partial({
-          id: t.string,
-          type: t.string,
-          data: t.partial({
-            object: t.partial({
-              id: t.string,
-              amount: t.number,
-              amount_capturable: t.number,
-              amount_received: t.number,
-              charges: t.partial({
-                data: t.array(
-                  t.partial({
-                    id: t.string,
-                    object: t.string,
-                    amount: t.number,
-                    amount_refunded: t.number,
-                  }),
-                ),
+        t.intersection([
+          t.partial({
+            id: t.string,
+            type: t.string,
+            data: t.partial({
+              object: t.partial({
+                id: t.string,
+                amount: t.number,
+                amount_capturable: t.number,
+                amount_received: t.number,
+                charges: t.partial({
+                  data: t.array(
+                    t.partial({
+                      id: t.string,
+                      object: t.string,
+                      amount: t.number,
+                      amount_refunded: t.number,
+                    }),
+                  ),
+                }),
               }),
             }),
           }),
-        }),
+          t.record(t.string, t.unknown),
+        ]),
         t.type({
           type: Defined,
           id: Defined,
@@ -171,7 +179,7 @@ export const Request: RequestC = t.brand(
     x,
   ): x is t.Branded<
     {
-      payload?: {
+      payload?: ({
         id?: string;
         type?: string;
         data?: {
@@ -190,7 +198,7 @@ export const Request: RequestC = t.brand(
             };
           };
         };
-      } & {
+      } & Record<string, unknown>) & {
         type: Defined;
         id: Defined;
         data: Defined;

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/gateway/yaband.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/gateway/yaband.ts
@@ -32,24 +32,24 @@ export const schemaId =
 // The purpose of this remains a mystery
 export type Request = t.Branded<
   {
-    payload?: {
+    payload?: ({
       sign?: string;
-      data?: {
+      data?: ({
         type?: string;
         order_id?: string;
         trade_id?: string;
         transaction_id?: string;
         state?: string;
-      } & {
+      } & Record<string, unknown>) & {
         type: Defined;
         order_id: Defined;
         state: Defined;
       };
-    } & {
+    } & Record<string, unknown>) & {
       sign: Defined;
       data: Defined;
     };
-    headers?: {};
+    headers?: Record<string, unknown>;
     params?: {
       gatewayName?: string & 'yaband';
     } & {
@@ -67,32 +67,42 @@ export type RequestC = t.BrandC<
       t.PartialC<{
         payload: t.IntersectionC<
           [
-            t.PartialC<{
-              sign: t.StringC;
-              data: t.IntersectionC<
-                [
-                  t.PartialC<{
-                    type: t.StringC;
-                    order_id: t.StringC;
-                    trade_id: t.StringC;
-                    transaction_id: t.StringC;
-                    state: t.StringC;
-                  }>,
-                  t.TypeC<{
-                    type: typeof Defined;
-                    order_id: typeof Defined;
-                    state: typeof Defined;
-                  }>,
-                ]
-              >;
-            }>,
+            t.IntersectionC<
+              [
+                t.PartialC<{
+                  sign: t.StringC;
+                  data: t.IntersectionC<
+                    [
+                      t.IntersectionC<
+                        [
+                          t.PartialC<{
+                            type: t.StringC;
+                            order_id: t.StringC;
+                            trade_id: t.StringC;
+                            transaction_id: t.StringC;
+                            state: t.StringC;
+                          }>,
+                          t.RecordC<t.StringC, t.UnknownC>,
+                        ]
+                      >,
+                      t.TypeC<{
+                        type: typeof Defined;
+                        order_id: typeof Defined;
+                        state: typeof Defined;
+                      }>,
+                    ]
+                  >;
+                }>,
+                t.RecordC<t.StringC, t.UnknownC>,
+              ]
+            >,
             t.TypeC<{
               sign: typeof Defined;
               data: typeof Defined;
             }>,
           ]
         >;
-        headers: t.TypeC<{}>;
+        headers: t.UnknownRecordC;
         params: t.IntersectionC<
           [
             t.PartialC<{
@@ -116,29 +126,35 @@ export const Request: RequestC = t.brand(
   t.intersection([
     t.partial({
       payload: t.intersection([
-        t.partial({
-          sign: t.string,
-          data: t.intersection([
-            t.partial({
-              type: t.string,
-              order_id: t.string,
-              trade_id: t.string,
-              transaction_id: t.string,
-              state: t.string,
-            }),
-            t.type({
-              type: Defined,
-              order_id: Defined,
-              state: Defined,
-            }),
-          ]),
-        }),
+        t.intersection([
+          t.partial({
+            sign: t.string,
+            data: t.intersection([
+              t.intersection([
+                t.partial({
+                  type: t.string,
+                  order_id: t.string,
+                  trade_id: t.string,
+                  transaction_id: t.string,
+                  state: t.string,
+                }),
+                t.record(t.string, t.unknown),
+              ]),
+              t.type({
+                type: Defined,
+                order_id: Defined,
+                state: Defined,
+              }),
+            ]),
+          }),
+          t.record(t.string, t.unknown),
+        ]),
         t.type({
           sign: Defined,
           data: Defined,
         }),
       ]),
-      headers: t.type({}),
+      headers: t.UnknownRecord,
       params: t.intersection([
         t.partial({
           gatewayName: t.intersection([t.string, t.literal('yaband')]),
@@ -157,24 +173,24 @@ export const Request: RequestC = t.brand(
     x,
   ): x is t.Branded<
     {
-      payload?: {
+      payload?: ({
         sign?: string;
-        data?: {
+        data?: ({
           type?: string;
           order_id?: string;
           trade_id?: string;
           transaction_id?: string;
           state?: string;
-        } & {
+        } & Record<string, unknown>) & {
           type: Defined;
           order_id: Defined;
           state: Defined;
         };
-      } & {
+      } & Record<string, unknown>) & {
         sign: Defined;
         data: Defined;
       };
-      headers?: {};
+      headers?: Record<string, unknown>;
       params?: {
         gatewayName?: string & 'yaband';
       } & {

--- a/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/response.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/webhooks-payments/response.ts
@@ -31,7 +31,7 @@ export const schemaId =
 // AvainpayResponse
 // The purpose of this remains a mystery
 export type AvainpayResponse = t.Branded<
-  {
+  ({
     action_str?: string;
     data_type?: string;
     log_list?: Array<unknown>;
@@ -40,8 +40,8 @@ export type AvainpayResponse = t.Branded<
       nonce?: string;
       signature?: string;
     };
-    response_map?: {};
-  } & {
+    response_map?: Record<string, unknown>;
+  } & Record<string, unknown>) & {
     action_str: Defined;
     data_type: Defined;
   },
@@ -50,17 +50,22 @@ export type AvainpayResponse = t.Branded<
 export type AvainpayResponseC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        action_str: t.StringC;
-        data_type: t.StringC;
-        log_list: t.UnknownArrayC;
-        trans_map: t.PartialC<{
-          system_time: t.NumberC;
-          nonce: t.StringC;
-          signature: t.StringC;
-        }>;
-        response_map: t.TypeC<{}>;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            action_str: t.StringC;
+            data_type: t.StringC;
+            log_list: t.UnknownArrayC;
+            trans_map: t.PartialC<{
+              system_time: t.NumberC;
+              nonce: t.StringC;
+              signature: t.StringC;
+            }>;
+            response_map: t.UnknownRecordC;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         action_str: typeof Defined;
         data_type: typeof Defined;
@@ -71,17 +76,20 @@ export type AvainpayResponseC = t.BrandC<
 >;
 export const AvainpayResponse: AvainpayResponseC = t.brand(
   t.intersection([
-    t.partial({
-      action_str: t.string,
-      data_type: t.string,
-      log_list: t.UnknownArray,
-      trans_map: t.partial({
-        system_time: t.number,
-        nonce: t.string,
-        signature: t.string,
+    t.intersection([
+      t.partial({
+        action_str: t.string,
+        data_type: t.string,
+        log_list: t.UnknownArray,
+        trans_map: t.partial({
+          system_time: t.number,
+          nonce: t.string,
+          signature: t.string,
+        }),
+        response_map: t.UnknownRecord,
       }),
-      response_map: t.type({}),
-    }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       action_str: Defined,
       data_type: Defined,
@@ -90,7 +98,7 @@ export const AvainpayResponse: AvainpayResponseC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       action_str?: string;
       data_type?: string;
       log_list?: Array<unknown>;
@@ -99,8 +107,8 @@ export const AvainpayResponse: AvainpayResponseC = t.brand(
         nonce?: string;
         signature?: string;
       };
-      response_map?: {};
-    } & {
+      response_map?: Record<string, unknown>;
+    } & Record<string, unknown>) & {
       action_str: Defined;
       data_type: Defined;
     },

--- a/maas-schemas-ts/src/maas-backend/webhooks/zendesk-push-notification/request.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/zendesk-push-notification/request.ts
@@ -9,6 +9,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 */
 
 import * as t from 'io-ts';
+import * as Common_ from '../../../core/components/common';
 
 export type Defined = {} | null;
 export class DefinedType extends t.Type<Defined> {
@@ -32,10 +33,15 @@ export const schemaId =
 // The default export. More information at the top.
 export type Request = t.Branded<
   {
-    devices?: Array<{
-      identifier: Defined;
-      type: Defined;
-    }>;
+    devices?: Array<
+      {
+        identifier?: Common_.DeviceToken;
+        type?: 'ios' | 'android';
+      } & {
+        identifier: Defined;
+        type: Defined;
+      }
+    >;
     notification?: {
       body?: string;
       title?: string;
@@ -52,10 +58,18 @@ export type RequestC = t.BrandC<
     [
       t.PartialC<{
         devices: t.ArrayC<
-          t.TypeC<{
-            identifier: typeof Defined;
-            type: typeof Defined;
-          }>
+          t.IntersectionC<
+            [
+              t.PartialC<{
+                identifier: typeof Common_.DeviceToken;
+                type: t.UnionC<[t.LiteralC<'ios'>, t.LiteralC<'android'>]>;
+              }>,
+              t.TypeC<{
+                identifier: typeof Defined;
+                type: typeof Defined;
+              }>,
+            ]
+          >
         >;
         notification: t.PartialC<{
           body: t.StringC;
@@ -75,10 +89,16 @@ export const Request: RequestC = t.brand(
   t.intersection([
     t.partial({
       devices: t.array(
-        t.type({
-          identifier: Defined,
-          type: Defined,
-        }),
+        t.intersection([
+          t.partial({
+            identifier: Common_.DeviceToken,
+            type: t.union([t.literal('ios'), t.literal('android')]),
+          }),
+          t.type({
+            identifier: Defined,
+            type: Defined,
+          }),
+        ]),
       ),
       notification: t.partial({
         body: t.string,
@@ -95,10 +115,15 @@ export const Request: RequestC = t.brand(
     x,
   ): x is t.Branded<
     {
-      devices?: Array<{
-        identifier: Defined;
-        type: Defined;
-      }>;
+      devices?: Array<
+        {
+          identifier?: Common_.DeviceToken;
+          type?: 'ios' | 'android';
+        } & {
+          identifier: Defined;
+          type: Defined;
+        }
+      >;
       notification?: {
         body?: string;
         title?: string;

--- a/maas-schemas-ts/src/maas-backend/webhooks/zendesk-push-notification/response.ts
+++ b/maas-schemas-ts/src/maas-backend/webhooks/zendesk-push-notification/response.ts
@@ -33,6 +33,9 @@ export const schemaId =
 export type Response = t.Branded<
   {
     results?: {
+      successCount?: number;
+      failureCount?: number;
+    } & {
       successCount: Defined;
       failureCount: Defined;
     };
@@ -45,10 +48,18 @@ export type ResponseC = t.BrandC<
   t.IntersectionC<
     [
       t.PartialC<{
-        results: t.TypeC<{
-          successCount: typeof Defined;
-          failureCount: typeof Defined;
-        }>;
+        results: t.IntersectionC<
+          [
+            t.PartialC<{
+              successCount: t.NumberC;
+              failureCount: t.NumberC;
+            }>,
+            t.TypeC<{
+              successCount: typeof Defined;
+              failureCount: typeof Defined;
+            }>,
+          ]
+        >;
       }>,
       t.TypeC<{
         results: typeof Defined;
@@ -60,10 +71,16 @@ export type ResponseC = t.BrandC<
 export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
-      results: t.type({
-        successCount: Defined,
-        failureCount: Defined,
-      }),
+      results: t.intersection([
+        t.partial({
+          successCount: t.number,
+          failureCount: t.number,
+        }),
+        t.type({
+          successCount: Defined,
+          failureCount: Defined,
+        }),
+      ]),
     }),
     t.type({
       results: Defined,
@@ -74,6 +91,9 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       results?: {
+        successCount?: number;
+        failureCount?: number;
+      } & {
         successCount: Defined;
         failureCount: Defined;
       };

--- a/maas-schemas-ts/src/tsp/booking-create/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-create/request.ts
@@ -38,7 +38,7 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-create/request.json';
 // Request
 // The default export. More information at the top.
 export type Request = t.Branded<
-  {
+  ({
     leg?: BookingOption_.Leg;
     meta?: BookingMeta_.BookingMeta;
     terms?: Booking_.Terms;
@@ -46,7 +46,7 @@ export type Request = t.Branded<
     tspProduct?: BookingOption_.TspProduct;
     configurator?: Configurator_.Configurator;
     customerSelection?: CustomerSelection_.CustomerSelection;
-  } & {
+  } & Record<string, unknown>) & {
     leg: Defined;
     meta: Defined;
     terms: Defined;
@@ -58,15 +58,20 @@ export type Request = t.Branded<
 export type RequestC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        leg: typeof BookingOption_.Leg;
-        meta: typeof BookingMeta_.BookingMeta;
-        terms: typeof Booking_.Terms;
-        customer: typeof Customer_.Customer;
-        tspProduct: typeof BookingOption_.TspProduct;
-        configurator: typeof Configurator_.Configurator;
-        customerSelection: typeof CustomerSelection_.CustomerSelection;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            leg: typeof BookingOption_.Leg;
+            meta: typeof BookingMeta_.BookingMeta;
+            terms: typeof Booking_.Terms;
+            customer: typeof Customer_.Customer;
+            tspProduct: typeof BookingOption_.TspProduct;
+            configurator: typeof Configurator_.Configurator;
+            customerSelection: typeof CustomerSelection_.CustomerSelection;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         leg: typeof Defined;
         meta: typeof Defined;
@@ -80,15 +85,18 @@ export type RequestC = t.BrandC<
 >;
 export const Request: RequestC = t.brand(
   t.intersection([
-    t.partial({
-      leg: BookingOption_.Leg,
-      meta: BookingMeta_.BookingMeta,
-      terms: Booking_.Terms,
-      customer: Customer_.Customer,
-      tspProduct: BookingOption_.TspProduct,
-      configurator: Configurator_.Configurator,
-      customerSelection: CustomerSelection_.CustomerSelection,
-    }),
+    t.intersection([
+      t.partial({
+        leg: BookingOption_.Leg,
+        meta: BookingMeta_.BookingMeta,
+        terms: Booking_.Terms,
+        customer: Customer_.Customer,
+        tspProduct: BookingOption_.TspProduct,
+        configurator: Configurator_.Configurator,
+        customerSelection: CustomerSelection_.CustomerSelection,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       leg: Defined,
       meta: Defined,
@@ -100,7 +108,7 @@ export const Request: RequestC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       leg?: BookingOption_.Leg;
       meta?: BookingMeta_.BookingMeta;
       terms?: Booking_.Terms;
@@ -108,7 +116,7 @@ export const Request: RequestC = t.brand(
       tspProduct?: BookingOption_.TspProduct;
       configurator?: Configurator_.Configurator;
       customerSelection?: CustomerSelection_.CustomerSelection;
-    } & {
+    } & Record<string, unknown>) & {
       leg: Defined;
       meta: Defined;
       terms: Defined;

--- a/maas-schemas-ts/src/tsp/booking-options-list/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-options-list/request.ts
@@ -72,7 +72,8 @@ export type Request = t.Branded<
     | Booking_.TspId
     | Common_.AppInstanceId
     | (string | number | boolean)
-  >) & {
+  > &
+    Record<string, unknown>) & {
     startTime: Defined;
     from: Defined;
   },
@@ -125,6 +126,7 @@ export type RequestC = t.BrandC<
               ]
             >
           >,
+          t.RecordC<t.StringC, t.UnknownC>,
         ]
       >,
       t.TypeC<{
@@ -178,6 +180,7 @@ export const Request: RequestC = t.brand(
           t.union([t.string, t.number, t.boolean]),
         ]),
       ),
+      t.record(t.string, t.unknown),
     ]),
     t.type({
       startTime: Defined,
@@ -223,7 +226,8 @@ export const Request: RequestC = t.brand(
       | Booking_.TspId
       | Common_.AppInstanceId
       | (string | number | boolean)
-    >) & {
+    > &
+      Record<string, unknown>) & {
       startTime: Defined;
       from: Defined;
     },

--- a/maas-schemas-ts/src/tsp/booking-read-by-id/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-read-by-id/request.ts
@@ -33,7 +33,7 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-read-by-id/request.js
 export type Request = t.Branded<
   {
     tspId?: Booking_.TspId;
-    query?: {};
+    query?: Record<string, unknown>;
   } & {
     tspId: Defined;
   },
@@ -44,7 +44,7 @@ export type RequestC = t.BrandC<
     [
       t.PartialC<{
         tspId: typeof Booking_.TspId;
-        query: t.TypeC<{}>;
+        query: t.UnknownRecordC;
       }>,
       t.TypeC<{
         tspId: typeof Defined;
@@ -57,7 +57,7 @@ export const Request: RequestC = t.brand(
   t.intersection([
     t.partial({
       tspId: Booking_.TspId,
-      query: t.type({}),
+      query: t.UnknownRecord,
     }),
     t.type({
       tspId: Defined,
@@ -68,7 +68,7 @@ export const Request: RequestC = t.brand(
   ): x is t.Branded<
     {
       tspId?: Booking_.TspId;
-      query?: {};
+      query?: Record<string, unknown>;
     } & {
       tspId: Defined;
     },

--- a/maas-schemas-ts/src/tsp/booking-read-by-id/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-read-by-id/response.ts
@@ -9,6 +9,10 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 */
 
 import * as t from 'io-ts';
+import * as Booking_ from '../../core/booking';
+import * as State_ from '../../core/components/state';
+import * as BookingOption_ from '../../core/booking-option';
+import * as BookingMeta_ from '../../core/booking-meta';
 
 export type Defined = {} | null;
 export class DefinedType extends t.Type<Defined> {
@@ -31,27 +35,71 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-read-by-id/response.j
 // The default export. More information at the top.
 export type Response = t.Branded<
   {
+    tspId?: Booking_.TspId;
+    cost?: Booking_.Cost;
+    state?: State_.BookingState;
+    leg?: BookingOption_.LegDelta;
+    meta?: BookingMeta_.BookingMeta;
+    terms?: Booking_.Terms;
+    token?: Booking_.Token;
+    tspProduct?: BookingOption_.TspProduct;
+  } & {
     tspId: Defined;
     state: Defined;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
-  t.TypeC<{
-    tspId: typeof Defined;
-    state: typeof Defined;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        tspId: typeof Booking_.TspId;
+        cost: typeof Booking_.Cost;
+        state: typeof State_.BookingState;
+        leg: typeof BookingOption_.LegDelta;
+        meta: typeof BookingMeta_.BookingMeta;
+        terms: typeof Booking_.Terms;
+        token: typeof Booking_.Token;
+        tspProduct: typeof BookingOption_.TspProduct;
+      }>,
+      t.TypeC<{
+        tspId: typeof Defined;
+        state: typeof Defined;
+      }>,
+    ]
+  >,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
-  t.type({
-    tspId: Defined,
-    state: Defined,
-  }),
+  t.intersection([
+    t.partial({
+      tspId: Booking_.TspId,
+      cost: Booking_.Cost,
+      state: State_.BookingState,
+      leg: BookingOption_.LegDelta,
+      meta: BookingMeta_.BookingMeta,
+      terms: Booking_.Terms,
+      token: Booking_.Token,
+      tspProduct: BookingOption_.TspProduct,
+    }),
+    t.type({
+      tspId: Defined,
+      state: Defined,
+    }),
+  ]),
   (
     x,
   ): x is t.Branded<
     {
+      tspId?: Booking_.TspId;
+      cost?: Booking_.Cost;
+      state?: State_.BookingState;
+      leg?: BookingOption_.LegDelta;
+      meta?: BookingMeta_.BookingMeta;
+      terms?: Booking_.Terms;
+      token?: Booking_.Token;
+      tspProduct?: BookingOption_.TspProduct;
+    } & {
       tspId: Defined;
       state: Defined;
     },

--- a/maas-schemas-ts/src/tsp/booking-receipt/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-receipt/response.ts
@@ -9,6 +9,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 */
 
 import * as t from 'io-ts';
+import * as Booking_ from '../../core/booking';
 
 export type Defined = {} | null;
 export class DefinedType extends t.Type<Defined> {
@@ -31,27 +32,51 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-receipt/response.json
 // The default export. More information at the top.
 export type Response = t.Branded<
   {
+    tspId?: Booking_.TspId;
+    cost?: Booking_.Cost;
+    receipt?: Record<string, unknown>;
+  } & {
     tspId: Defined;
     cost: Defined;
   },
   ResponseBrand
 >;
 export type ResponseC = t.BrandC<
-  t.TypeC<{
-    tspId: typeof Defined;
-    cost: typeof Defined;
-  }>,
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        tspId: typeof Booking_.TspId;
+        cost: typeof Booking_.Cost;
+        receipt: t.UnknownRecordC;
+      }>,
+      t.TypeC<{
+        tspId: typeof Defined;
+        cost: typeof Defined;
+      }>,
+    ]
+  >,
   ResponseBrand
 >;
 export const Response: ResponseC = t.brand(
-  t.type({
-    tspId: Defined,
-    cost: Defined,
-  }),
+  t.intersection([
+    t.partial({
+      tspId: Booking_.TspId,
+      cost: Booking_.Cost,
+      receipt: t.UnknownRecord,
+    }),
+    t.type({
+      tspId: Defined,
+      cost: Defined,
+    }),
+  ]),
   (
     x,
   ): x is t.Branded<
     {
+      tspId?: Booking_.TspId;
+      cost?: Booking_.Cost;
+      receipt?: Record<string, unknown>;
+    } & {
       tspId: Defined;
       cost: Defined;
     },

--- a/maas-schemas-ts/src/tsp/booking-ticket/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-ticket/request.ts
@@ -31,11 +31,11 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-ticket/request.json';
 // Request
 // The default export. More information at the top.
 export type Request = t.Branded<
-  {
+  ({
     tspId?: Booking_.TspId;
     ticket?: string | Array<string>;
     token?: Booking_.Token;
-  } & {
+  } & Record<string, unknown>) & {
     ticket: Defined;
     token: Defined;
     tspId: Defined;
@@ -45,11 +45,16 @@ export type Request = t.Branded<
 export type RequestC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        tspId: typeof Booking_.TspId;
-        ticket: t.UnionC<[t.StringC, t.ArrayC<t.StringC>]>;
-        token: typeof Booking_.Token;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            tspId: typeof Booking_.TspId;
+            ticket: t.UnionC<[t.StringC, t.ArrayC<t.StringC>]>;
+            token: typeof Booking_.Token;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         ticket: typeof Defined;
         token: typeof Defined;
@@ -61,11 +66,14 @@ export type RequestC = t.BrandC<
 >;
 export const Request: RequestC = t.brand(
   t.intersection([
-    t.partial({
-      tspId: Booking_.TspId,
-      ticket: t.union([t.string, t.array(t.string)]),
-      token: Booking_.Token,
-    }),
+    t.intersection([
+      t.partial({
+        tspId: Booking_.TspId,
+        ticket: t.union([t.string, t.array(t.string)]),
+        token: Booking_.Token,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       ticket: Defined,
       token: Defined,
@@ -75,11 +83,11 @@ export const Request: RequestC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       tspId?: Booking_.TspId;
       ticket?: string | Array<string>;
       token?: Booking_.Token;
-    } & {
+    } & Record<string, unknown>) & {
       ticket: Defined;
       token: Defined;
       tspId: Defined;

--- a/maas-schemas-ts/src/tsp/booking-ticket/response.ts
+++ b/maas-schemas-ts/src/tsp/booking-ticket/response.ts
@@ -31,13 +31,13 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-ticket/response.json'
 // Response
 // The default export. More information at the top.
 export type Response = t.Branded<
-  {
+  ({
     ticket?: string;
     type?: string & ('html' | 'pdf' | 'svg' | 'png');
     contentType?: string &
       ('application/pdf' | 'image/svg+xml' | 'image/png' | 'text/html');
     refreshAt?: Units_.Time;
-  } & {
+  } & Record<string, unknown>) & {
     ticket: Defined;
     type: Defined;
     contentType: Defined;
@@ -47,36 +47,41 @@ export type Response = t.Branded<
 export type ResponseC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        ticket: t.StringC;
-        type: t.IntersectionC<
-          [
-            t.StringC,
-            t.UnionC<
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            ticket: t.StringC;
+            type: t.IntersectionC<
               [
-                t.LiteralC<'html'>,
-                t.LiteralC<'pdf'>,
-                t.LiteralC<'svg'>,
-                t.LiteralC<'png'>,
+                t.StringC,
+                t.UnionC<
+                  [
+                    t.LiteralC<'html'>,
+                    t.LiteralC<'pdf'>,
+                    t.LiteralC<'svg'>,
+                    t.LiteralC<'png'>,
+                  ]
+                >,
               ]
-            >,
-          ]
-        >;
-        contentType: t.IntersectionC<
-          [
-            t.StringC,
-            t.UnionC<
+            >;
+            contentType: t.IntersectionC<
               [
-                t.LiteralC<'application/pdf'>,
-                t.LiteralC<'image/svg+xml'>,
-                t.LiteralC<'image/png'>,
-                t.LiteralC<'text/html'>,
+                t.StringC,
+                t.UnionC<
+                  [
+                    t.LiteralC<'application/pdf'>,
+                    t.LiteralC<'image/svg+xml'>,
+                    t.LiteralC<'image/png'>,
+                    t.LiteralC<'text/html'>,
+                  ]
+                >,
               ]
-            >,
-          ]
-        >;
-        refreshAt: typeof Units_.Time;
-      }>,
+            >;
+            refreshAt: typeof Units_.Time;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         ticket: typeof Defined;
         type: typeof Defined;
@@ -88,28 +93,31 @@ export type ResponseC = t.BrandC<
 >;
 export const Response: ResponseC = t.brand(
   t.intersection([
-    t.partial({
-      ticket: t.string,
-      type: t.intersection([
-        t.string,
-        t.union([
-          t.literal('html'),
-          t.literal('pdf'),
-          t.literal('svg'),
-          t.literal('png'),
+    t.intersection([
+      t.partial({
+        ticket: t.string,
+        type: t.intersection([
+          t.string,
+          t.union([
+            t.literal('html'),
+            t.literal('pdf'),
+            t.literal('svg'),
+            t.literal('png'),
+          ]),
         ]),
-      ]),
-      contentType: t.intersection([
-        t.string,
-        t.union([
-          t.literal('application/pdf'),
-          t.literal('image/svg+xml'),
-          t.literal('image/png'),
-          t.literal('text/html'),
+        contentType: t.intersection([
+          t.string,
+          t.union([
+            t.literal('application/pdf'),
+            t.literal('image/svg+xml'),
+            t.literal('image/png'),
+            t.literal('text/html'),
+          ]),
         ]),
-      ]),
-      refreshAt: Units_.Time,
-    }),
+        refreshAt: Units_.Time,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       ticket: Defined,
       type: Defined,
@@ -119,13 +127,13 @@ export const Response: ResponseC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       ticket?: string;
       type?: string & ('html' | 'pdf' | 'svg' | 'png');
       contentType?: string &
         ('application/pdf' | 'image/svg+xml' | 'image/png' | 'text/html');
       refreshAt?: Units_.Time;
-    } & {
+    } & Record<string, unknown>) & {
       ticket: Defined;
       type: Defined;
       contentType: Defined;

--- a/maas-schemas-ts/src/tsp/booking-update/request.ts
+++ b/maas-schemas-ts/src/tsp/booking-update/request.ts
@@ -34,14 +34,14 @@ export const schemaId = 'http://maasglobal.com/tsp/booking-update/request.json';
 // Request
 // The default export. More information at the top.
 export type Request = t.Branded<
-  {
+  ({
     tspId?: Booking_.TspId;
     state?: 'RESERVED' | 'ACTIVATED' | 'ON_HOLD' | 'EXPIRED';
     configurator?: Configurator_.Configurator;
     meta?: BookingMeta_.BookingMeta;
     terms?: Booking_.Terms;
     customerSelection?: CustomerSelection_.CustomerSelection;
-  } & {
+  } & Record<string, unknown>) & {
     tspId: Defined;
   },
   RequestBrand
@@ -49,21 +49,26 @@ export type Request = t.Branded<
 export type RequestC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        tspId: typeof Booking_.TspId;
-        state: t.UnionC<
-          [
-            t.LiteralC<'RESERVED'>,
-            t.LiteralC<'ACTIVATED'>,
-            t.LiteralC<'ON_HOLD'>,
-            t.LiteralC<'EXPIRED'>,
-          ]
-        >;
-        configurator: typeof Configurator_.Configurator;
-        meta: typeof BookingMeta_.BookingMeta;
-        terms: typeof Booking_.Terms;
-        customerSelection: typeof CustomerSelection_.CustomerSelection;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            tspId: typeof Booking_.TspId;
+            state: t.UnionC<
+              [
+                t.LiteralC<'RESERVED'>,
+                t.LiteralC<'ACTIVATED'>,
+                t.LiteralC<'ON_HOLD'>,
+                t.LiteralC<'EXPIRED'>,
+              ]
+            >;
+            configurator: typeof Configurator_.Configurator;
+            meta: typeof BookingMeta_.BookingMeta;
+            terms: typeof Booking_.Terms;
+            customerSelection: typeof CustomerSelection_.CustomerSelection;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         tspId: typeof Defined;
       }>,
@@ -73,19 +78,22 @@ export type RequestC = t.BrandC<
 >;
 export const Request: RequestC = t.brand(
   t.intersection([
-    t.partial({
-      tspId: Booking_.TspId,
-      state: t.union([
-        t.literal('RESERVED'),
-        t.literal('ACTIVATED'),
-        t.literal('ON_HOLD'),
-        t.literal('EXPIRED'),
-      ]),
-      configurator: Configurator_.Configurator,
-      meta: BookingMeta_.BookingMeta,
-      terms: Booking_.Terms,
-      customerSelection: CustomerSelection_.CustomerSelection,
-    }),
+    t.intersection([
+      t.partial({
+        tspId: Booking_.TspId,
+        state: t.union([
+          t.literal('RESERVED'),
+          t.literal('ACTIVATED'),
+          t.literal('ON_HOLD'),
+          t.literal('EXPIRED'),
+        ]),
+        configurator: Configurator_.Configurator,
+        meta: BookingMeta_.BookingMeta,
+        terms: Booking_.Terms,
+        customerSelection: CustomerSelection_.CustomerSelection,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       tspId: Defined,
     }),
@@ -93,14 +101,14 @@ export const Request: RequestC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       tspId?: Booking_.TspId;
       state?: 'RESERVED' | 'ACTIVATED' | 'ON_HOLD' | 'EXPIRED';
       configurator?: Configurator_.Configurator;
       meta?: BookingMeta_.BookingMeta;
       terms?: Booking_.Terms;
       customerSelection?: CustomerSelection_.CustomerSelection;
-    } & {
+    } & Record<string, unknown>) & {
       tspId: Defined;
     },
     RequestBrand

--- a/maas-schemas-ts/src/tsp/customer-auth-validate/request.ts
+++ b/maas-schemas-ts/src/tsp/customer-auth-validate/request.ts
@@ -31,10 +31,10 @@ export const schemaId = 'http://maasglobal.com/tsp/customer-auth-validate/reques
 // Request
 // The default export. More information at the top.
 export type Request = t.Branded<
-  {
+  ({
     encodedData?: Common_.EncodedQueryParam;
     error?: Common_.ErrorKey;
-  } & {
+  } & Record<string, unknown>) & {
     encodedData: Defined;
   },
   RequestBrand
@@ -42,10 +42,15 @@ export type Request = t.Branded<
 export type RequestC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        encodedData: typeof Common_.EncodedQueryParam;
-        error: typeof Common_.ErrorKey;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            encodedData: typeof Common_.EncodedQueryParam;
+            error: typeof Common_.ErrorKey;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         encodedData: typeof Defined;
       }>,
@@ -55,10 +60,13 @@ export type RequestC = t.BrandC<
 >;
 export const Request: RequestC = t.brand(
   t.intersection([
-    t.partial({
-      encodedData: Common_.EncodedQueryParam,
-      error: Common_.ErrorKey,
-    }),
+    t.intersection([
+      t.partial({
+        encodedData: Common_.EncodedQueryParam,
+        error: Common_.ErrorKey,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       encodedData: Defined,
     }),
@@ -66,10 +74,10 @@ export const Request: RequestC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       encodedData?: Common_.EncodedQueryParam;
       error?: Common_.ErrorKey;
-    } & {
+    } & Record<string, unknown>) & {
       encodedData: Defined;
     },
     RequestBrand

--- a/maas-schemas-ts/src/tsp/customer-auth/request.ts
+++ b/maas-schemas-ts/src/tsp/customer-auth/request.ts
@@ -33,11 +33,11 @@ export const schemaId = 'http://maasglobal.com/tsp/customer-auth/request.json';
 // Request
 // The default export. More information at the top.
 export type Request = t.Branded<
-  {
+  ({
     nonce?: Common_.EncodedQueryParam;
     returnUrl?: Units_.Url;
     locale?: I18n_.Locale;
-  } & {
+  } & Record<string, unknown>) & {
     nonce: Defined;
     returnUrl: Defined;
   },
@@ -46,11 +46,16 @@ export type Request = t.Branded<
 export type RequestC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        nonce: typeof Common_.EncodedQueryParam;
-        returnUrl: typeof Units_.Url;
-        locale: typeof I18n_.Locale;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            nonce: typeof Common_.EncodedQueryParam;
+            returnUrl: typeof Units_.Url;
+            locale: typeof I18n_.Locale;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         nonce: typeof Defined;
         returnUrl: typeof Defined;
@@ -61,11 +66,14 @@ export type RequestC = t.BrandC<
 >;
 export const Request: RequestC = t.brand(
   t.intersection([
-    t.partial({
-      nonce: Common_.EncodedQueryParam,
-      returnUrl: Units_.Url,
-      locale: I18n_.Locale,
-    }),
+    t.intersection([
+      t.partial({
+        nonce: Common_.EncodedQueryParam,
+        returnUrl: Units_.Url,
+        locale: I18n_.Locale,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       nonce: Defined,
       returnUrl: Defined,
@@ -74,11 +82,11 @@ export const Request: RequestC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       nonce?: Common_.EncodedQueryParam;
       returnUrl?: Units_.Url;
       locale?: I18n_.Locale;
-    } & {
+    } & Record<string, unknown>) & {
       nonce: Defined;
       returnUrl: Defined;
     },

--- a/maas-schemas-ts/src/tsp/customer-registration/response.ts
+++ b/maas-schemas-ts/src/tsp/customer-registration/response.ts
@@ -30,9 +30,9 @@ export const schemaId = 'http://maasglobal.com/tsp/customer-registration/respons
 // Response
 // The default export. More information at the top.
 export type Response = t.Branded<
-  {
-    customer?: {};
-  } & {
+  ({
+    customer?: Record<string, unknown>;
+  } & Record<string, unknown>) & {
     customer: Defined;
   },
   ResponseBrand
@@ -40,9 +40,14 @@ export type Response = t.Branded<
 export type ResponseC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        customer: t.TypeC<{}>;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            customer: t.UnknownRecordC;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         customer: typeof Defined;
       }>,
@@ -52,9 +57,12 @@ export type ResponseC = t.BrandC<
 >;
 export const Response: ResponseC = t.brand(
   t.intersection([
-    t.partial({
-      customer: t.type({}),
-    }),
+    t.intersection([
+      t.partial({
+        customer: t.UnknownRecord,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       customer: Defined,
     }),
@@ -62,9 +70,9 @@ export const Response: ResponseC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
-      customer?: {};
-    } & {
+    ({
+      customer?: Record<string, unknown>;
+    } & Record<string, unknown>) & {
       customer: Defined;
     },
     ResponseBrand

--- a/maas-schemas-ts/src/tsp/manage/request.ts
+++ b/maas-schemas-ts/src/tsp/manage/request.ts
@@ -31,10 +31,10 @@ export const schemaId = 'http://maasglobal.com/tsp/manage/request.json';
 // Request
 // The default export. More information at the top.
 export type Request = t.Branded<
-  {
+  ({
     operation?: string;
     customer?: Customer_.Customer;
-  } & {
+  } & Record<string, unknown>) & {
     operation: Defined;
   },
   RequestBrand
@@ -42,10 +42,15 @@ export type Request = t.Branded<
 export type RequestC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        operation: t.StringC;
-        customer: typeof Customer_.Customer;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            operation: t.StringC;
+            customer: typeof Customer_.Customer;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         operation: typeof Defined;
       }>,
@@ -55,10 +60,13 @@ export type RequestC = t.BrandC<
 >;
 export const Request: RequestC = t.brand(
   t.intersection([
-    t.partial({
-      operation: t.string,
-      customer: Customer_.Customer,
-    }),
+    t.intersection([
+      t.partial({
+        operation: t.string,
+        customer: Customer_.Customer,
+      }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       operation: Defined,
     }),
@@ -66,10 +74,10 @@ export const Request: RequestC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       operation?: string;
       customer?: Customer_.Customer;
-    } & {
+    } & Record<string, unknown>) & {
       operation: Defined;
     },
     RequestBrand

--- a/maas-schemas-ts/src/tsp/manage/response.ts
+++ b/maas-schemas-ts/src/tsp/manage/response.ts
@@ -33,7 +33,7 @@ export const schemaId = 'http://maasglobal.com/tsp/manage/response.json';
 // Response
 // The default export. More information at the top.
 export type Response = t.Branded<
-  {
+  ({
     success?: boolean;
     message?: string;
     updateBookingsWith?: {
@@ -42,7 +42,7 @@ export type Response = t.Branded<
       token?: Booking_.Token;
       tspProducts?: Array<BookingOption_.TspProduct>;
     };
-  } & {
+  } & Record<string, unknown>) & {
     success: Defined;
   },
   ResponseBrand
@@ -50,16 +50,21 @@ export type Response = t.Branded<
 export type ResponseC = t.BrandC<
   t.IntersectionC<
     [
-      t.PartialC<{
-        success: t.BooleanC;
-        message: t.StringC;
-        updateBookingsWith: t.PartialC<{
-          meta: typeof BookingMeta_.BookingMeta;
-          terms: typeof Booking_.Terms;
-          token: typeof Booking_.Token;
-          tspProducts: t.ArrayC<typeof BookingOption_.TspProduct>;
-        }>;
-      }>,
+      t.IntersectionC<
+        [
+          t.PartialC<{
+            success: t.BooleanC;
+            message: t.StringC;
+            updateBookingsWith: t.PartialC<{
+              meta: typeof BookingMeta_.BookingMeta;
+              terms: typeof Booking_.Terms;
+              token: typeof Booking_.Token;
+              tspProducts: t.ArrayC<typeof BookingOption_.TspProduct>;
+            }>;
+          }>,
+          t.RecordC<t.StringC, t.UnknownC>,
+        ]
+      >,
       t.TypeC<{
         success: typeof Defined;
       }>,
@@ -69,16 +74,19 @@ export type ResponseC = t.BrandC<
 >;
 export const Response: ResponseC = t.brand(
   t.intersection([
-    t.partial({
-      success: t.boolean,
-      message: t.string,
-      updateBookingsWith: t.partial({
-        meta: BookingMeta_.BookingMeta,
-        terms: Booking_.Terms,
-        token: Booking_.Token,
-        tspProducts: t.array(BookingOption_.TspProduct),
+    t.intersection([
+      t.partial({
+        success: t.boolean,
+        message: t.string,
+        updateBookingsWith: t.partial({
+          meta: BookingMeta_.BookingMeta,
+          terms: Booking_.Terms,
+          token: Booking_.Token,
+          tspProducts: t.array(BookingOption_.TspProduct),
+        }),
       }),
-    }),
+      t.record(t.string, t.unknown),
+    ]),
     t.type({
       success: Defined,
     }),
@@ -86,7 +94,7 @@ export const Response: ResponseC = t.brand(
   (
     x,
   ): x is t.Branded<
-    {
+    ({
       success?: boolean;
       message?: string;
       updateBookingsWith?: {
@@ -95,7 +103,7 @@ export const Response: ResponseC = t.brand(
         token?: Booking_.Token;
         tspProducts?: Array<BookingOption_.TspProduct>;
       };
-    } & {
+    } & Record<string, unknown>) & {
       success: Defined;
     },
     ResponseBrand

--- a/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-response.ts
+++ b/maas-schemas-ts/src/tsp/webhooks-bookings-update/remote-response.ts
@@ -143,28 +143,28 @@ export interface BookingDeltaBrand {
 export type RemoteResponse = t.Branded<
   {
     booking?: BookingDelta;
-    debug?: {};
+    debug?: Record<string, unknown>;
   },
   RemoteResponseBrand
 >;
 export type RemoteResponseC = t.BrandC<
   t.PartialC<{
     booking: typeof BookingDelta;
-    debug: t.TypeC<{}>;
+    debug: t.RecordC<t.StringC, t.UnknownC>;
   }>,
   RemoteResponseBrand
 >;
 export const RemoteResponse: RemoteResponseC = t.brand(
   t.partial({
     booking: BookingDelta,
-    debug: t.type({}),
+    debug: t.record(t.string, t.unknown),
   }),
   (
     x,
   ): x is t.Branded<
     {
       booking?: BookingDelta;
-      debug?: {};
+      debug?: Record<string, unknown>;
     },
     RemoteResponseBrand
   > => true,

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -997,6 +997,8 @@ WARNING: maxLength field not supported outside top-level definitions
 INFO: missing description
   in ../maas-schemas/schemas/maas-backend/bookings/bookings-agency-products/response.json
 INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/bookings/bookings-cancel/response.json
+INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/request.json
 WARNING: pattern field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/bookings/bookings-list/request.json
@@ -1478,6 +1480,14 @@ WARNING: minItems field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/push-notification/request.json
 WARNING: maxItems field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/push-notification/request.json
+INFO: primitive type "integer" used outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/push-notification/response.json
+WARNING: minimum field not supported outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/push-notification/response.json
+INFO: primitive type "integer" used outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/push-notification/response.json
+WARNING: minimum field not supported outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/push-notification/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/routes/routes-query/request.json
 INFO: primitive type "string" used outside top-level definitions
@@ -1818,6 +1828,14 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
+INFO: primitive type "integer" used outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/response.json
+WARNING: minimum field not supported outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/response.json
+INFO: primitive type "integer" used outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/response.json
+WARNING: minimum field not supported outside top-level definitions
+  in ../maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/tsp/booking-options-list/request.json
 WARNING: maxLength field not supported outside top-level definitions

--- a/maas-schemas-ts/yarn.lock
+++ b/maas-schemas-ts/yarn.lock
@@ -1965,10 +1965,10 @@ io-ts-codegen@^0.4.5:
   resolved "https://registry.yarnpkg.com/io-ts-codegen/-/io-ts-codegen-0.4.5.tgz#67a5e0e0d72751451ab6c2c70e2f304408f398de"
   integrity sha512-7Q6CbNyYOIelPt2OddqMIk5jGfUM5Z+Y2OSsPAJnaSRroCwedAp0cFNh5h02nsE/33P9xjyGhKTajMkPApEdcA==
 
-io-ts-from-json-schema@^0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/io-ts-from-json-schema/-/io-ts-from-json-schema-0.0.12.tgz#a7facd8f76812247d5780f50b134f5cbf844feff"
-  integrity sha512-jJSwsuM2aDN6FPL6ZQp6OxQApvH7+aHrpgj8tP7PgIlHZZqH/IGBhuGRfAit1nd+iDeMbmqVbAAoXfBU9vcfPA==
+io-ts-from-json-schema@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/io-ts-from-json-schema/-/io-ts-from-json-schema-0.0.13.tgz#b4f0208dfa36d80f158909b960d88ad7278cf7eb"
+  integrity sha512-1HQvbl7E+F2g7y1MGwKd4rUYgf6dKyqvYkCQxbXGw37RZgTx+oPEltve8qSX1yAh50I2ZAJNR9tnj/0HYH1ONQ==
   dependencies:
     glob "^7.1.6"
     io-ts-codegen "^0.4.5"

--- a/maas-schemas/schemas/core/components/geometry.json
+++ b/maas-schemas/schemas/core/components/geometry.json
@@ -7,6 +7,7 @@
   "oneOf": [
     {
       "title": "Point",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["Point"]
@@ -18,6 +19,7 @@
     },
     {
       "title": "MultiPoint",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["MultiPoint"]
@@ -29,6 +31,7 @@
     },
     {
       "title": "LineString",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["LineString"]
@@ -40,6 +43,7 @@
     },
     {
       "title": "MultiLineString",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["MultiLineString"]
@@ -54,6 +58,7 @@
     },
     {
       "title": "Polygon",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["Polygon"]
@@ -65,6 +70,7 @@
     },
     {
       "title": "MultiPolygon",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["MultiPolygon"]

--- a/maas-schemas/schemas/geojson/geometry.json
+++ b/maas-schemas/schemas/geojson/geometry.json
@@ -7,6 +7,7 @@
   "oneOf": [
     {
       "title": "Point",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["Point"]
@@ -18,6 +19,7 @@
     },
     {
       "title": "MultiPoint",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["MultiPoint"]
@@ -29,6 +31,7 @@
     },
     {
       "title": "LineString",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["LineString"]
@@ -40,6 +43,7 @@
     },
     {
       "title": "MultiLineString",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["MultiLineString"]
@@ -54,6 +58,7 @@
     },
     {
       "title": "Polygon",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["Polygon"]
@@ -65,6 +70,7 @@
     },
     {
       "title": "MultiPolygon",
+      "type": "object",
       "properties": {
         "type": {
           "enum": ["MultiPolygon"]

--- a/maas-schemas/schemas/maas-backend/bookings/bookings-cancel/response.json
+++ b/maas-schemas/schemas/maas-backend/bookings/bookings-cancel/response.json
@@ -1,6 +1,7 @@
 {
   "$id": "http://maasglobal.com/maas-backend/bookings/bookings-cancel/response.json",
   "description": "Response schema for bookings-retrieve",
+  "type": "object",
   "properties": {
     "booking": {
       "allOf": [

--- a/maas-schemas/schemas/maas-backend/push-notification/response.json
+++ b/maas-schemas/schemas/maas-backend/push-notification/response.json
@@ -7,6 +7,7 @@
       "$ref": "http://maasglobal.com/core/components/units.json#/definitions/identityId"
     },
     "results": {
+      "type": "object",
       "properties": {
         "successCount": { "type": "integer", "minimum": 0 },
         "failureCount": { "type": "integer", "minimum": 0 }

--- a/maas-schemas/schemas/maas-backend/routes/routes-query/response.json
+++ b/maas-schemas/schemas/maas-backend/routes/routes-query/response.json
@@ -1,6 +1,7 @@
 {
   "$id": "http://maasglobal.com/maas-backend/routes/routes-query/response.json",
   "description": "MaaS.fi routes-query response schema",
+  "type": "object",
   "properties": {
     "plan": {
       "$ref": "http://maasglobal.com/core/plan.json"

--- a/maas-schemas/schemas/maas-backend/subscriptions/subscription.json
+++ b/maas-schemas/schemas/maas-backend/subscriptions/subscription.json
@@ -8,6 +8,7 @@
           "$ref": "#/definitions/subscriptionBase"
         },
         {
+          "type": "object",
           "required": ["plan", "addons", "coupons", "changeState"],
           "additionalProperties": true
         }
@@ -19,6 +20,7 @@
           "$ref": "#/definitions/subscriptionBase"
         },
         {
+          "type": "object",
           "required": ["plan", "addons"],
           "additionalProperties": true
         }
@@ -30,6 +32,7 @@
           "$ref": "#/definitions/subscriptionBase"
         },
         {
+          "type": "object",
           "required": [],
           "additionalProperties": true
         }

--- a/maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
+++ b/maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/request.json
@@ -8,6 +8,7 @@
       "minItems": 1,
       "maxItems": 50,
       "items": {
+        "type": "object",
         "properties": {
           "identifier": {
             "$ref": "http://maasglobal.com/core/components/common.json#/definitions/deviceToken"

--- a/maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/response.json
+++ b/maas-schemas/schemas/maas-backend/webhooks/zendesk-push-notification/response.json
@@ -4,6 +4,7 @@
   "type": "object",
   "properties": {
     "results": {
+      "type": "object",
       "properties": {
         "successCount": { "type": "integer", "minimum": 0 },
         "failureCount": { "type": "integer", "minimum": 0 }

--- a/maas-schemas/schemas/tsp/booking-read-by-id/response.json
+++ b/maas-schemas/schemas/tsp/booking-read-by-id/response.json
@@ -1,6 +1,7 @@
 {
   "$id": "http://maasglobal.com/tsp/booking-read-by-id/response.json",
   "description": "Response schema for getting a specific booking with a TSP ID from a TSP adapter",
+  "type": "object",
   "properties": {
     "tspId": {
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"

--- a/maas-schemas/schemas/tsp/booking-receipt/response.json
+++ b/maas-schemas/schemas/tsp/booking-receipt/response.json
@@ -1,6 +1,7 @@
 {
   "$id": "http://maasglobal.com/tsp/booking-receipt/response.json",
   "description": "Response schema for getting a receipt for specific booking",
+  "type": "object",
   "properties": {
     "tspId": {
       "$ref": "http://maasglobal.com/core/booking.json#/definitions/tspId"


### PR DESCRIPTION
This PR adds `type` field to all Arrays and Objects. While not strictly necessary it makes converting the schema a lot easier in typical cases that do not combine features of Array and Object types.