### PR TITLE
Non-strict mode validation helper

### DIFF
--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas-ts",
-  "version": "18.0.0",
+  "version": "18.1.0",
   "description": "TypeScript types and io-ts validators for maas-schemas",
   "main": "index.js",
   "files": [

--- a/maas-schemas-ts/src/_types/core/components/geolocation.ts
+++ b/maas-schemas-ts/src/_types/core/components/geolocation.ts
@@ -96,7 +96,7 @@ export type Properties = t.Branded<
     city?: string;
     country?: string;
     countryCode?: string;
-    houseNumber?: number;
+    houseNumber?: string;
     zipcode?: Address_.ZipCode;
   } & Record<string, unknown>) & {
     name: Defined;
@@ -115,7 +115,7 @@ export type PropertiesC = t.BrandC<
             city: t.StringC;
             country: t.StringC;
             countryCode: t.StringC;
-            houseNumber: t.NumberC;
+            houseNumber: t.StringC;
             zipcode: typeof Address_.ZipCode;
           }>,
           t.RecordC<t.StringC, t.UnknownC>,
@@ -138,7 +138,7 @@ export const Properties: PropertiesC = t.brand(
         city: t.string,
         country: t.string,
         countryCode: t.string,
-        houseNumber: t.number,
+        houseNumber: t.string,
         zipcode: Address_.ZipCode,
       }),
       t.record(t.string, t.unknown),
@@ -157,7 +157,7 @@ export const Properties: PropertiesC = t.brand(
       city?: string;
       country?: string;
       countryCode?: string;
-      houseNumber?: number;
+      houseNumber?: string;
       zipcode?: Address_.ZipCode;
     } & Record<string, unknown>) & {
       name: Defined;

--- a/maas-schemas-ts/src/_types/core/components/units-geo.ts
+++ b/maas-schemas-ts/src/_types/core/components/units-geo.ts
@@ -273,7 +273,9 @@ export type ShortLocationC = t.BrandC<
 >;
 export const ShortLocation: ShortLocationC = t.brand(
   t.tuple([Latitude, Longitude]),
-  (x): x is t.Branded<[Latitude, Longitude], ShortLocationBrand> => true,
+  (x): x is t.Branded<[Latitude, Longitude], ShortLocationBrand> =>
+    (Array.isArray(x) === false || x.length >= 2) &&
+    (Array.isArray(x) === false || x.length <= 2),
   'ShortLocation',
 );
 export type ShortLocationBrand = {

--- a/maas-schemas-ts/src/_types/maas-backend/bookings/bookings-agency-options/response.ts
+++ b/maas-schemas-ts/src/_types/maas-backend/bookings/bookings-agency-options/response.ts
@@ -47,18 +47,20 @@ export type Option = t.Branded<
     configurator?: Booking_.Configurator;
   } & Record<string, unknown>) &
     (
-      | {
-          leg: Defined;
-          terms: Defined;
-          product: Defined;
-          fares: Defined;
-        }
-      | {
-          leg: Defined;
-          terms: Defined;
-          product: Defined;
-          configurator: Defined;
-        }
+      | (Record<string, unknown> &
+          Record<string, unknown> & {
+            leg: Defined;
+            terms: Defined;
+            product: Defined;
+            fares: Defined;
+          })
+      | (Record<string, unknown> &
+          Record<string, unknown> & {
+            leg: Defined;
+            terms: Defined;
+            product: Defined;
+            configurator: Defined;
+          })
     ),
   OptionBrand
 >;
@@ -88,18 +90,30 @@ export type OptionC = t.BrandC<
       >,
       t.UnionC<
         [
-          t.TypeC<{
-            leg: typeof Defined;
-            terms: typeof Defined;
-            product: typeof Defined;
-            fares: typeof Defined;
-          }>,
-          t.TypeC<{
-            leg: typeof Defined;
-            terms: typeof Defined;
-            product: typeof Defined;
-            configurator: typeof Defined;
-          }>,
+          t.IntersectionC<
+            [
+              t.UnknownRecordC,
+              t.RecordC<t.StringC, t.UnknownC>,
+              t.TypeC<{
+                leg: typeof Defined;
+                terms: typeof Defined;
+                product: typeof Defined;
+                fares: typeof Defined;
+              }>,
+            ]
+          >,
+          t.IntersectionC<
+            [
+              t.UnknownRecordC,
+              t.RecordC<t.StringC, t.UnknownC>,
+              t.TypeC<{
+                leg: typeof Defined;
+                terms: typeof Defined;
+                product: typeof Defined;
+                configurator: typeof Defined;
+              }>,
+            ]
+          >,
         ]
       >,
     ]
@@ -126,18 +140,26 @@ export const Option: OptionC = t.brand(
       t.record(t.string, t.unknown),
     ]),
     t.union([
-      t.type({
-        leg: Defined,
-        terms: Defined,
-        product: Defined,
-        fares: Defined,
-      }),
-      t.type({
-        leg: Defined,
-        terms: Defined,
-        product: Defined,
-        configurator: Defined,
-      }),
+      t.intersection([
+        t.UnknownRecord,
+        t.record(t.string, t.unknown),
+        t.type({
+          leg: Defined,
+          terms: Defined,
+          product: Defined,
+          fares: Defined,
+        }),
+      ]),
+      t.intersection([
+        t.UnknownRecord,
+        t.record(t.string, t.unknown),
+        t.type({
+          leg: Defined,
+          terms: Defined,
+          product: Defined,
+          configurator: Defined,
+        }),
+      ]),
     ]),
   ]),
   (
@@ -155,18 +177,20 @@ export const Option: OptionC = t.brand(
       configurator?: Booking_.Configurator;
     } & Record<string, unknown>) &
       (
-        | {
-            leg: Defined;
-            terms: Defined;
-            product: Defined;
-            fares: Defined;
-          }
-        | {
-            leg: Defined;
-            terms: Defined;
-            product: Defined;
-            configurator: Defined;
-          }
+        | (Record<string, unknown> &
+            Record<string, unknown> & {
+              leg: Defined;
+              terms: Defined;
+              product: Defined;
+              fares: Defined;
+            })
+        | (Record<string, unknown> &
+            Record<string, unknown> & {
+              leg: Defined;
+              terms: Defined;
+              product: Defined;
+              configurator: Defined;
+            })
       ),
     OptionBrand
   > => true,

--- a/maas-schemas-ts/translation.log
+++ b/maas-schemas-ts/translation.log
@@ -328,11 +328,7 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
-INFO: primitive type "string" used outside top-level definitions
-  in ../maas-schemas/schemas/core/components/geolocation.json
-WARNING: minLength field not supported outside top-level definitions
-  in ../maas-schemas/schemas/core/components/geolocation.json
-WARNING: maxLength field not supported outside top-level definitions
+WARNING: examples field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
@@ -340,11 +336,7 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
-INFO: primitive type "string" used outside top-level definitions
-  in ../maas-schemas/schemas/core/components/geolocation.json
-WARNING: minLength field not supported outside top-level definitions
-  in ../maas-schemas/schemas/core/components/geolocation.json
-WARNING: maxLength field not supported outside top-level definitions
+WARNING: examples field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
@@ -352,17 +344,39 @@ WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: examples field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
 INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
-INFO: primitive type "integer" used outside top-level definitions
+WARNING: examples field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+INFO: primitive type "string" used outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: minLength field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: maxLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: examples field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: minLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: maxLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: examples field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+INFO: primitive type "string" used outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: minLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: maxLength field not supported outside top-level definitions
+  in ../maas-schemas/schemas/core/components/geolocation.json
+WARNING: examples field not supported outside top-level definitions
   in ../maas-schemas/schemas/core/components/geolocation.json
 WARNING: missing $schema declaration
   in ../maas-schemas/schemas/core/components/geolocation.json

--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "18.0.0",
+  "version": "18.1.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/geolocation.json
+++ b/maas-schemas/schemas/core/components/geolocation.json
@@ -46,37 +46,44 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 256
+          "maxLength": 256,
+          "examples": ["Jani Hirviinen", "Barri Känälainen-sön"]
         },
         "streetNumber": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 16
+          "maxLength": 16,
+          "examples": ["1", "221B"]
         },
         "streetName": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 256
+          "maxLength": 256,
+          "examples": ["Kalevankatu", "Baker Street", "John Stenbergin ranta"]
         },
         "city": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 64
+          "maxLength": 64,
+          "examples": ["Helsinki", "Tokyo"]
         },
         "country": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 64
+          "maxLength": 64,
+          "examples": ["Finland", "Japan"]
         },
         "countryCode": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 256
+          "maxLength": 256,
+          "examples": ["FI", "JP"]
         },
         "houseNumber": {
-          "type": "integer",
+          "type": "string",
           "minLength": 1,
-          "maxLength": 16
+          "maxLength": 16,
+          "examples": ["1", "221B", "A 9"]
         },
         "zipcode": {
           "$ref": "https://schemas.maas.global/core/components/address.json#/definitions/zipCode"

--- a/maas-schemas/schemas/core/components/units-geo.json
+++ b/maas-schemas/schemas/core/components/units-geo.json
@@ -77,6 +77,8 @@
           "$ref": "#/definitions/longitude"
         }
       ],
+      "minItems": 2,
+      "maxItems": 2,
       "additionalItems": false
     },
     "shortLocationString": {

--- a/maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/response.json
+++ b/maas-schemas/schemas/maas-backend/bookings/bookings-agency-options/response.json
@@ -64,9 +64,11 @@
         {
           "oneOf": [
             {
+              "type": "object",
               "required": ["leg", "terms", "product", "fares"]
             },
             {
+              "type": "object",
               "required": ["leg", "terms", "product", "configurator"]
             }
           ]

--- a/maasglobal-json-schema-validator/package.json
+++ b/maasglobal-json-schema-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maasglobal-json-schema-validator",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "license": "MIT",
   "main": "lib/index.js",

--- a/maasglobal-json-schema-validator/src/main.ts
+++ b/maasglobal-json-schema-validator/src/main.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import Ajv, { Options } from 'ajv';
 
 import { ValidationError } from './validation-error';
 
@@ -31,7 +31,10 @@ export type RegistryPath<P extends NpmPackageName = NpmPackageName> =
 export const registryPath = <P extends NpmPackageName>(packageName: P): RegistryPath<P> =>
   `${packageName}/lib/ajv/registry`;
 
-export function validator(registries: Registries): Validator {
+export function validator(
+  registries: Registries,
+  optionsOverride: Partial<Options> = {},
+): Validator {
   const ajv: Ajv = new Ajv({
     strictTypes: true,
     strictTuples: true,
@@ -51,6 +54,7 @@ export function validator(registries: Registries): Validator {
     validateSchema: false,
     verbose: true,
     $data: true,
+    ...optionsOverride,
   });
   ajv.addKeyword('invalid');
 


### PR DESCRIPTION
## What has been implemented?

When integrating the new versions of Ajv with strict mode validation into the backend, it has become apparent that some things will need to use a backwards-compatible "non-strict" validation mode.

~~This PR adds to the existing convenience utils to also provide a `validateNonStrict` validator.~~

PR amended to allow for options override in the `maasglobal-json-schema-validator` validate function.
This makes it easier for backend to use it for non-strict validations as needed.
