### PR TITLE
WS-11244 - Cancellation end time

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.23.0",
+  "version": "14.24.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/core/components/terms.ts
+++ b/maas-schemas-ts/src/core/components/terms.ts
@@ -82,7 +82,6 @@ export type Cancellation = t.Branded<
       startTime?: Units_.Time;
       endTime?: Units_.Time;
     } & {
-      startTime: Defined;
       endTime: Defined;
     };
   } & {
@@ -106,7 +105,6 @@ export type CancellationC = t.BrandC<
               endTime: typeof Units_.Time;
             }>,
             t.TypeC<{
-              startTime: typeof Defined;
               endTime: typeof Defined;
             }>,
           ]
@@ -133,7 +131,6 @@ export const Cancellation: CancellationC = t.brand(
           endTime: Units_.Time,
         }),
         t.type({
-          startTime: Defined,
           endTime: Defined,
         }),
       ]),
@@ -155,7 +152,6 @@ export const Cancellation: CancellationC = t.brand(
         startTime?: Units_.Time;
         endTime?: Units_.Time;
       } & {
-        startTime: Defined;
         endTime: Defined;
       };
     } & {

--- a/maas-schemas-ts/src/core/components/terms.ts
+++ b/maas-schemas-ts/src/core/components/terms.ts
@@ -78,6 +78,13 @@ export type Cancellation = t.Branded<
     cost?: Cost_.Cost;
     fare?: Fare_.Fare;
     refunded?: boolean;
+    validity?: {
+      startTime?: Units_.Time;
+      endTime?: Units_.Time;
+    } & {
+      startTime: Defined;
+      endTime: Defined;
+    };
   } & {
     cancellable: Defined;
     refunded: Defined;
@@ -92,6 +99,18 @@ export type CancellationC = t.BrandC<
         cost: typeof Cost_.Cost;
         fare: typeof Fare_.Fare;
         refunded: t.BooleanC;
+        validity: t.IntersectionC<
+          [
+            t.PartialC<{
+              startTime: typeof Units_.Time;
+              endTime: typeof Units_.Time;
+            }>,
+            t.TypeC<{
+              startTime: typeof Defined;
+              endTime: typeof Defined;
+            }>,
+          ]
+        >;
       }>,
       t.TypeC<{
         cancellable: typeof Defined;
@@ -108,6 +127,16 @@ export const Cancellation: CancellationC = t.brand(
       cost: Cost_.Cost,
       fare: Fare_.Fare,
       refunded: t.boolean,
+      validity: t.intersection([
+        t.partial({
+          startTime: Units_.Time,
+          endTime: Units_.Time,
+        }),
+        t.type({
+          startTime: Defined,
+          endTime: Defined,
+        }),
+      ]),
     }),
     t.type({
       cancellable: Defined,
@@ -122,6 +151,13 @@ export const Cancellation: CancellationC = t.brand(
       cost?: Cost_.Cost;
       fare?: Fare_.Fare;
       refunded?: boolean;
+      validity?: {
+        startTime?: Units_.Time;
+        endTime?: Units_.Time;
+      } & {
+        startTime: Defined;
+        endTime: Defined;
+      };
     } & {
       cancellable: Defined;
       refunded: Defined;

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.23.0",
+  "version": "14.24.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/terms.json
+++ b/maas-schemas/schemas/core/components/terms.json
@@ -187,7 +187,7 @@
             "startTime": { "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" },
             "endTime": { "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }
           },
-          "required": ["startTime", "endTime"]
+          "required": ["endTime"]
         }
       },
       "required": ["cancellable", "refunded"]

--- a/maas-schemas/schemas/core/components/terms.json
+++ b/maas-schemas/schemas/core/components/terms.json
@@ -179,6 +179,15 @@
         "refunded": {
           "type": "boolean",
           "description": "Whether this part of the booking has been refunded"
+        },
+        "validity": {
+          "description": "Cancellation validity conditions",
+          "type": "object",
+          "properties": {
+            "startTime": { "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" },
+            "endTime": { "$ref": "http://maasglobal.com/core/components/units.json#/definitions/time" }
+          },
+          "required": ["startTime", "endTime"]
         }
       },
       "required": ["cancellable", "refunded"]


### PR DESCRIPTION
As discussed and agreed with @konker cancellation policy will have additional `endTime` -> `terms.cancellation.outward.validity.endTime` which will have a timestamp when this policy ends.

Required for: https://maasglobal.atlassian.net/browse/WS-11244

`startTime` is optional as we can simply assume = `startTime` = now().