### PR TITLE
WHM-1596 taxi pickup at

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "15.3.1",
+  "version": "15.4.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "15.3.0",
+  "version": "15.3.1",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/_types/core/modes/MODE_TAXI.ts
+++ b/maas-schemas-ts/src/_types/core/modes/MODE_TAXI.ts
@@ -34,6 +34,7 @@ export type MODE_TAXI = t.Branded<
     pickupIdentificationCode?: string;
     dispatchOrderId?: string;
     eta?: Units_.Time;
+    pickupAt?: Units_.Time;
     taxiCenter?: {
       image?: Units_.Url;
       name?: string;
@@ -60,6 +61,7 @@ export type MODE_TAXIC = t.BrandC<
     pickupIdentificationCode: t.StringC;
     dispatchOrderId: t.StringC;
     eta: typeof Units_.Time;
+    pickupAt: typeof Units_.Time;
     taxiCenter: t.PartialC<{
       image: typeof Units_.Url;
       name: t.StringC;
@@ -86,6 +88,7 @@ export const MODE_TAXI: MODE_TAXIC = t.brand(
     pickupIdentificationCode: t.string,
     dispatchOrderId: t.string,
     eta: Units_.Time,
+    pickupAt: Units_.Time,
     taxiCenter: t.partial({
       image: Units_.Url,
       name: t.string,
@@ -112,6 +115,7 @@ export const MODE_TAXI: MODE_TAXIC = t.brand(
       pickupIdentificationCode?: string;
       dispatchOrderId?: string;
       eta?: Units_.Time;
+      pickupAt?: Units_.Time;
       taxiCenter?: {
         image?: Units_.Url;
         name?: string;

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1010,6 +1010,8 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
+WARNING: unexpected key in a $ref object
+  in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/modes/MODE_TAXI.json
 WARNING: minLength field not supported outside top-level definitions

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "15.3.0",
+  "version": "15.3.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "15.3.1",
+  "version": "15.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/modes/MODE_TAXI.json
+++ b/maas-schemas/schemas/core/modes/MODE_TAXI.json
@@ -59,7 +59,7 @@
     },
     "eta": { "$ref": "https://schemas.maas.global/core/components/units.json#/definitions/time" },
     "pickupAt": {
-      "description": "The time that the customer requires the taxi to pick them up.",
+      "description": "The time that the customer requires the taxi to pick them up. It’s the same what booking.leg.startime if operator doesn't change anything, otherwise it can be different.",
       "$ref": "https://schemas.maas.global/core/components/units.json#/definitions/time"
     },
     "taxiCenter": {

--- a/maas-schemas/schemas/core/modes/MODE_TAXI.json
+++ b/maas-schemas/schemas/core/modes/MODE_TAXI.json
@@ -58,6 +58,10 @@
       "maxLength": 128
     },
     "eta": { "$ref": "https://schemas.maas.global/core/components/units.json#/definitions/time" },
+    "pickupAt": {
+      "description": "The time that the customer requires the taxi to pick them up.",
+      "$ref": "https://schemas.maas.global/core/components/units.json#/definitions/time"
+    },
     "taxiCenter": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
`PickUpAt` – the time that the Customer requires the taxi to pick them up

It is not always the same what: `booking.leg.starttime` (the time when the trip is requested to start). In typical scenario: `pickupAt` == `booking.leg.starttime`, but we can have scenarios when taxi operator updates pickup at in admin panel (after contacting customer) and then : `pickupAt` != `booking.leg.starttime`. We can not reflect this change, editing `booking.leg.starttime` becuase this is used in so many other places in BE (example step functions) so new meta information has been added. To sum up:

`PickupAt` - it’s the same what `booking.leg.startime` if operator doesnt change anything, otherwise it can be different.
