### PR TITLE
Vehicle ids by mode

### DIFF
--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "18.5.0",
+  "version": "19.0.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/vehicle.json
+++ b/maas-schemas/schemas/core/components/vehicle.json
@@ -11,6 +11,54 @@
       "items": {
         "$ref": "#/definitions/vehicleId"
       }
+    },
+    "vehicleIdsByMode": {
+      "type": "object",
+      "properties": {
+        "MODE_BICYCLE": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_BUS": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_BUSISH": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_CABLE_CAR": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_CAR": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_FERRY": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_FUNICULAR": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_GONDOLA": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_RAIL": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_SCOOTER": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_SHARED_BICYCLE": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_SHARED_CAR": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_SHARED_E_BICYCLE": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_SUBWAY": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_TAXI": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_TRAIN": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_TRAINISH": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_TRAM": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_TRANSIT": { "$ref": "#/definitions/vehicleIds" },
+        "MODE_WALK": { "$ref": "#/definitions/vehicleIds" }
+      },
+      "required": [
+        "MODE_BICYCLE",
+        "MODE_BUS",
+        "MODE_BUSISH",
+        "MODE_CABLE_CAR",
+        "MODE_CAR",
+        "MODE_FERRY",
+        "MODE_FUNICULAR",
+        "MODE_GONDOLA",
+        "MODE_RAIL",
+        "MODE_SCOOTER",
+        "MODE_SHARED_BICYCLE",
+        "MODE_SHARED_CAR",
+        "MODE_SHARED_E_BICYCLE",
+        "MODE_SUBWAY",
+        "MODE_TAXI",
+        "MODE_TRAIN",
+        "MODE_TRAINISH",
+        "MODE_TRAM",
+        "MODE_TRANSIT",
+        "MODE_WALK"
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/maas-schemas/src/io-ts/_translation.log
+++ b/maas-schemas/src/io-ts/_translation.log
@@ -792,6 +792,8 @@ INFO: missing description
   in schemas/core/components/units.json
 INFO: missing description
   in schemas/core/components/vehicle.json
+INFO: missing description
+  in schemas/core/components/vehicle.json
 INFO: primitive type "string" used outside top-level definitions
   in schemas/core/customer.json
 INFO: primitive type "string" used outside top-level definitions

--- a/maas-schemas/src/io-ts/_types/core/components/vehicle.ts
+++ b/maas-schemas/src/io-ts/_types/core/components/vehicle.ts
@@ -10,6 +10,21 @@ See https://www.npmjs.com/package/io-ts-from-json-schema
 
 import * as t from 'io-ts';
 
+export type Defined = {} | null;
+export class DefinedType extends t.Type<Defined> {
+  readonly _tag: 'DefinedType' = 'DefinedType';
+  constructor() {
+    super(
+      'defined',
+      (u): u is Defined => typeof u !== 'undefined',
+      (u, c) => (this.is(u) ? t.success(u) : t.failure(u, c)),
+      t.identity,
+    );
+  }
+}
+export type DefinedC = {} & DefinedType;
+export const Defined: DefinedC = new DefinedType();
+
 export const schemaId = 'https://schemas.maas.global/core/components/vehicle.json';
 
 // VehicleId
@@ -36,6 +51,206 @@ export const VehicleIds: VehicleIdsC = t.brand(
 );
 export type VehicleIdsBrand = {
   readonly VehicleIds: unique symbol;
+};
+
+// VehicleIdsByMode
+// The purpose of this remains a mystery
+export type VehicleIdsByMode = t.Branded<
+  {
+    MODE_BICYCLE?: VehicleIds;
+    MODE_BUS?: VehicleIds;
+    MODE_BUSISH?: VehicleIds;
+    MODE_CABLE_CAR?: VehicleIds;
+    MODE_CAR?: VehicleIds;
+    MODE_FERRY?: VehicleIds;
+    MODE_FUNICULAR?: VehicleIds;
+    MODE_GONDOLA?: VehicleIds;
+    MODE_RAIL?: VehicleIds;
+    MODE_SCOOTER?: VehicleIds;
+    MODE_SHARED_BICYCLE?: VehicleIds;
+    MODE_SHARED_CAR?: VehicleIds;
+    MODE_SHARED_E_BICYCLE?: VehicleIds;
+    MODE_SUBWAY?: VehicleIds;
+    MODE_TAXI?: VehicleIds;
+    MODE_TRAIN?: VehicleIds;
+    MODE_TRAINISH?: VehicleIds;
+    MODE_TRAM?: VehicleIds;
+    MODE_TRANSIT?: VehicleIds;
+    MODE_WALK?: VehicleIds;
+  } & {
+    MODE_BICYCLE: Defined;
+    MODE_BUS: Defined;
+    MODE_BUSISH: Defined;
+    MODE_CABLE_CAR: Defined;
+    MODE_CAR: Defined;
+    MODE_FERRY: Defined;
+    MODE_FUNICULAR: Defined;
+    MODE_GONDOLA: Defined;
+    MODE_RAIL: Defined;
+    MODE_SCOOTER: Defined;
+    MODE_SHARED_BICYCLE: Defined;
+    MODE_SHARED_CAR: Defined;
+    MODE_SHARED_E_BICYCLE: Defined;
+    MODE_SUBWAY: Defined;
+    MODE_TAXI: Defined;
+    MODE_TRAIN: Defined;
+    MODE_TRAINISH: Defined;
+    MODE_TRAM: Defined;
+    MODE_TRANSIT: Defined;
+    MODE_WALK: Defined;
+  },
+  VehicleIdsByModeBrand
+>;
+export type VehicleIdsByModeC = t.BrandC<
+  t.IntersectionC<
+    [
+      t.PartialC<{
+        MODE_BICYCLE: typeof VehicleIds;
+        MODE_BUS: typeof VehicleIds;
+        MODE_BUSISH: typeof VehicleIds;
+        MODE_CABLE_CAR: typeof VehicleIds;
+        MODE_CAR: typeof VehicleIds;
+        MODE_FERRY: typeof VehicleIds;
+        MODE_FUNICULAR: typeof VehicleIds;
+        MODE_GONDOLA: typeof VehicleIds;
+        MODE_RAIL: typeof VehicleIds;
+        MODE_SCOOTER: typeof VehicleIds;
+        MODE_SHARED_BICYCLE: typeof VehicleIds;
+        MODE_SHARED_CAR: typeof VehicleIds;
+        MODE_SHARED_E_BICYCLE: typeof VehicleIds;
+        MODE_SUBWAY: typeof VehicleIds;
+        MODE_TAXI: typeof VehicleIds;
+        MODE_TRAIN: typeof VehicleIds;
+        MODE_TRAINISH: typeof VehicleIds;
+        MODE_TRAM: typeof VehicleIds;
+        MODE_TRANSIT: typeof VehicleIds;
+        MODE_WALK: typeof VehicleIds;
+      }>,
+      t.TypeC<{
+        MODE_BICYCLE: typeof Defined;
+        MODE_BUS: typeof Defined;
+        MODE_BUSISH: typeof Defined;
+        MODE_CABLE_CAR: typeof Defined;
+        MODE_CAR: typeof Defined;
+        MODE_FERRY: typeof Defined;
+        MODE_FUNICULAR: typeof Defined;
+        MODE_GONDOLA: typeof Defined;
+        MODE_RAIL: typeof Defined;
+        MODE_SCOOTER: typeof Defined;
+        MODE_SHARED_BICYCLE: typeof Defined;
+        MODE_SHARED_CAR: typeof Defined;
+        MODE_SHARED_E_BICYCLE: typeof Defined;
+        MODE_SUBWAY: typeof Defined;
+        MODE_TAXI: typeof Defined;
+        MODE_TRAIN: typeof Defined;
+        MODE_TRAINISH: typeof Defined;
+        MODE_TRAM: typeof Defined;
+        MODE_TRANSIT: typeof Defined;
+        MODE_WALK: typeof Defined;
+      }>,
+    ]
+  >,
+  VehicleIdsByModeBrand
+>;
+export const VehicleIdsByMode: VehicleIdsByModeC = t.brand(
+  t.intersection([
+    t.partial({
+      MODE_BICYCLE: VehicleIds,
+      MODE_BUS: VehicleIds,
+      MODE_BUSISH: VehicleIds,
+      MODE_CABLE_CAR: VehicleIds,
+      MODE_CAR: VehicleIds,
+      MODE_FERRY: VehicleIds,
+      MODE_FUNICULAR: VehicleIds,
+      MODE_GONDOLA: VehicleIds,
+      MODE_RAIL: VehicleIds,
+      MODE_SCOOTER: VehicleIds,
+      MODE_SHARED_BICYCLE: VehicleIds,
+      MODE_SHARED_CAR: VehicleIds,
+      MODE_SHARED_E_BICYCLE: VehicleIds,
+      MODE_SUBWAY: VehicleIds,
+      MODE_TAXI: VehicleIds,
+      MODE_TRAIN: VehicleIds,
+      MODE_TRAINISH: VehicleIds,
+      MODE_TRAM: VehicleIds,
+      MODE_TRANSIT: VehicleIds,
+      MODE_WALK: VehicleIds,
+    }),
+    t.type({
+      MODE_BICYCLE: Defined,
+      MODE_BUS: Defined,
+      MODE_BUSISH: Defined,
+      MODE_CABLE_CAR: Defined,
+      MODE_CAR: Defined,
+      MODE_FERRY: Defined,
+      MODE_FUNICULAR: Defined,
+      MODE_GONDOLA: Defined,
+      MODE_RAIL: Defined,
+      MODE_SCOOTER: Defined,
+      MODE_SHARED_BICYCLE: Defined,
+      MODE_SHARED_CAR: Defined,
+      MODE_SHARED_E_BICYCLE: Defined,
+      MODE_SUBWAY: Defined,
+      MODE_TAXI: Defined,
+      MODE_TRAIN: Defined,
+      MODE_TRAINISH: Defined,
+      MODE_TRAM: Defined,
+      MODE_TRANSIT: Defined,
+      MODE_WALK: Defined,
+    }),
+  ]),
+  (
+    x,
+  ): x is t.Branded<
+    {
+      MODE_BICYCLE?: VehicleIds;
+      MODE_BUS?: VehicleIds;
+      MODE_BUSISH?: VehicleIds;
+      MODE_CABLE_CAR?: VehicleIds;
+      MODE_CAR?: VehicleIds;
+      MODE_FERRY?: VehicleIds;
+      MODE_FUNICULAR?: VehicleIds;
+      MODE_GONDOLA?: VehicleIds;
+      MODE_RAIL?: VehicleIds;
+      MODE_SCOOTER?: VehicleIds;
+      MODE_SHARED_BICYCLE?: VehicleIds;
+      MODE_SHARED_CAR?: VehicleIds;
+      MODE_SHARED_E_BICYCLE?: VehicleIds;
+      MODE_SUBWAY?: VehicleIds;
+      MODE_TAXI?: VehicleIds;
+      MODE_TRAIN?: VehicleIds;
+      MODE_TRAINISH?: VehicleIds;
+      MODE_TRAM?: VehicleIds;
+      MODE_TRANSIT?: VehicleIds;
+      MODE_WALK?: VehicleIds;
+    } & {
+      MODE_BICYCLE: Defined;
+      MODE_BUS: Defined;
+      MODE_BUSISH: Defined;
+      MODE_CABLE_CAR: Defined;
+      MODE_CAR: Defined;
+      MODE_FERRY: Defined;
+      MODE_FUNICULAR: Defined;
+      MODE_GONDOLA: Defined;
+      MODE_RAIL: Defined;
+      MODE_SCOOTER: Defined;
+      MODE_SHARED_BICYCLE: Defined;
+      MODE_SHARED_CAR: Defined;
+      MODE_SHARED_E_BICYCLE: Defined;
+      MODE_SUBWAY: Defined;
+      MODE_TAXI: Defined;
+      MODE_TRAIN: Defined;
+      MODE_TRAINISH: Defined;
+      MODE_TRAM: Defined;
+      MODE_TRANSIT: Defined;
+      MODE_WALK: Defined;
+    },
+    VehicleIdsByModeBrand
+  > => true,
+  'VehicleIdsByMode',
+);
+export type VehicleIdsByModeBrand = {
+  readonly VehicleIdsByMode: unique symbol;
 };
 
 // Vehicle

--- a/maas-schemas/src/io-ts/_utils/core/components/vehicle/__tests__/vehicle-ids-by-mode.ts
+++ b/maas-schemas/src/io-ts/_utils/core/components/vehicle/__tests__/vehicle-ids-by-mode.ts
@@ -1,0 +1,118 @@
+import { validator } from 'io-ts-validator';
+
+import { BookingMeta } from '../../../../../_types/core/booking-meta';
+import { VehicleIdsByMode } from '../../../../../_types/core/components/vehicle';
+import * as VehicleIdsByMode_ from '../vehicle-ids-by-mode';
+
+describe('vehicle-ids-by-mode', () => {
+  describe('fromBookingBeta', () => {
+    it('should extract VehicleIds from BookingMeta', () => {
+      const bicycleId = 'bicycle1';
+      const carId = 'car1';
+      const scooterId = 'scooter1';
+      const sharedBicycleId = 'sharedBicycle1';
+      const sharedCarId = 'sharedCar1';
+      const sharedEBicycleId = 'sharedEBicycle1';
+      const taxiId = 'taxi1';
+      const bookingMeta = validator(BookingMeta).decodeSync({
+        MODE_BICYCLE: {
+          bike: {
+            id: bicycleId,
+          },
+        },
+        MODE_BUS: {},
+        MODE_BUSISH: {},
+        MODE_CABLE_CAR: {},
+        MODE_CAR: {
+          id: carId,
+          name: 'Basic Car',
+          description: 'Red sedan',
+          image: 'https://example.com/image.png',
+        },
+        MODE_FERRY: {},
+        MODE_FUNICULAR: {},
+        MODE_GONDOLA: {},
+        MODE_RAIL: {},
+        MODE_SCOOTER: {
+          scooter: {
+            id: scooterId,
+          },
+        },
+        MODE_SHARED_BICYCLE: {
+          bike: {
+            id: sharedBicycleId,
+          },
+        },
+        MODE_SHARED_CAR: {
+          id: sharedCarId,
+          name: 'Basic Car',
+          description: 'Red sedan',
+          image: 'https://example.com/image.png',
+        },
+        MODE_SHARED_E_BICYCLE: {
+          bike: {
+            id: sharedEBicycleId,
+          },
+        },
+        MODE_SUBWAY: {},
+        MODE_TAXI: {
+          vehicleId: taxiId,
+        },
+        MODE_TRAIN: {},
+        MODE_TRAINISH: {},
+        MODE_TRAM: {},
+        MODE_TRANSIT: {},
+        MODE_WALK: {},
+      });
+      const result: VehicleIdsByMode = VehicleIdsByMode_.fromBookingMeta(bookingMeta);
+      expect(result).toEqual({
+        MODE_BICYCLE: [bicycleId],
+        MODE_BUS: [],
+        MODE_BUSISH: [],
+        MODE_CABLE_CAR: [],
+        MODE_CAR: [carId],
+        MODE_FERRY: [],
+        MODE_FUNICULAR: [],
+        MODE_GONDOLA: [],
+        MODE_RAIL: [],
+        MODE_SCOOTER: [scooterId],
+        MODE_SHARED_BICYCLE: [sharedBicycleId],
+        MODE_SHARED_CAR: [sharedCarId],
+        MODE_SHARED_E_BICYCLE: [sharedEBicycleId],
+        MODE_SUBWAY: [],
+        MODE_TAXI: [taxiId],
+        MODE_TRAIN: [],
+        MODE_TRAINISH: [],
+        MODE_TRAM: [],
+        MODE_TRANSIT: [],
+        MODE_WALK: [],
+      });
+    });
+    it('should support BookingMeta with no modes', () => {
+      const bookingMeta = validator(BookingMeta).decodeSync({});
+      const result: VehicleIdsByMode = VehicleIdsByMode_.fromBookingMeta(bookingMeta);
+      expect(result).toEqual({
+        MODE_BICYCLE: [],
+        MODE_BUS: [],
+        MODE_BUSISH: [],
+        MODE_CABLE_CAR: [],
+        MODE_CAR: [],
+        MODE_FERRY: [],
+        MODE_FUNICULAR: [],
+        MODE_GONDOLA: [],
+        MODE_RAIL: [],
+        MODE_SCOOTER: [],
+        MODE_SHARED_BICYCLE: [],
+        MODE_SHARED_CAR: [],
+        MODE_SHARED_E_BICYCLE: [],
+        MODE_SUBWAY: [],
+        MODE_TAXI: [],
+        MODE_TRAIN: [],
+        MODE_TRAINISH: [],
+        MODE_TRAM: [],
+        MODE_TRANSIT: [],
+        MODE_WALK: [],
+      });
+    });
+  });
+});

--- a/maas-schemas/src/io-ts/_utils/core/components/vehicle/__tests__/vehicle-ids.ts
+++ b/maas-schemas/src/io-ts/_utils/core/components/vehicle/__tests__/vehicle-ids.ts
@@ -1,6 +1,5 @@
 import { validator } from 'io-ts-validator';
 
-import { BookingMeta } from '../../../../../_types/core/booking-meta';
 import { VehicleId, VehicleIds } from '../../../../../_types/core/components/vehicle';
 import { MODE_BICYCLE } from '../../../../../_types/core/modes/MODE_BICYCLE';
 import { MODE_BUS } from '../../../../../_types/core/modes/MODE_BUS';
@@ -275,83 +274,6 @@ describe('vehicle-ids', () => {
     it('should extract VehicleIds from MODE_WALK', () => {
       const mode = validator(MODE_WALK).decodeSync({});
       const result: VehicleIds = VehicleIds_.fromMODE_WALK(mode);
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('fromBookingBeta', () => {
-    it('should extract VehicleIds from BookingMeta', () => {
-      const bicycleId = 'bicycle1';
-      const carId = 'car1';
-      const scooterId = 'scooter1';
-      const sharedBicycleId = 'sharedBicycle1';
-      const sharedCarId = 'sharedCar1';
-      const sharedEBicycleId = 'sharedEBicycle1';
-      const taxiId = 'taxi1';
-      const bookingMeta = validator(BookingMeta).decodeSync({
-        MODE_BICYCLE: {
-          bike: {
-            id: bicycleId,
-          },
-        },
-        MODE_BUS: {},
-        MODE_BUSISH: {},
-        MODE_CABLE_CAR: {},
-        MODE_CAR: {
-          id: carId,
-          name: 'Basic Car',
-          description: 'Red sedan',
-          image: 'https://example.com/image.png',
-        },
-        MODE_FERRY: {},
-        MODE_FUNICULAR: {},
-        MODE_GONDOLA: {},
-        MODE_RAIL: {},
-        MODE_SCOOTER: {
-          scooter: {
-            id: scooterId,
-          },
-        },
-        MODE_SHARED_BICYCLE: {
-          bike: {
-            id: sharedBicycleId,
-          },
-        },
-        MODE_SHARED_CAR: {
-          id: sharedCarId,
-          name: 'Basic Car',
-          description: 'Red sedan',
-          image: 'https://example.com/image.png',
-        },
-        MODE_SHARED_E_BICYCLE: {
-          bike: {
-            id: sharedEBicycleId,
-          },
-        },
-        MODE_SUBWAY: {},
-        MODE_TAXI: {
-          vehicleId: taxiId,
-        },
-        MODE_TRAIN: {},
-        MODE_TRAINISH: {},
-        MODE_TRAM: {},
-        MODE_TRANSIT: {},
-        MODE_WALK: {},
-      });
-      const result: VehicleIds = VehicleIds_.fromBookingMeta(bookingMeta);
-      expect(result).toEqual([
-        bicycleId,
-        carId,
-        scooterId,
-        sharedBicycleId,
-        sharedCarId,
-        sharedEBicycleId,
-        taxiId,
-      ]);
-    });
-    it('should support BookingMeta with no modes', () => {
-      const bookingMeta = validator(BookingMeta).decodeSync({});
-      const result: VehicleIds = VehicleIds_.fromBookingMeta(bookingMeta);
       expect(result).toEqual([]);
     });
   });

--- a/maas-schemas/src/io-ts/_utils/core/components/vehicle/__tests__/vehicle.ts
+++ b/maas-schemas/src/io-ts/_utils/core/components/vehicle/__tests__/vehicle.ts
@@ -4,4 +4,7 @@ describe('vehicle', () => {
   it('should export VehicleIds utils', () => {
     expect(Vehicle_.VehicleIds_).toBeDefined;
   });
+  it('should export VehicleIdsByMode utils', () => {
+    expect(Vehicle_.VehicleIdsByMode_).toBeDefined;
+  });
 });

--- a/maas-schemas/src/io-ts/_utils/core/components/vehicle/vehicle-ids-by-mode.ts
+++ b/maas-schemas/src/io-ts/_utils/core/components/vehicle/vehicle-ids-by-mode.ts
@@ -1,0 +1,68 @@
+import { BookingMeta } from '../../../../_types/core/booking-meta';
+import { VehicleIdsByMode } from '../../../../_types/core/components/vehicle';
+import * as VehicleIds_ from './vehicle-ids';
+
+export function fromBookingMeta(meta: BookingMeta): VehicleIdsByMode {
+  return {
+    MODE_BICYCLE: meta['MODE_BICYCLE']
+      ? VehicleIds_.fromMODE_BICYCLE(meta['MODE_BICYCLE'])
+      : VehicleIds_.empty,
+    MODE_BUS: meta['MODE_BUS']
+      ? VehicleIds_.fromMODE_BUS(meta['MODE_BUS'])
+      : VehicleIds_.empty,
+    MODE_BUSISH: meta['MODE_BUSISH']
+      ? VehicleIds_.fromMODE_BUSISH(meta['MODE_BUSISH'])
+      : VehicleIds_.empty,
+    MODE_CABLE_CAR: meta['MODE_CABLE_CAR']
+      ? VehicleIds_.fromMODE_CABLE_CAR(meta['MODE_CABLE_CAR'])
+      : VehicleIds_.empty,
+    MODE_CAR: meta['MODE_CAR']
+      ? VehicleIds_.fromMODE_CAR(meta['MODE_CAR'])
+      : VehicleIds_.empty,
+    MODE_FERRY: meta['MODE_FERRY']
+      ? VehicleIds_.fromMODE_FERRY(meta['MODE_FERRY'])
+      : VehicleIds_.empty,
+    MODE_FUNICULAR: meta['MODE_FUNICULAR']
+      ? VehicleIds_.fromMODE_FUNICULAR(meta['MODE_FUNICULAR'])
+      : VehicleIds_.empty,
+    MODE_GONDOLA: meta['MODE_GONDOLA']
+      ? VehicleIds_.fromMODE_GONDOLA(meta['MODE_GONDOLA'])
+      : VehicleIds_.empty,
+    MODE_RAIL: meta['MODE_RAIL']
+      ? VehicleIds_.fromMODE_RAIL(meta['MODE_RAIL'])
+      : VehicleIds_.empty,
+    MODE_SCOOTER: meta['MODE_SCOOTER']
+      ? VehicleIds_.fromMODE_SCOOTER(meta['MODE_SCOOTER'])
+      : VehicleIds_.empty,
+    MODE_SHARED_BICYCLE: meta['MODE_SHARED_BICYCLE']
+      ? VehicleIds_.fromMODE_SHARED_BICYCLE(meta['MODE_SHARED_BICYCLE'])
+      : VehicleIds_.empty,
+    MODE_SHARED_CAR: meta['MODE_SHARED_CAR']
+      ? VehicleIds_.fromMODE_SHARED_CAR(meta['MODE_SHARED_CAR'])
+      : VehicleIds_.empty,
+    MODE_SHARED_E_BICYCLE: meta['MODE_SHARED_E_BICYCLE']
+      ? VehicleIds_.fromMODE_SHARED_E_BICYCLE(meta['MODE_SHARED_E_BICYCLE'])
+      : VehicleIds_.empty,
+    MODE_SUBWAY: meta['MODE_SUBWAY']
+      ? VehicleIds_.fromMODE_SUBWAY(meta['MODE_SUBWAY'])
+      : VehicleIds_.empty,
+    MODE_TAXI: meta['MODE_TAXI']
+      ? VehicleIds_.fromMODE_TAXI(meta['MODE_TAXI'])
+      : VehicleIds_.empty,
+    MODE_TRAIN: meta['MODE_TRAIN']
+      ? VehicleIds_.fromMODE_TRAIN(meta['MODE_TRAIN'])
+      : VehicleIds_.empty,
+    MODE_TRAINISH: meta['MODE_TRAINISH']
+      ? VehicleIds_.fromMODE_TRAINISH(meta['MODE_TRAINISH'])
+      : VehicleIds_.empty,
+    MODE_TRAM: meta['MODE_TRAM']
+      ? VehicleIds_.fromMODE_TRAM(meta['MODE_TRAM'])
+      : VehicleIds_.empty,
+    MODE_TRANSIT: meta['MODE_TRANSIT']
+      ? VehicleIds_.fromMODE_TRANSIT(meta['MODE_TRANSIT'])
+      : VehicleIds_.empty,
+    MODE_WALK: meta['MODE_WALK']
+      ? VehicleIds_.fromMODE_WALK(meta['MODE_WALK'])
+      : VehicleIds_.empty,
+  } as VehicleIdsByMode;
+}

--- a/maas-schemas/src/io-ts/_utils/core/components/vehicle/vehicle-ids.ts
+++ b/maas-schemas/src/io-ts/_utils/core/components/vehicle/vehicle-ids.ts
@@ -1,4 +1,3 @@
-import { BookingMeta } from '../../../../_types/core/booking-meta';
 import { VehicleId, VehicleIds } from '../../../../_types/core/components/vehicle';
 import { MODE_BICYCLE } from '../../../../_types/core/modes/MODE_BICYCLE';
 import { MODE_BUS } from '../../../../_types/core/modes/MODE_BUS';
@@ -125,32 +124,3 @@ export function fromMODE_WALK(_mode: MODE_WALK): VehicleIds {
 }
 
 /* eslint-enable @typescript-eslint/naming-convention */
-
-export function fromBookingMeta(meta: BookingMeta): VehicleIds {
-  return flatten([
-    meta['MODE_BICYCLE'] ? fromMODE_BICYCLE(meta['MODE_BICYCLE']) : empty,
-    meta['MODE_BUS'] ? fromMODE_BUS(meta['MODE_BUS']) : empty,
-    meta['MODE_BUSISH'] ? fromMODE_BUSISH(meta['MODE_BUSISH']) : empty,
-    meta['MODE_CABLE_CAR'] ? fromMODE_CABLE_CAR(meta['MODE_CABLE_CAR']) : empty,
-    meta['MODE_CAR'] ? fromMODE_CAR(meta['MODE_CAR']) : empty,
-    meta['MODE_FERRY'] ? fromMODE_FERRY(meta['MODE_FERRY']) : empty,
-    meta['MODE_FUNICULAR'] ? fromMODE_FUNICULAR(meta['MODE_FUNICULAR']) : empty,
-    meta['MODE_GONDOLA'] ? fromMODE_GONDOLA(meta['MODE_GONDOLA']) : empty,
-    meta['MODE_RAIL'] ? fromMODE_RAIL(meta['MODE_RAIL']) : empty,
-    meta['MODE_SCOOTER'] ? fromMODE_SCOOTER(meta['MODE_SCOOTER']) : empty,
-    meta['MODE_SHARED_BICYCLE']
-      ? fromMODE_SHARED_BICYCLE(meta['MODE_SHARED_BICYCLE'])
-      : empty,
-    meta['MODE_SHARED_CAR'] ? fromMODE_SHARED_CAR(meta['MODE_SHARED_CAR']) : empty,
-    meta['MODE_SHARED_E_BICYCLE']
-      ? fromMODE_SHARED_E_BICYCLE(meta['MODE_SHARED_E_BICYCLE'])
-      : empty,
-    meta['MODE_SUBWAY'] ? fromMODE_SUBWAY(meta['MODE_SUBWAY']) : empty,
-    meta['MODE_TAXI'] ? fromMODE_TAXI(meta['MODE_TAXI']) : empty,
-    meta['MODE_TRAIN'] ? fromMODE_TRAIN(meta['MODE_TRAIN']) : empty,
-    meta['MODE_TRAINISH'] ? fromMODE_TRAINISH(meta['MODE_TRAINISH']) : empty,
-    meta['MODE_TRAM'] ? fromMODE_TRAM(meta['MODE_TRAM']) : empty,
-    meta['MODE_TRANSIT'] ? fromMODE_TRANSIT(meta['MODE_TRANSIT']) : empty,
-    meta['MODE_WALK'] ? fromMODE_WALK(meta['MODE_WALK']) : empty,
-  ]);
-}

--- a/maas-schemas/src/io-ts/_utils/core/components/vehicle/vehicle.ts
+++ b/maas-schemas/src/io-ts/_utils/core/components/vehicle/vehicle.ts
@@ -1,1 +1,2 @@
 export * as VehicleIds_ from './vehicle-ids';
+export * as VehicleIdsByMode_ from './vehicle-ids-by-mode';


### PR DESCRIPTION
Adds a library function for resolving VehicleIds by Mode. This replaces the previous resolver which returned the VehicleIds in an array without context.