### PR TITLE
Fix jest warning

### DIFF
--- a/maas-schemas-ts/jest.config.js
+++ b/maas-schemas-ts/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json',
+      tsconfig: 'tsconfig.json',
       diagnostics: {
         ignoreCodes: [6133, 6196],
       },


### PR DESCRIPTION
Jest keeps complaining "ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead". This PR fixes the warning.