### PR TITLE
Update ajv json schema validator

### DIFF
--- a/maasglobal-json-schema-validator/package.json
+++ b/maasglobal-json-schema-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maasglobal-json-schema-validator",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "license": "MIT",
   "main": "lib/index.js",

--- a/maasglobal-json-schema-validator/package.json
+++ b/maasglobal-json-schema-validator/package.json
@@ -8,8 +8,7 @@
     "lib/**/*"
   ],
   "dependencies": {
-    "ajv": "^6.8.1",
-    "ajv-keywords": "^3.4.1"
+    "ajv": "^8.12.0"
   },
   "devDependencies": {
     "@types/glob": "^8.0.0",

--- a/maasglobal-json-schema-validator/src/conformance.ts
+++ b/maasglobal-json-schema-validator/src/conformance.ts
@@ -1,4 +1,4 @@
-import ajvFactory from 'ajv';
+import Ajv from 'ajv';
 import * as fs from 'fs';
 import * as glob from 'glob';
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
@@ -13,7 +13,7 @@ type InvalidExamples = Record<InvalidExample, Description>;
 type JsonSchema = JSONSchema7 & { invalid?: InvalidExamples };
 type JsonSchemaDefinition = JSONSchema7Definition & (boolean | JsonSchema);
 
-const ajv = ajvFactory({ allErrors: true });
+const ajv = new Ajv({ allErrors: true });
 
 const slash = '/';
 const endpointSchema = 'endpoint.json';

--- a/maasglobal-json-schema-validator/src/main.ts
+++ b/maasglobal-json-schema-validator/src/main.ts
@@ -1,5 +1,4 @@
-import AJV from 'ajv';
-import initKeywords from 'ajv-keywords';
+import Ajv from 'ajv';
 
 import { ValidationError } from './validation-error';
 
@@ -16,23 +15,27 @@ export type Validator = {
 };
 
 export function validator(registries: Registries): Validator {
-  const ajv: AJV.Ajv = new AJV({
+  const ajv: Ajv = new Ajv({
+    strictTypes: true,
+    strictTuples: true,
+    strictRequired: false,
+    strictSchema: true,
+    strictNumbers: true,
+    allowUnionTypes: true,
     addUsedSchema: false,
     allErrors: true,
     coerceTypes: true,
-    errorDataPath: 'property',
     inlineRefs: false,
     meta: true,
     multipleOfPrecision: 6,
     removeAdditional: true,
-    //sanitize: false,
-    sourceCode: false,
-    useDefaults: true,
+    code: { source: false },
+    useDefaults: false,
     validateSchema: false,
     verbose: true,
     $data: true,
   });
-  initKeywords(ajv);
+  ajv.addKeyword('invalid');
 
   registries.forEach((registry) => {
     Object.values(registry).forEach((schema) => ajv.addSchema(schema));

--- a/maasglobal-json-schema-validator/src/validation-error.ts
+++ b/maasglobal-json-schema-validator/src/validation-error.ts
@@ -1,6 +1,6 @@
 /* eslint-disable fp/no-class, fp/no-this, fp/no-mutation */
 
-import AJV from 'ajv';
+import Ajv from 'ajv';
 
 const MAXIMUM_REPORTED_RESPONSE_LENGTH = 80;
 
@@ -52,13 +52,10 @@ export class ValidationError extends Error {
    * @param object the object that failed to validate
    * @return the new error
    */
-  static fromValidatorErrors(
-    errors: AJV.Ajv['errors'],
-    object: unknown,
-  ): ValidationError {
-    const errorArray: Array<AJV.ErrorObject> = Array.isArray(errors) ? errors : [];
+  static fromValidatorErrors(errors: Ajv['errors'], object: unknown): ValidationError {
+    const errorArray: Ajv['errors'] = Array.isArray(errors) ? errors : [];
     const messages = errorArray.map((error) => {
-      return `'${error.dataPath}' ${trim(error.message ?? String())}, got '${
+      return `'${error.instancePath}' ${trim(error.message ?? String())}, got '${
         error.data == null ? String(error.data) : trim(JSON.stringify(error.data))
       }'`;
     });

--- a/maasglobal-json-schema-validator/yarn.lock
+++ b/maasglobal-json-schema-validator/yarn.lock
@@ -854,6 +854,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.8.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -3249,6 +3259,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -4001,6 +4016,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What has been implemented?
Upgrade the json-schema-validator to use Ajv v8.
Main benefits are:
  - no need for plugin to use unicode extends regexp format
  - strict mode