### PR TITLE
Fix for benefits initiate request bug

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.19.1",
+  "version": "14.20.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.19.1",
+  "version": "14.20.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/maas-backend/customers/benefits/initiate/request.json
+++ b/maas-schemas/schemas/maas-backend/customers/benefits/initiate/request.json
@@ -35,7 +35,7 @@
         }
       },
       "additionalProperties": true,
-      "oneOf": [
+      "anyOf": [
         { "required": ["amount", "currency"] },
         { "required": ["amount", "currency", "productType", "productId"] }
       ]


### PR DESCRIPTION
## What has been implemented?
Use `anyOf` instead of `oneOf` as alternatives are not mutually exclusive.