### PR TITLE
WHM-1700 - add payment instruction

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "15.11.0",
+  "version": "15.12.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/_types/core/product.ts
+++ b/maas-schemas-ts/src/_types/core/product.ts
@@ -116,6 +116,7 @@ export type Product = t.Branded<
     tspProductId?: string;
     allowFinishTrip?: boolean;
     preAuthBuffer?: PreAuthBuffer;
+    paymentInstruction?: string;
   } & {
     id: Defined;
     tspProductId: Defined;
@@ -136,6 +137,7 @@ export type ProductC = t.BrandC<
         tspProductId: t.StringC;
         allowFinishTrip: t.BooleanC;
         preAuthBuffer: typeof PreAuthBuffer;
+        paymentInstruction: t.StringC;
       }>,
       t.TypeC<{
         id: typeof Defined;
@@ -158,6 +160,7 @@ export const Product: ProductC = t.brand(
       tspProductId: t.string,
       allowFinishTrip: t.boolean,
       preAuthBuffer: PreAuthBuffer,
+      paymentInstruction: t.string,
     }),
     t.type({
       id: Defined,
@@ -178,6 +181,7 @@ export const Product: ProductC = t.brand(
       tspProductId?: string;
       allowFinishTrip?: boolean;
       preAuthBuffer?: PreAuthBuffer;
+      paymentInstruction?: string;
     } & {
       id: Defined;
       tspProductId: Defined;

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -1214,6 +1214,12 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/product.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/product.json
+INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/core/product.json
+WARNING: minLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/product.json
+WARNING: maxLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/product.json
 INFO: missing description
   in ../maas-schemas/schemas/core/product.json
 INFO: missing description

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "15.11.0",
+  "version": "15.12.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/product.json
+++ b/maas-schemas/schemas/core/product.json
@@ -38,6 +38,12 @@
     },
     "preAuthBuffer": {
       "$ref": "#/definitions/preAuthBuffer"
+    },
+    "paymentInstruction": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "description": "A product may define a text to be shown in Detailed Pricing segment, due to regulatory or partner mandated requirement. This is informed by product.paymentInstruction object, containing localized text string"
     }
   },
   "definitions": {


### PR DESCRIPTION
Added `paymentInstruction` to product object.

WIKI: https://maasglobal.atlassian.net/wiki/spaces/MM/pages/2408382479/Payment+confirmation+price+details

slack discussion: https://maasfi.slack.com/archives/GTHV87PT8/p1641807211055700?thread_ts=1641517058.006000&cid=GTHV87PT8