### PR TITLE
WS-11983 - 24Rent - Finnish SSID

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.29.1",
+  "version": "14.30.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/core/components/common.ts
+++ b/maas-schemas-ts/src/core/components/common.ts
@@ -325,6 +325,21 @@ export interface SsidBrand {
   readonly Ssid: unique symbol;
 }
 
+// SsidFI
+// Finnish Social Security ID
+export type SsidFI = t.Branded<string, SsidFIBrand>;
+export type SsidFIC = t.BrandC<t.StringC, SsidFIBrand>;
+export const SsidFI: SsidFIC = t.brand(
+  t.string,
+  (x): x is t.Branded<string, SsidFIBrand> =>
+    typeof x !== 'string' ||
+    x.match(RegExp('^[0-9]{6}[-+A][0-9]{3}[0-9ABCDEFHJKLMNPRSTUVWXY]$')) !== null,
+  'SsidFI',
+);
+export interface SsidFIBrand {
+  readonly SsidFI: unique symbol;
+}
+
 // EncodedQueryParam
 // Encoded Query Params
 export type EncodedQueryParam = t.Branded<string, EncodedQueryParamBrand>;

--- a/maas-schemas-ts/src/core/customer.ts
+++ b/maas-schemas-ts/src/core/customer.ts
@@ -71,6 +71,7 @@ export type Customer = t.Branded<
     clientId?: Common_.ClientId;
     dob?: boolean | Units_.IsoDate;
     ssid?: boolean | Common_.Ssid;
+    'ssid-fi'?: boolean | Common_.SsidFI;
     documents?: Array<PersonalDocument_.PersonalDocument>;
     balances?: Record<
       string,
@@ -123,6 +124,7 @@ export type CustomerC = t.BrandC<
     clientId: typeof Common_.ClientId;
     dob: t.UnionC<[t.BooleanC, typeof Units_.IsoDate]>;
     ssid: t.UnionC<[t.BooleanC, typeof Common_.Ssid]>;
+    'ssid-fi': t.UnionC<[t.BooleanC, typeof Common_.SsidFI]>;
     documents: t.ArrayC<typeof PersonalDocument_.PersonalDocument>;
     balances: t.RecordC<
       t.StringC,
@@ -203,6 +205,7 @@ export const Customer: CustomerC = t.brand(
     clientId: Common_.ClientId,
     dob: t.union([t.boolean, Units_.IsoDate]),
     ssid: t.union([t.boolean, Common_.Ssid]),
+    'ssid-fi': t.union([t.boolean, Common_.SsidFI]),
     documents: t.array(PersonalDocument_.PersonalDocument),
     balances: t.record(
       t.string,
@@ -269,6 +272,7 @@ export const Customer: CustomerC = t.brand(
       clientId?: Common_.ClientId;
       dob?: boolean | Units_.IsoDate;
       ssid?: boolean | Common_.Ssid;
+      'ssid-fi'?: boolean | Common_.SsidFI;
       documents?: Array<PersonalDocument_.PersonalDocument>;
       balances?: Record<
         string,

--- a/maas-schemas-ts/src/core/personal-document.ts
+++ b/maas-schemas-ts/src/core/personal-document.ts
@@ -346,11 +346,11 @@ export const examplesValidTo: NonEmptyArray<ValidTo> = ([
 
 // Category
 // The purpose of this remains a mystery
-export type Category = t.Branded<string | Null, CategoryBrand>;
-export type CategoryC = t.BrandC<t.UnionC<[t.StringC, typeof Null]>, CategoryBrand>;
+export type Category = t.Branded<Null | string, CategoryBrand>;
+export type CategoryC = t.BrandC<t.UnionC<[typeof Null, t.StringC]>, CategoryBrand>;
 export const Category: CategoryC = t.brand(
-  t.union([t.string, Null]),
-  (x): x is t.Branded<string | Null, CategoryBrand> => true,
+  t.union([Null, t.string]),
+  (x): x is t.Branded<Null | string, CategoryBrand> => true,
   'Category',
 );
 export interface CategoryBrand {

--- a/maas-schemas-ts/src/maas-backend/customers/personalData.ts
+++ b/maas-schemas-ts/src/maas-backend/customers/personalData.ts
@@ -35,6 +35,7 @@ export type PersonalData = t.Branded<
     zipCode?: Address_.ZipCode;
     dob?: boolean | Units_.IsoDate;
     ssid?: boolean | Common_.Ssid;
+    'ssid-fi'?: boolean | Common_.SsidFI;
     subscriberType?: string;
     profileImageUrl?: string;
     nationality?: string;
@@ -61,6 +62,7 @@ export type PersonalDataC = t.BrandC<
         zipCode: typeof Address_.ZipCode;
         dob: t.UnionC<[t.BooleanC, typeof Units_.IsoDate]>;
         ssid: t.UnionC<[t.BooleanC, typeof Common_.Ssid]>;
+        'ssid-fi': t.UnionC<[t.BooleanC, typeof Common_.SsidFI]>;
         subscriberType: t.StringC;
         profileImageUrl: t.StringC;
         nationality: t.StringC;
@@ -89,6 +91,7 @@ export const PersonalData: PersonalDataC = t.brand(
       zipCode: Address_.ZipCode,
       dob: t.union([t.boolean, Units_.IsoDate]),
       ssid: t.union([t.boolean, Common_.Ssid]),
+      'ssid-fi': t.union([t.boolean, Common_.SsidFI]),
       subscriberType: t.string,
       profileImageUrl: t.string,
       nationality: t.string,
@@ -115,6 +118,7 @@ export const PersonalData: PersonalDataC = t.brand(
       zipCode?: Address_.ZipCode;
       dob?: boolean | Units_.IsoDate;
       ssid?: boolean | Common_.Ssid;
+      'ssid-fi'?: boolean | Common_.SsidFI;
       subscriberType?: string;
       profileImageUrl?: string;
       nationality?: string;

--- a/maas-schemas-ts/src/tsp/post-kyc-verification-update/request.ts
+++ b/maas-schemas-ts/src/tsp/post-kyc-verification-update/request.ts
@@ -36,6 +36,7 @@ export const schemaId =
 export type Request = t.Branded<
   {
     customer?: Customer_.Customer;
+    verified?: Array<string>;
   } & {
     customer: Defined;
   },
@@ -46,6 +47,7 @@ export type RequestC = t.BrandC<
     [
       t.PartialC<{
         customer: typeof Customer_.Customer;
+        verified: t.ArrayC<t.StringC>;
       }>,
       t.TypeC<{
         customer: typeof Defined;
@@ -58,6 +60,7 @@ export const Request: RequestC = t.brand(
   t.intersection([
     t.partial({
       customer: Customer_.Customer,
+      verified: t.array(t.string),
     }),
     t.type({
       customer: Defined,
@@ -68,6 +71,7 @@ export const Request: RequestC = t.brand(
   ): x is t.Branded<
     {
       customer?: Customer_.Customer;
+      verified?: Array<string>;
     } & {
       customer: Defined;
     },
@@ -105,6 +109,7 @@ export const examplesRequest: NonEmptyArray<Request> = ([
         },
       ],
     },
+    verified: ['dob', 'ssid'],
   },
 ] as unknown) as NonEmptyArray<Request>;
 

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -2866,6 +2866,8 @@ WARNING: missing $schema declaration
   in ../maas-schemas/schemas/tsp/package-create/response.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/tsp/post-kyc-verification-update/request.json
+INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/tsp/post-kyc-verification-update/request.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
 INFO: primitive type "number" used outside top-level definitions

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1044,10 +1044,6 @@ INFO: missing description
   in ../maas-schemas/schemas/core/paymentSource.json
 INFO: missing description
   in ../maas-schemas/schemas/core/paymentSource.json
-INFO: primitive type "string" used outside top-level definitions
-  in ../maas-schemas/schemas/core/personal-document.json
-WARNING: examples field not supported outside top-level definitions
-  in ../maas-schemas/schemas/core/personal-document.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/core/personal-document.json
 INFO: missing description

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.29.1",
+  "version": "14.30.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/common.json
+++ b/maas-schemas/schemas/core/components/common.json
@@ -101,6 +101,11 @@
       "type": "string",
       "minLength": 4
     },
+    "ssidFI": {
+      "description": "Finnish Social Security ID",
+      "type": "string",
+      "pattern": "^[0-9]{6}[-+A][0-9]{3}[0-9ABCDEFHJKLMNPRSTUVWXY]$"
+    },
     "encodedQueryParam": {
       "description": "Encoded Query Params",
       "type": "string",

--- a/maas-schemas/schemas/core/customer.json
+++ b/maas-schemas/schemas/core/customer.json
@@ -88,6 +88,15 @@
         }
       ]
     },
+    "ssid-fi": {
+      "description": "Finnish Social Security ID",
+      "anyOf": [
+        { "type": "boolean" },
+        {
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/ssidFI"
+        }
+      ]
+    },
     "documents": {
       "type": "array",
       "items": {

--- a/maas-schemas/schemas/core/personal-document.json
+++ b/maas-schemas/schemas/core/personal-document.json
@@ -58,15 +58,7 @@
       "examples": ["2030-12-31"]
     },
     "category": {
-      "oneOf": [
-        {
-          "type": "string",
-          "examples": ["normal"]
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": ["null", "string"]
     },
     "details": {
       "type": "object"

--- a/maas-schemas/schemas/maas-backend/customers/personalData.json
+++ b/maas-schemas/schemas/maas-backend/customers/personalData.json
@@ -73,6 +73,17 @@
         }
       ]
     },
+    "ssid-fi": {
+      "description": "Finnish Social Security ID",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "http://maasglobal.com/core/components/common.json#/definitions/ssidFI"
+        }
+      ]
+    },
     "subscriberType": {
       "description": "Subscriber Type",
       "type": "string"

--- a/maas-schemas/schemas/tsp/post-kyc-verification-update/request.json
+++ b/maas-schemas/schemas/tsp/post-kyc-verification-update/request.json
@@ -5,6 +5,11 @@
   "properties": {
     "customer": {
       "$ref": "http://maasglobal.com/core/customer.json"
+    },
+    "verified": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of verified personal data itmes"
     }
   },
   "required": ["customer"],
@@ -40,7 +45,8 @@
             "validTo": "2022-02-21"
           }
         ]
-      }
+      },
+      "verified": ["dob", "ssid"]
     }
   ]
 }


### PR DESCRIPTION
## What has been implemented?

Finnish SSID - JIRA: https://maasglobal.atlassian.net/browse/WS-11983

Added `verified` list - used to pass additional information to TSP

Additionally, corrected:
```
 "message": {
        "logMessage": "[TSP] Caught a request validation error: '.customer.documents[0].category' should match exactly one schema in oneOf, got 'null'"
    }
```

More info: https://bleepcoder.com/ajv/511358905/oneof-with-type-null-breaks-validation


JIRA: https://maasglobal.atlassian.net/browse/WS-11983