### PR TITLE
WS-11991 - Added state and errorCode to post-kyc-verification-update response

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "14.28.0",
+  "version": "14.29.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/tsp/post-kyc-verification-update/response.ts
+++ b/maas-schemas-ts/src/tsp/post-kyc-verification-update/response.ts
@@ -36,6 +36,8 @@ export type Response = t.Branded<
   {
     status?: number;
     message?: string;
+    state?: string;
+    errorCode?: string;
   } & {
     message: Defined;
     status: Defined;
@@ -48,6 +50,8 @@ export type ResponseC = t.BrandC<
       t.PartialC<{
         status: t.NumberC;
         message: t.StringC;
+        state: t.StringC;
+        errorCode: t.StringC;
       }>,
       t.TypeC<{
         message: typeof Defined;
@@ -62,6 +66,8 @@ export const Response: ResponseC = t.brand(
     t.partial({
       status: t.number,
       message: t.string,
+      state: t.string,
+      errorCode: t.string,
     }),
     t.type({
       message: Defined,
@@ -74,6 +80,8 @@ export const Response: ResponseC = t.brand(
     {
       status?: number;
       message?: string;
+      state?: string;
+      errorCode?: string;
     } & {
       message: Defined;
       status: Defined;
@@ -88,6 +96,12 @@ export interface ResponseBrand {
 /** require('io-ts-validator').validator(nonEmptyArray(Response)).decodeSync(examplesResponse) // => examplesResponse */
 export const examplesResponse: NonEmptyArray<Response> = ([
   { status: 200, message: 'Documents were processed.' },
+  {
+    status: 403,
+    message: 'Verification state returned from TSP',
+    state: 'DECLINED',
+    errorCode: 'ERROR_TSP_CATEGORY_B_REQUIRED',
+  },
 ] as unknown) as NonEmptyArray<Response>;
 
 export default Response;

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -2868,6 +2868,10 @@ INFO: primitive type "number" used outside top-level definitions
   in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
+INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
+INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/tsp/stations-list/request.json
 INFO: primitive type "string" used outside top-level definitions

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "14.28.0",
+  "version": "14.29.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
+++ b/maas-schemas/schemas/tsp/post-kyc-verification-update/response.json
@@ -4,10 +4,20 @@
   "type": "object",
   "properties": {
     "status": {
-      "type": "number"
+      "type": "number",
+      "description": "Status code"
     },
     "message": {
-      "type": "string"
+      "type": "string",
+      "description": "Debug message"
+    },
+    "state": {
+      "type": "string",
+      "description": "Verification state"
+    },
+    "errorCode": {
+      "type": "string",
+      "description": "Error code"
     }
   },
   "required": ["message", "status"],
@@ -16,6 +26,12 @@
     {
       "status": 200,
       "message": "Documents were processed."
+    },
+    {
+      "status": 403,
+      "message": "Verification state returned from TSP",
+      "state": "DECLINED",
+      "errorCode": "ERROR_TSP_CATEGORY_B_REQUIRED"
     }
   ]
 }


### PR DESCRIPTION
## What has been implemented?

Added `state` and `errorCode` to `post-kyc-verification-update` response.

More details: https://maasglobal.atlassian.net/browse/WS-11991