### PR TITLE
maas-schemas-ts deprecation announcement

### DIFF
--- a/.github/workflows/cd-maas-schemas-ts.yml
+++ b/.github/workflows/cd-maas-schemas-ts.yml
@@ -1,0 +1,35 @@
+name: CD maas-schemas-ts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'maas-schemas-ts/package.json'
+      - '.github/workflows/cd-maas-schemas-ts.yml'
+
+defaults:
+  run:
+    working-directory: maas-schemas-ts
+
+env:
+  NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_NPM_TOKEN }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: publish
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Dependencies
+        run: |
+          yarn
+      - name: Deploy to Registry
+        run: |
+          yarn deploy-npm

--- a/maas-schemas-ts/README.md
+++ b/maas-schemas-ts/README.md
@@ -1,0 +1,13 @@
+# MaaS Schemas TypeScript Support
+
+**DEPRECATED**
+
+This auxiliary package started as an experiment to provide TypeScript support for the [maas-schemas](https://www.npmjs.com/package/maas-schemas) package. TypeScript support has since been added to the main package, and this package has been discontinued. Please migrate to the main schema package and update your import paths according to the following example.
+
+```typescript
+// old import path
+import { Phone } from 'maas-schemas-ts/lib/core/components/common';
+
+// new import path
+import { Phone } from 'maas-schemas/lib/io-ts/core/components/common';
+```

--- a/maas-schemas-ts/package.json
+++ b/maas-schemas-ts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "maas-schemas-ts",
+  "version": "19.0.0",
+  "description": "TypeScript types and io-ts validators for maas-schemas",
+  "scripts": {
+    "deploy-npm": "yarn publish --non-interactive",
+    "deploy-alpha": "yarn publish --non-interactive --tag alpha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maasglobal/maas-schemas.git"
+  },
+  "keywords": [
+    "schemas",
+    "maas",
+    "io-ts",
+    "TypeScript"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/maasglobal/maas-schemas/issues"
+  },
+  "homepage": "https://github.com/maasglobal/maas-schemas/",
+  "peerDependencies": {
+  },
+  "devDependencies": {
+  }
+}


### PR DESCRIPTION
This PR adds a deprecation announcement for `maas-schemas-ts` and describes a migration path to `maas-schemas`.