### PR TITLE
Unmodified terms

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas-ts",
-  "version": "15.24.0",
+  "version": "15.25.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas-ts/src/_types/core/booking.ts
+++ b/maas-schemas-ts/src/_types/core/booking.ts
@@ -318,6 +318,7 @@ export type Booking = t.Branded<
     token?: Token;
     meta?: BookingMeta_.BookingMeta;
     terms?: Terms;
+    unmodifiedTerms?: Terms;
     customer?: Customer_.Customer & {
       identityId: Defined;
     };
@@ -352,6 +353,7 @@ export type BookingC = t.BrandC<
             token: typeof Token;
             meta: typeof BookingMeta_.BookingMeta;
             terms: typeof Terms;
+            unmodifiedTerms: typeof Terms;
             customer: t.IntersectionC<
               [
                 typeof Customer_.Customer,
@@ -395,6 +397,7 @@ export const Booking: BookingC = t.brand(
         token: Token,
         meta: BookingMeta_.BookingMeta,
         terms: Terms,
+        unmodifiedTerms: Terms,
         customer: t.intersection([
           Customer_.Customer,
           t.type({
@@ -432,6 +435,7 @@ export const Booking: BookingC = t.brand(
       token?: Token;
       meta?: BookingMeta_.BookingMeta;
       terms?: Terms;
+      unmodifiedTerms?: Terms;
       customer?: Customer_.Customer & {
         identityId: Defined;
       };
@@ -1119,7 +1123,11 @@ export const examplesBooking: NonEmptyArray<Booking> = ([
       reusable: false,
       validity: { endTime: 1636426799000, startTime: 1636372740000 },
     },
-    meta: {},
+    unmodifiedTerms: {
+      reusable: true,
+      validity: { endTime: 1636426799000, startTime: 1636372740000 },
+    },
+    meta: { foo: 'bar' },
     created: 1636370303239,
     modified: 1636370618830,
     cost: null,

--- a/maas-schemas-ts/src/_types/core/components/configuratorCommon.ts
+++ b/maas-schemas-ts/src/_types/core/components/configuratorCommon.ts
@@ -42,6 +42,7 @@ export type Choice = t.Branded<
     cost?: Cost_.Cost;
     fares?: Array<Fare_.Fare>;
     terms?: Terms_.Terms;
+    unmodifiedTerms?: Terms_.Terms;
     meta?: Record<string, unknown> & Record<string, unknown>;
   } & Record<string, unknown>) & {
     id: Defined;
@@ -63,6 +64,7 @@ export type ChoiceC = t.BrandC<
             cost: typeof Cost_.Cost;
             fares: t.ArrayC<typeof Fare_.Fare>;
             terms: typeof Terms_.Terms;
+            unmodifiedTerms: typeof Terms_.Terms;
             meta: t.IntersectionC<[t.UnknownRecordC, t.RecordC<t.StringC, t.UnknownC>]>;
           }>,
           t.RecordC<t.StringC, t.UnknownC>,
@@ -88,6 +90,7 @@ export const Choice: ChoiceC = t.brand(
         cost: Cost_.Cost,
         fares: t.array(Fare_.Fare),
         terms: Terms_.Terms,
+        unmodifiedTerms: Terms_.Terms,
         meta: t.intersection([t.UnknownRecord, t.record(t.string, t.unknown)]),
       }),
       t.record(t.string, t.unknown),
@@ -109,6 +112,7 @@ export const Choice: ChoiceC = t.brand(
       cost?: Cost_.Cost;
       fares?: Array<Fare_.Fare>;
       terms?: Terms_.Terms;
+      unmodifiedTerms?: Terms_.Terms;
       meta?: Record<string, unknown> & Record<string, unknown>;
     } & Record<string, unknown>) & {
       id: Defined;

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas",
-  "version": "15.24.0",
+  "version": "15.25.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas/schemas/core/booking.json
+++ b/maas-schemas/schemas/core/booking.json
@@ -47,6 +47,9 @@
     "terms": {
       "$ref": "#/definitions/terms"
     },
+    "unmodifiedTerms": {
+      "$ref": "#/definitions/terms"
+    },
     "customer": {
       "description": "MaaS booking customer",
       "allOf": [
@@ -981,7 +984,16 @@
           "startTime": 1636372740000
         }
       },
-      "meta": {},
+      "unmodifiedTerms": {
+        "reusable": true,
+        "validity": {
+          "endTime": 1636426799000,
+          "startTime": 1636372740000
+        }
+      },
+      "meta": {
+        "foo": "bar"
+      },
       "created": 1636370303239,
       "modified": 1636370618830,
       "cost": null,

--- a/maas-schemas/schemas/core/components/configuratorCommon.json
+++ b/maas-schemas/schemas/core/components/configuratorCommon.json
@@ -60,6 +60,9 @@
         "terms": {
           "$ref": "https://schemas.maas.global/core/components/terms.json"
         },
+        "unmodifiedTerms": {
+          "$ref": "https://schemas.maas.global/core/components/terms.json"
+        },
         "meta": {
           "type": "object"
         }


### PR DESCRIPTION
## What has been implemented?
Add (optional) `modifiedTerms` property to booking and configuratorChoice.
This is so that fare rules can have the original terms to use during reconcile logic.
Fare rules may modify the terms when pricing an option, so this "remembers" the original terms which can be referenced during reconcile.

