### PR TITLE
Force a newer version to be published in Nexus

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "15.5.0",
+  "version": "15.6.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "15.5.0",
+  "version": "15.6.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {


### PR DESCRIPTION
Oddly, previous PR didn't show version conflict: https://github.com/maasglobal/maas-schemas/pull/666

Force a newer version to be published in Nexus (that has changes from PR #666).