### PR TITLE
Mode taxi phone loosen

### DIFF
--- a/maas-schemas/package.json
+++ b/maas-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-schemas",
-  "version": "20.3.0",
+  "version": "20.4.0",
   "description": "Schemas for MaaS infrastructure",
   "main": "index.js",
   "engine": {

--- a/maas-schemas/schemas/core/components/common.json
+++ b/maas-schemas/schemas/core/components/common.json
@@ -91,6 +91,11 @@
       "type": "string",
       "pattern": "^\\+?(?:\\d){6,14}\\d$"
     },
+    "loosePhone": {
+      "description": "Loose definition of phone number",
+      "type": "string",
+      "pattern": "^\\+?[\\d\\s.-]+$"
+    },
     "email": {
       "description": "Rough validation of a valid e-mail address, see https://davidcel.is/posts/stop-validating-email-addresses-with-regex/",
       "type": "string",

--- a/maas-schemas/schemas/core/modes/MODE_TAXI.json
+++ b/maas-schemas/schemas/core/modes/MODE_TAXI.json
@@ -84,7 +84,7 @@
           "maxLength": 64
         },
         "phone": {
-          "$ref": "https://schemas.maas.global/core/components/common.json#/definitions/phone"
+          "$ref": "https://schemas.maas.global/core/components/common.json#/definitions/loosePhone"
         },
         "supportUrl": {
           "description": "The taxi center support link. It can be for example: chat URL, FAQ url, etc...",

--- a/maas-schemas/src/io-ts/_types/core/components/common.ts
+++ b/maas-schemas/src/io-ts/_types/core/components/common.ts
@@ -227,6 +227,20 @@ export type RawPhoneBrand = {
   readonly RawPhone: unique symbol;
 };
 
+// LoosePhone
+// Loose definition of phone number
+export type LoosePhone = t.Branded<string, LoosePhoneBrand>;
+export type LoosePhoneC = t.BrandC<t.StringC, LoosePhoneBrand>;
+export const LoosePhone: LoosePhoneC = t.brand(
+  t.string,
+  (x): x is t.Branded<string, LoosePhoneBrand> =>
+    typeof x !== 'string' || x.match(RegExp('^\\+?[\\d\\s.-]+$', 'u')) !== null,
+  'LoosePhone',
+);
+export type LoosePhoneBrand = {
+  readonly LoosePhone: unique symbol;
+};
+
 // Email
 // Rough validation of a valid e-mail address, see https://davidcel.is/posts/stop-validating-email-addresses-with-regex/
 export type Email = t.Branded<string, EmailBrand>;

--- a/maas-schemas/src/io-ts/_types/core/modes/MODE_TAXI.ts
+++ b/maas-schemas/src/io-ts/_types/core/modes/MODE_TAXI.ts
@@ -44,7 +44,7 @@ export type MODE_TAXI = t.Branded<
     taxiCenter?: {
       image?: Units_c404_.Url;
       name?: string;
-      phone?: Common_ffba_.Phone;
+      phone?: Common_ffba_.LoosePhone;
       supportUrl?: Units_c404_.Url;
     } & Record<string, unknown>;
     messageToDriver?: string;
@@ -82,7 +82,7 @@ export type MODE_TAXIC = t.BrandC<
         t.PartialC<{
           image: typeof Units_c404_.Url;
           name: t.StringC;
-          phone: typeof Common_ffba_.Phone;
+          phone: typeof Common_ffba_.LoosePhone;
           supportUrl: typeof Units_c404_.Url;
         }>,
         t.RecordC<t.StringC, t.UnknownC>,
@@ -120,7 +120,7 @@ export const MODE_TAXI: MODE_TAXIC = t.brand(
       t.partial({
         image: Units_c404_.Url,
         name: t.string,
-        phone: Common_ffba_.Phone,
+        phone: Common_ffba_.LoosePhone,
         supportUrl: Units_c404_.Url,
       }),
       t.record(t.string, t.unknown),
@@ -153,7 +153,7 @@ export const MODE_TAXI: MODE_TAXIC = t.brand(
       taxiCenter?: {
         image?: Units_c404_.Url;
         name?: string;
-        phone?: Common_ffba_.Phone;
+        phone?: Common_ffba_.LoosePhone;
         supportUrl?: Units_c404_.Url;
       } & Record<string, unknown>;
       messageToDriver?: string;


### PR DESCRIPTION
## What has been implemented?
E.g. to prevent this kind of error:
```
Invalid JSON: 'ValidationError: '.meta.MODE_TAXI.taxiCenter.phone' should match pattern \\\\\\\"^\\\\\\\\+(?:\\\\\\\\d){6,14}\\\\\\\\d$\\\\\\\", got '\\\\\\\"+065551\\\\\\\"'')\\\",\\\"errorCode\\\":\\\"DEFAULT_ERROR_CODE_TSP_ERROR\\\",\\\"errorMessage\\\":\\\"There was a problem contacting the service provider, please try again later.\\\"}\",\"trace\":[\"TSPError: 500 [wetaxi] undefined: Invalid JSON: 'ValidationError: '.meta.MODE_TAXI.taxiCenter.phone' should match pattern \\\"^\\\\+(?:\\\\d){6,14}\\\\d$\\\", got '\\\"+065551\\\"''\",\"    at handleRequestError (/var/task/steps-main/step-reserve/handler.js:13016:9)\",\"    at Object.handleRequest (/var/task/steps-main/step-reserve/handler.js:13138:12)\",\"    at processTicksAndRejections (internal/process/task_queues.js:95:5)\",\"    at async Object.reserve (/var/task/steps-main/step-reserve/handler.js:11988:18)\",\"    at async Object.reserveBooking (/var/task/steps-main/step-reserve/handler.js:2578:23)\",\"    at async /var/task/steps-main/step-reserve/handler.js:282:25\",\"    at async Object.<anonymous> (/var/task/steps-main/step-reserve/handler.js:47438:24)\",\"    at async Object.module.exports (/var/task/steps-main/step-reserve/handler.js:274:3)\"]}"
```