### PR TITLE
Support token id currency

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.17.0",
+  "version": "14.18.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/core/components/fare.ts
+++ b/maas-schemas-ts/src/core/components/fare.ts
@@ -10,6 +10,8 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 import * as t from 'io-ts';
 import * as Common_ from './common';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 export interface NullBrand {
   readonly Null: unique symbol;
@@ -110,7 +112,7 @@ export const defaultFareTypeREFUND: FareTypeREFUND = ('refund' as unknown) as Fa
 export type Fare = t.Branded<
   {
     amount?: number | Null;
-    currency?: Common_.MetaCurrency;
+    currency?: Common_.MetaCurrency | TokenId;
     tokenId?: TokenId;
     hidden?: boolean;
     originalAmount?: number | Null;
@@ -127,7 +129,7 @@ export type FareC = t.BrandC<
     [
       t.PartialC<{
         amount: t.UnionC<[t.NumberC, typeof Null]>;
-        currency: typeof Common_.MetaCurrency;
+        currency: t.UnionC<[typeof Common_.MetaCurrency, typeof TokenId]>;
         tokenId: typeof TokenId;
         hidden: t.BooleanC;
         originalAmount: t.UnionC<[t.NumberC, typeof Null]>;
@@ -146,7 +148,7 @@ export const Fare: FareC = t.brand(
   t.intersection([
     t.partial({
       amount: t.union([t.number, Null]),
-      currency: Common_.MetaCurrency,
+      currency: t.union([Common_.MetaCurrency, TokenId]),
       tokenId: TokenId,
       hidden: t.boolean,
       originalAmount: t.union([t.number, Null]),
@@ -163,7 +165,7 @@ export const Fare: FareC = t.brand(
   ): x is t.Branded<
     {
       amount?: number | Null;
-      currency?: Common_.MetaCurrency;
+      currency?: Common_.MetaCurrency | TokenId;
       tokenId?: TokenId;
       hidden?: boolean;
       originalAmount?: number | Null;
@@ -180,6 +182,25 @@ export const Fare: FareC = t.brand(
 export interface FareBrand {
   readonly Fare: unique symbol;
 }
+/** require('io-ts-validator').validator(nonEmptyArray(Fare)).decodeSync(examplesFare) // => examplesFare */
+export const examplesFare: NonEmptyArray<Fare> = ([
+  { type: 'charge', amount: 1200, currency: 'WMP', productionAmount: 1234 },
+  { type: 'refund', amount: 1200, currency: 'WMP', productionAmount: 1234 },
+  { type: 'charge', amount: 12, currency: 'TOKEN', tokenId: 'fi-package-benefit' },
+  { type: 'refund', amount: 12, currency: 'TOKEN', tokenId: 'fi-package-benefit' },
+  {
+    type: 'charge',
+    amount: 12,
+    currency: 'fi-package-benefit',
+    tokenId: 'fi-package-benefit',
+  },
+  {
+    type: 'refund',
+    amount: 12,
+    currency: 'fi-package-benefit',
+    tokenId: 'fi-package-benefit',
+  },
+] as unknown) as NonEmptyArray<Fare>;
 
 export default Fare;
 

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -90,7 +90,7 @@ export type Customer = t.Branded<
           amount: Defined;
         })
       | (({
-          currency?: Common_.MetaCurrencyTOKEN;
+          currency?: Common_.MetaCurrencyTOKEN | Fare_.TokenId;
           tokenId?: Fare_.TokenId;
           amount?: number | Null;
         } & Record<string, unknown>) & {
@@ -183,7 +183,9 @@ export type CustomerC = t.BrandC<
                       t.IntersectionC<
                         [
                           t.PartialC<{
-                            currency: typeof Common_.MetaCurrencyTOKEN;
+                            currency: t.UnionC<
+                              [typeof Common_.MetaCurrencyTOKEN, typeof Fare_.TokenId]
+                            >;
                             tokenId: typeof Fare_.TokenId;
                             amount: t.UnionC<[t.NumberC, typeof Null]>;
                           }>,
@@ -276,7 +278,7 @@ export const Customer: CustomerC = t.brand(
             t.intersection([
               t.intersection([
                 t.partial({
-                  currency: Common_.MetaCurrencyTOKEN,
+                  currency: t.union([Common_.MetaCurrencyTOKEN, Fare_.TokenId]),
                   tokenId: Fare_.TokenId,
                   amount: t.union([t.number, Null]),
                 }),
@@ -346,7 +348,7 @@ export const Customer: CustomerC = t.brand(
             amount: Defined;
           })
         | (({
-            currency?: Common_.MetaCurrencyTOKEN;
+            currency?: Common_.MetaCurrencyTOKEN | Fare_.TokenId;
             tokenId?: Fare_.TokenId;
             amount?: number | Null;
           } & Record<string, unknown>) & {
@@ -415,6 +417,12 @@ export const examplesCustomer: NonEmptyArray<Customer> = ([
       'cx-test-token_v2': {
         currency: 'TOKEN',
         tokenId: 'cx-test-token_v2',
+        amount: 1,
+        type: 'charge',
+      },
+      'cx-test-token_v3': {
+        currency: 'cx-test-token_v3',
+        tokenId: 'cx-test-token_v3',
         amount: 1,
         type: 'charge',
       },

--- a/maas-schemas-ts/src/maas-backend/products/provider.ts
+++ b/maas-schemas-ts/src/maas-backend/products/provider.ts
@@ -11,6 +11,7 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 import * as t from 'io-ts';
 import * as Common_ from '../../core/components/common';
 import * as Units_ from '../../core/components/units';
+import * as Fare_ from '../../core/components/fare';
 import * as PersonalDataAllowItem_ from '../../core/components/personalDataAllowItem';
 import * as PersonalDataValidation_ from '../../core/components/personalDataValidation';
 import * as PersonalDocumentRequiredItem_ from '../../core/components/personalDocumentRequiredItem';
@@ -393,7 +394,7 @@ export type Provider = t.Branded<
     extra?: {
       radius?: {
         fixedFareAmount?: number;
-        fixedFareCurrency?: Units_.Currency | Common_.MetaCurrency;
+        fixedFareCurrency?: Units_.Currency | Common_.MetaCurrency | Fare_.TokenId;
         maxRadiusMetres?: number;
         description?: string;
       } & {
@@ -469,7 +470,11 @@ export type ProviderC = t.BrandC<
               t.PartialC<{
                 fixedFareAmount: t.NumberC;
                 fixedFareCurrency: t.UnionC<
-                  [typeof Units_.Currency, typeof Common_.MetaCurrency]
+                  [
+                    typeof Units_.Currency,
+                    typeof Common_.MetaCurrency,
+                    typeof Fare_.TokenId,
+                  ]
                 >;
                 maxRadiusMetres: t.NumberC;
                 description: t.StringC;
@@ -565,7 +570,11 @@ export const Provider: ProviderC = t.brand(
         radius: t.intersection([
           t.partial({
             fixedFareAmount: t.number,
-            fixedFareCurrency: t.union([Units_.Currency, Common_.MetaCurrency]),
+            fixedFareCurrency: t.union([
+              Units_.Currency,
+              Common_.MetaCurrency,
+              Fare_.TokenId,
+            ]),
             maxRadiusMetres: t.number,
             description: t.string,
           }),
@@ -638,7 +647,7 @@ export const Provider: ProviderC = t.brand(
       extra?: {
         radius?: {
           fixedFareAmount?: number;
-          fixedFareCurrency?: Units_.Currency | Common_.MetaCurrency;
+          fixedFareCurrency?: Units_.Currency | Common_.MetaCurrency | Fare_.TokenId;
           maxRadiusMetres?: number;
           description?: string;
         } & {

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.17.0",
+  "version": "14.18.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/fare.json
+++ b/maas-schemas/schemas/core/components/fare.json
@@ -26,7 +26,10 @@
       "minimum": 0
     },
     "currency": {
-      "$ref": "http://maasglobal.com/core/components/common.json#/definitions/metaCurrency"
+      "oneOf": [
+        { "$ref": "http://maasglobal.com/core/components/common.json#/definitions/metaCurrency" },
+        { "$ref": "#/definitions/tokenId" }
+      ]
     },
     "tokenId": {
       "$ref": "#/definitions/tokenId"
@@ -46,5 +49,43 @@
     "type": { "$ref": "#/definitions/fareType" }
   },
   "required": ["amount", "currency"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "examples": [
+    {
+      "type": "charge",
+      "amount": 1200,
+      "currency": "WMP",
+      "productionAmount": 1234
+    },
+    {
+      "type": "refund",
+      "amount": 1200,
+      "currency": "WMP",
+      "productionAmount": 1234
+    },
+    {
+      "type": "charge",
+      "amount": 12,
+      "currency": "TOKEN",
+      "tokenId": "fi-package-benefit"
+    },
+    {
+      "type": "refund",
+      "amount": 12,
+      "currency": "TOKEN",
+      "tokenId": "fi-package-benefit"
+    },
+    {
+      "type": "charge",
+      "amount": 12,
+      "currency": "fi-package-benefit",
+      "tokenId": "fi-package-benefit"
+    },
+    {
+      "type": "refund",
+      "amount": 12,
+      "currency": "fi-package-benefit",
+      "tokenId": "fi-package-benefit"
+    }
+  ]
 }

--- a/maas-schemas/schemas/core/customer.json
+++ b/maas-schemas/schemas/core/customer.json
@@ -118,7 +118,14 @@
           "description": "key would typically match tokenId",
           "properties": {
             "currency": {
-              "$ref": "http://maasglobal.com/core/components/common.json#/definitions/metaCurrencyTOKEN"
+              "oneOf": [
+                {
+                  "$ref": "http://maasglobal.com/core/components/common.json#/definitions/metaCurrencyTOKEN"
+                },
+                {
+                  "$ref": "http://maasglobal.com/core/components/fare.json#/definitions/tokenId"
+                }
+              ]
             },
             "tokenId": {
               "$ref": "http://maasglobal.com/core/components/fare.json#/definitions/tokenId"
@@ -214,6 +221,12 @@
         "cx-test-token_v2": {
           "currency": "TOKEN",
           "tokenId": "cx-test-token_v2",
+          "amount": 1,
+          "type": "charge"
+        },
+        "cx-test-token_v3": {
+          "currency": "cx-test-token_v3",
+          "tokenId": "cx-test-token_v3",
           "amount": 1,
           "type": "charge"
         }

--- a/maas-schemas/schemas/maas-backend/products/provider.json
+++ b/maas-schemas/schemas/maas-backend/products/provider.json
@@ -83,6 +83,9 @@
                 },
                 {
                   "$ref": "http://maasglobal.com/core/components/common.json#/definitions/metaCurrency"
+                },
+                {
+                  "$ref": "http://maasglobal.com/core/components/fare.json#/definitions/tokenId"
                 }
               ]
             },


### PR DESCRIPTION
TokenIds are sometimes used directly instead of the meta currency `TOKEN`. This PR makes it official.