### PR TITLE
TSP receipt duration

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas-ts",
-  "version": "15.23.0",
+  "version": "15.24.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas-ts/src/_types/tsp/booking-receipt/response.ts
+++ b/maas-schemas-ts/src/_types/tsp/booking-receipt/response.ts
@@ -92,6 +92,7 @@ export interface TspReceiptBrand {
 export type Response = t.Branded<
   {
     tspId?: Booking_.TspId;
+    cost?: Booking_.Cost;
     receipt?: TspReceipt;
   } & {
     tspId: Defined;
@@ -104,6 +105,7 @@ export type ResponseC = t.BrandC<
     [
       t.PartialC<{
         tspId: typeof Booking_.TspId;
+        cost: typeof Booking_.Cost;
         receipt: typeof TspReceipt;
       }>,
       t.TypeC<{
@@ -118,6 +120,7 @@ export const Response: ResponseC = t.brand(
   t.intersection([
     t.partial({
       tspId: Booking_.TspId,
+      cost: Booking_.Cost,
       receipt: TspReceipt,
     }),
     t.type({
@@ -130,6 +133,7 @@ export const Response: ResponseC = t.brand(
   ): x is t.Branded<
     {
       tspId?: Booking_.TspId;
+      cost?: Booking_.Cost;
       receipt?: TspReceipt;
     } & {
       tspId: Defined;
@@ -146,6 +150,14 @@ export interface ResponseBrand {
 export const examplesResponse: NonEmptyArray<Response> = ([
   {
     tspId: 'abc123',
+    receipt: {
+      cost: { amount: 23.45, currency: 'EUR' },
+      terms: { validity: { endTime: 1658177898859, startTime: 1658177898859 } },
+    },
+  },
+  {
+    tspId: 'abc123',
+    cost: { amount: 23.45, currency: 'EUR' },
     receipt: {
       cost: { amount: 23.45, currency: 'EUR' },
       terms: { validity: { endTime: 1658177898859, startTime: 1658177898859 } },

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas",
-  "version": "15.23.0",
+  "version": "15.24.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas/schemas/tsp/booking-receipt/response.json
+++ b/maas-schemas/schemas/tsp/booking-receipt/response.json
@@ -2,18 +2,47 @@
   "$id": "https://schemas.maas.global/tsp/booking-receipt/response.json",
   "description": "Response schema for getting a receipt for specific booking",
   "type": "object",
+  "definitions": {
+    "tspReceipt": {
+      "type": "object",
+      "description": "Receipt as received from TSP",
+      "properties": {
+        "cost": {
+          "$ref": "https://schemas.maas.global/core/booking.json#/definitions/cost"
+        },
+        "terms": {
+          "$ref": "https://schemas.maas.global/core/components/terms.json"
+        }
+      },
+      "required": ["cost", "terms"],
+      "additionalProperties": false
+    }
+  },
   "properties": {
     "tspId": {
       "$ref": "https://schemas.maas.global/core/booking.json#/definitions/tspId"
     },
-    "cost": {
-      "$ref": "https://schemas.maas.global/core/booking.json#/definitions/cost"
-    },
     "receipt": {
-      "type": "object",
-      "description": "Receipt as received from TSP, could be stored for future reference."
+      "$ref": "#/definitions/tspReceipt"
     }
   },
-  "required": ["tspId", "cost"],
-  "additionalProperties": false
+  "required": ["tspId", "receipt"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "tspId": "abc123",
+      "receipt": {
+        "cost": {
+          "amount": 23.45,
+          "currency": "EUR"
+        },
+        "terms": {
+          "validity": {
+            "endTime": 1658177898859,
+            "startTime": 1658177898859
+          }
+        }
+      }
+    }
+  ]
 }

--- a/maas-schemas/schemas/tsp/booking-receipt/response.json
+++ b/maas-schemas/schemas/tsp/booking-receipt/response.json
@@ -22,6 +22,9 @@
     "tspId": {
       "$ref": "https://schemas.maas.global/core/booking.json#/definitions/tspId"
     },
+    "cost": {
+      "$ref": "https://schemas.maas.global/core/booking.json#/definitions/cost"
+    },
     "receipt": {
       "$ref": "#/definitions/tspReceipt"
     }
@@ -31,6 +34,25 @@
   "examples": [
     {
       "tspId": "abc123",
+      "receipt": {
+        "cost": {
+          "amount": 23.45,
+          "currency": "EUR"
+        },
+        "terms": {
+          "validity": {
+            "endTime": 1658177898859,
+            "startTime": 1658177898859
+          }
+        }
+      }
+    },
+    {
+      "tspId": "abc123",
+      "cost": {
+        "amount": 23.45,
+        "currency": "EUR"
+      },
       "receipt": {
         "cost": {
           "amount": 23.45,


### PR DESCRIPTION
## What has been implemented?
Amend the TSP receipt response schema to include terms.
This also introduces a TspReceipt type into typescript.

This will alllows clients to have reliable duration data when dealing with receipts, e.g. backend reconcile process.

See:
https://maasfi.slack.com/archives/C0QPZRKS4/p1658162964303249
