### PR TITLE
Require trailing slash in api urls

### DIFF
--- a/maas-schemas-ts/src/environments/apis.ts
+++ b/maas-schemas-ts/src/environments/apis.ts
@@ -164,7 +164,7 @@ export const examplesApiIndex: NonEmptyArray<ApiIndex> = ([
 ] as unknown) as NonEmptyArray<ApiIndex>;
 
 // ApiUrl
-// The purpose of this remains a mystery
+// has to be url, has to start https://, has to end with slash
 export type ApiUrl = t.Branded<string & Units_.Url, ApiUrlBrand>;
 export type ApiUrlC = t.BrandC<
   t.IntersectionC<[t.StringC, typeof Units_.Url]>,
@@ -173,7 +173,7 @@ export type ApiUrlC = t.BrandC<
 export const ApiUrl: ApiUrlC = t.brand(
   t.intersection([t.string, Units_.Url]),
   (x): x is t.Branded<string & Units_.Url, ApiUrlBrand> =>
-    typeof x !== 'string' || x.match(RegExp('^https:')) !== null,
+    typeof x !== 'string' || x.match(RegExp('^https://[^\\s]+/$')) !== null,
   'ApiUrl',
 );
 export interface ApiUrlBrand {

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1278,8 +1278,6 @@ INFO: missing description
   in ../maas-schemas/schemas/environments/apis.json
 INFO: missing description
   in ../maas-schemas/schemas/environments/apis.json
-INFO: missing description
-  in ../maas-schemas/schemas/environments/apis.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/environments/environments.json
 INFO: missing description

--- a/maas-schemas/schemas/environments/apis.json
+++ b/maas-schemas/schemas/environments/apis.json
@@ -53,8 +53,9 @@
       ]
     },
     "apiUrl": {
+      "description": "has to be url, has to start https://, has to end with slash",
       "type": "string",
-      "pattern": "^https:",
+      "pattern": "^https://[^\\s]+/$",
       "allOf": [{ "$ref": "http://maasglobal.com/core/components/units.json#/definitions/url" }],
       "examples": [
         "https://production.example.com/api/",


### PR DESCRIPTION
This adds the requirement for API URLs to end with a trailing slash