### PR TITLE
Fix io ts dependency import

### DIFF
--- a/maasglobal-schema-generator-io-ts/package.json
+++ b/maasglobal-schema-generator-io-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maasglobal-schema-generator-io-ts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "license": "MIT",
   "main": "lib/index.js",

--- a/maasglobal-schema-generator-io-ts/src/generate-codecs.ts
+++ b/maasglobal-schema-generator-io-ts/src/generate-codecs.ts
@@ -17,7 +17,7 @@ async function runConverter(pkg: SchemaPackage): Promise<void> {
   const { base, deps } = pkg.manifest;
 
   const importArgs = Object.entries(deps).map(
-    ([depBase, dep]) => `${depBase}^${dep.package}/lib/io-ts`,
+    ([depBase, dep]) => `${depBase}^${dep.package}/lib/io-ts/`,
   );
   const imports = importArgs.length === 0 ? [] : ['--import', ...importArgs];
 


### PR DESCRIPTION
A path delimiter was missing from generated io-ts import paths.