### PR TITLE
Allow itineraryV1 inputs to itinerary-create request

### DIFF
--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/maas-backend/itineraries/itinerary-create/request.json
+++ b/maas-schemas/schemas/maas-backend/itineraries/itinerary-create/request.json
@@ -39,10 +39,9 @@
       "type": "object",
       "properties": {
         "itinerary": {
-          "anyOf": [
-            {
-              "$ref": "https://schemas.maas.global/core/itineraryV2.json"
-            }
+          "oneOf": [
+            { "$ref": "https://schemas.maas.global/core/itinerary.json" },
+            { "$ref": "https://schemas.maas.global/core/itineraryV2.json" }
           ]
         },
         "customerSelections": {

--- a/maas-schemas/src/io-ts/_types/maas-backend/itineraries/itinerary-create/request.ts
+++ b/maas-schemas/src/io-ts/_types/maas-backend/itineraries/itinerary-create/request.ts
@@ -14,6 +14,7 @@ import * as ApiCommon_16a4_ from '../../../core/components/api-common';
 import * as Common_ffba_ from '../../../core/components/common';
 import * as CustomerSelection_57c3_ from '../../../core/components/customerSelection';
 import * as Message_554d_ from '../../../core/components/message';
+import * as Itinerary_8303_ from '../../../core/itinerary';
 import * as ItineraryV2_5f31_ from '../../../core/itineraryV2';
 import * as ProductOptionV2_8170_ from '../../../core/product-optionV2';
 
@@ -39,7 +40,7 @@ export const schemaId =
 // The purpose of this remains a mystery
 export type OutwardReturnWrapper = t.Branded<
   {
-    itinerary?: ItineraryV2_5f31_.ItineraryV2;
+    itinerary?: Itinerary_8303_.Itinerary | ItineraryV2_5f31_.ItineraryV2;
     customerSelections?: Array<
       {
         ref?: ProductOptionV2_8170_.Ref;
@@ -53,7 +54,9 @@ export type OutwardReturnWrapperC = t.BrandC<
   t.IntersectionC<
     [
       t.PartialC<{
-        itinerary: typeof ItineraryV2_5f31_.ItineraryV2;
+        itinerary: t.UnionC<
+          [typeof Itinerary_8303_.Itinerary, typeof ItineraryV2_5f31_.ItineraryV2]
+        >;
         customerSelections: t.ArrayC<
           t.IntersectionC<
             [
@@ -74,7 +77,7 @@ export type OutwardReturnWrapperC = t.BrandC<
 export const OutwardReturnWrapper: OutwardReturnWrapperC = t.brand(
   t.intersection([
     t.partial({
-      itinerary: ItineraryV2_5f31_.ItineraryV2,
+      itinerary: t.union([Itinerary_8303_.Itinerary, ItineraryV2_5f31_.ItineraryV2]),
       customerSelections: t.array(
         t.intersection([
           t.partial({
@@ -91,7 +94,7 @@ export const OutwardReturnWrapper: OutwardReturnWrapperC = t.brand(
     x,
   ): x is t.Branded<
     {
-      itinerary?: ItineraryV2_5f31_.ItineraryV2;
+      itinerary?: Itinerary_8303_.Itinerary | ItineraryV2_5f31_.ItineraryV2;
       customerSelections?: Array<
         {
           ref?: ProductOptionV2_8170_.Ref;


### PR DESCRIPTION

Fix for mistake in itinerary-create request schema to not allow routes-query-v2 inputs.