### PR TITLE
Update schema for error.json

### DIFF
--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "18.3.0",
+  "version": "18.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/error.json
+++ b/maas-schemas/schemas/core/error.json
@@ -24,7 +24,8 @@
     },
     "errorMessage": {
       "description": "A human readable error message (preferrably in English)",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "reason": {
       "title": "MaaS error reason definition",
@@ -38,9 +39,7 @@
       "examples": [{ "text": "INVALID_AUTHORIZATION", "errorCode": 500 }]
     },
     "responseErrorMessage": {
-      "allOf": [{ "$ref": "#/definitions/errorMessage" }],
-      "minLength": 1,
-      "maxLength": 256
+      "allOf": [{ "$ref": "#/definitions/errorMessage" }]
     },
     "response": {
       "title": "MaaS error response definition",

--- a/maas-schemas/src/io-ts/_types/core/error.ts
+++ b/maas-schemas/src/io-ts/_types/core/error.ts
@@ -96,7 +96,8 @@ export type ErrorMessage = t.Branded<string, ErrorMessageBrand>;
 export type ErrorMessageC = t.BrandC<t.StringC, ErrorMessageBrand>;
 export const ErrorMessage: ErrorMessageC = t.brand(
   t.string,
-  (x): x is t.Branded<string, ErrorMessageBrand> => true,
+  (x): x is t.Branded<string, ErrorMessageBrand> =>
+    typeof x !== 'string' || x.length >= 1,
   'ErrorMessage',
 );
 export type ErrorMessageBrand = {
@@ -152,9 +153,7 @@ export type ResponseErrorMessageC = t.BrandC<
 >;
 export const ResponseErrorMessage: ResponseErrorMessageC = t.brand(
   ErrorMessage,
-  (x): x is t.Branded<ErrorMessage, ResponseErrorMessageBrand> =>
-    (typeof x !== 'string' || x.length >= 1) &&
-    (typeof x !== 'string' || x.length <= 256),
+  (x): x is t.Branded<ErrorMessage, ResponseErrorMessageBrand> => true,
   'ResponseErrorMessage',
 );
 export type ResponseErrorMessageBrand = {


### PR DESCRIPTION
Tweaks to error.json schema.

Fix -> `strict mode: missing type \"string\" for keyword \"maxLength\" at \"https://schemas.maas.global/core/error.json#\" (strictTypes)`

Removed also max length as it was never used properly.