### PR TITLE
Fare rates unlock fee

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas-ts",
-  "version": "15.22.0",
+  "version": "15.23.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas-ts/src/_types/core/components/terms.ts
+++ b/maas-schemas-ts/src/_types/core/components/terms.ts
@@ -359,7 +359,8 @@ export type Terms = t.Branded<
           | 'missedReturnPenalty'
           | 'extra'
           | 'perKilometer'
-          | 'perParkMinute';
+          | 'perParkMinute'
+          | 'unlockFee';
       } & Record<string, unknown>) & {
         amount: Defined;
         currency: Defined;
@@ -463,6 +464,7 @@ export type TermsC = t.BrandC<
                         t.LiteralC<'extra'>,
                         t.LiteralC<'perKilometer'>,
                         t.LiteralC<'perParkMinute'>,
+                        t.LiteralC<'unlockFee'>,
                       ]
                     >;
                   }>,
@@ -557,6 +559,7 @@ export const Terms: TermsC = t.brand(
                 t.literal('extra'),
                 t.literal('perKilometer'),
                 t.literal('perParkMinute'),
+                t.literal('unlockFee'),
               ]),
             }),
             t.record(t.string, t.unknown),
@@ -622,7 +625,8 @@ export const Terms: TermsC = t.brand(
             | 'missedReturnPenalty'
             | 'extra'
             | 'perKilometer'
-            | 'perParkMinute';
+            | 'perParkMinute'
+            | 'unlockFee';
         } & Record<string, unknown>) & {
           amount: Defined;
           currency: Defined;

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas",
-  "version": "15.22.0",
+  "version": "15.23.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas/schemas/core/components/terms.json
+++ b/maas-schemas/schemas/core/components/terms.json
@@ -151,7 +151,7 @@
             "multipleOf": 1
           },
           "type": {
-            "enum": ["maxRate", "missedReturnPenalty", "extra", "perKilometer", "perParkMinute"]
+            "enum": ["maxRate", "missedReturnPenalty", "extra", "perKilometer", "perParkMinute", "unlockFee"]
           }
         },
         "required": ["amount", "currency"]


### PR DESCRIPTION
## What has been implemented?
Fairly trivial extra type added for fare rates.

For some reason, most scooters don't include the unlock fee in fare rates.
We plan to add this, using this new type.