### PR TITLE
WS-15073: Improve logs for async reservation.

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas-ts",
-  "version": "15.25.0",
+  "version": "15.26.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas-ts/src/_types/tsp/booking-read-by-id/response.ts
+++ b/maas-schemas-ts/src/_types/tsp/booking-read-by-id/response.ts
@@ -13,6 +13,7 @@ import * as Booking_ from '../../core/booking';
 import * as State_ from '../../core/components/state';
 import * as BookingOption_ from '../../core/booking-option';
 import * as BookingMeta_ from '../../core/booking-meta';
+import * as Error_ from '../../core/error';
 
 export type Defined = {} | null;
 export class DefinedType extends t.Type<Defined> {
@@ -44,6 +45,13 @@ export type Response = t.Branded<
     terms?: Booking_.Terms;
     token?: Booking_.Token;
     tspProduct?: BookingOption_.TspProduct;
+    error?: ({
+      message?: Error_.ErrorMessage;
+      code?: Error_.ErrorCode;
+    } & Record<string, unknown>) & {
+      message: Defined;
+      code: Defined;
+    };
   } & {
     tspId: Defined;
     state: Defined;
@@ -62,6 +70,23 @@ export type ResponseC = t.BrandC<
         terms: typeof Booking_.Terms;
         token: typeof Booking_.Token;
         tspProduct: typeof BookingOption_.TspProduct;
+        error: t.IntersectionC<
+          [
+            t.IntersectionC<
+              [
+                t.PartialC<{
+                  message: typeof Error_.ErrorMessage;
+                  code: typeof Error_.ErrorCode;
+                }>,
+                t.RecordC<t.StringC, t.UnknownC>,
+              ]
+            >,
+            t.TypeC<{
+              message: typeof Defined;
+              code: typeof Defined;
+            }>,
+          ]
+        >;
       }>,
       t.TypeC<{
         tspId: typeof Defined;
@@ -82,6 +107,19 @@ export const Response: ResponseC = t.brand(
       terms: Booking_.Terms,
       token: Booking_.Token,
       tspProduct: BookingOption_.TspProduct,
+      error: t.intersection([
+        t.intersection([
+          t.partial({
+            message: Error_.ErrorMessage,
+            code: Error_.ErrorCode,
+          }),
+          t.record(t.string, t.unknown),
+        ]),
+        t.type({
+          message: Defined,
+          code: Defined,
+        }),
+      ]),
     }),
     t.type({
       tspId: Defined,
@@ -100,6 +138,13 @@ export const Response: ResponseC = t.brand(
       terms?: Booking_.Terms;
       token?: Booking_.Token;
       tspProduct?: BookingOption_.TspProduct;
+      error?: ({
+        message?: Error_.ErrorMessage;
+        code?: Error_.ErrorCode;
+      } & Record<string, unknown>) & {
+        message: Defined;
+        code: Defined;
+      };
     } & {
       tspId: Defined;
       state: Defined;

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maasglobal/maas-schemas",
-  "version": "15.25.0",
+  "version": "15.26.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "publishConfig": {

--- a/maas-schemas/schemas/tsp/booking-read-by-id/response.json
+++ b/maas-schemas/schemas/tsp/booking-read-by-id/response.json
@@ -26,6 +26,18 @@
     },
     "tspProduct": {
       "$ref": "https://schemas.maas.global/core/booking-option.json#/definitions/tspProduct"
+    },
+    "error": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "$ref": "https://schemas.maas.global/core/error.json#/definitions/errorMessage"
+        },
+        "code": {
+          "$ref": "https://schemas.maas.global/core/error.json#/definitions/errorCode"
+        }
+      },
+      "required": ["message", "code"]
     }
   },
   "required": ["tspId", "state"],


### PR DESCRIPTION
## What has been implemented?

Add new booking property `error` which is used to proxy error to backend when reservcation is async. 

https://maasglobal.atlassian.net/browse/WS-15073
