### PR TITLE
Check counterexamples

### DIFF
--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -168,6 +168,8 @@ WARNING: unexpected key in a $ref object
   in ../maas-schemas/schemas/core/components/car-rental.json
 INFO: missing description
   in ../maas-schemas/schemas/core/components/car-rental.json
+WARNING: invalid field not supported
+  in ../maas-schemas/schemas/core/components/common.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/core/components/common.json
 INFO: missing description

--- a/maas-schemas/schemas/core/components/common.json
+++ b/maas-schemas/schemas/core/components/common.json
@@ -49,7 +49,10 @@
       "description": "ITU-T E.164 phone number, see https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s03.html",
       "type": "string",
       "pattern": "^\\+(?:\\d){6,14}\\d$",
-      "examples": ["+358401234567"]
+      "examples": ["+358401234567"],
+      "invalid": {
+        "IjM1ODQwMTIzNDU2NyI=": "phone number without plus"
+      }
     },
     "rawPhone": {
       "description": "Slightly looser definition of phone number",

--- a/maas-schemas/test/feature-require-schemas.js
+++ b/maas-schemas/test/feature-require-schemas.js
@@ -17,7 +17,7 @@ const ajv = ajvFactory({ allErrors: true });
 const JP_ROOT = '#';
 
 /**
- * Declaration checker
+ * Examples checker
  *
  * @param uri string
  * @param schema JSONSchema7Definition
@@ -59,6 +59,27 @@ function checkExamples(uri, schema) {
   if (typeof constant !== 'undefined') {
     it(`must accept ${pointer}/const ${JSON.stringify(constant)}`, () => {
       validate(uri, constant);
+    });
+  }
+
+  const { invalid } = schema;
+  if (typeof invalid !== 'undefined') {
+    Object.keys(invalid).forEach(b64 => {
+      const text = Buffer.from(b64, 'base64').toString('ascii');
+      const cut = text.slice(0, 40);
+      const display = text === cut ? cut : cut.concat('...');
+
+      const counterExample = JSON.parse(text);
+      const description = invalid[b64];
+      it(`must reject ${pointer}/invalid/${b64} ${description} ${display}`, () => {
+        try {
+          validate(uri, counterExample);
+        } catch (_validationError) {
+          // counterexamples should fail validation
+          return;
+        }
+        throw new Error('Counterexample passed validation!');
+      });
     });
   }
 }


### PR DESCRIPTION
This PR adds a test case that can be used to check invalid examples. The invalid values are base64 encoded to ensure that they look different from valid examples. Each invalid example comes with a comment explaining the contents of the base64 encoded value.

```
      #/definitions/phone
        ✓ must accept #/definitions/phone/examples/0 "+358401234567"
        ✓ must reject #/definitions/phone/invalid/IjM1ODQwMTIzNDU2NyI= phone number without plus "358401234567"
```